### PR TITLE
fix(rplidar): make normal-mode scanning robust; add descriptor re-sync, timeouts, DTR flip; refactor rptest to threaded queue

### DIFF
--- a/system_hw_test/rpdriver.py
+++ b/system_hw_test/rpdriver.py
@@ -23,13 +23,13 @@ Usage example:
 For additional information please refer to the RPLidar class documentation.
 """
 
+
 import codecs
 import logging
 import struct
 import sys
 import time
 from collections import namedtuple
-
 import serial
 
 SYNC_BYTE = b"\xA5"
@@ -58,27 +58,21 @@ HEALTH_TYPE = 6
 MAX_MOTOR_PWM = 1023
 DEFAULT_MOTOR_PWM = 660
 SET_PWM_BYTE = b"\xF0"
+AUTO_START_MOTOR    = True   # <--- set False if your host/thread manages motor
 
-_HEALTH_STATUSES = {
-    0: "Good",
-    1: "Warning",
-    2: "Error",
-}
-
+_HEALTH_STATUSES = {0: "Good", 1: "Warning", 2: "Error"}
 
 class RPLidarException(Exception):
     """Basic exception class for RPLidar"""
-
+    pass
 
 def _b2i(byte):
     """Converts byte to integer (for Python 2 compatibility)"""
     return byte if int(sys.version[0]) == 3 else ord(byte)
 
-
 def _showhex(signal):
     """Converts string bytes to hex representation (useful for debugging)"""
     return [format(_b2i(b), "#02x") for b in signal]
-
 
 def _process_scan(raw):
     """Processes input raw data and returns measurement data"""
@@ -94,73 +88,67 @@ def _process_scan(raw):
     distance = (_b2i(raw[3]) + (_b2i(raw[4]) << 8)) / 4.0
     return new_scan, quality, angle, distance
 
-
-def _process_express_scan(data, new_angle, trame):
-    new_scan = (new_angle < data.start_angle) & (trame == 1)
-    angle = (
-        data.start_angle
-        + ((new_angle - data.start_angle) % 360) / 32 * trame
-        - data.angle[trame - 1]
-    ) % 360
-    distance = data.distance[trame - 1]
-    return new_scan, None, angle, distance
-
-
 class RPDriver(object):
-    """Class for communicating with RPLidar rangefinder scanners"""
+    """
+    Robust serial driver for RPLIDAR (normal mode).
 
-    def __init__(self, port, baudrate=115200, timeout=1, logger=None):
-        """Initialize RPLidar object for communicating with the sensor.
+    Key behavior:
+    - Uses descriptor re-sync (hunts for A5 5A).
+    - Applies hard timeouts and short-read checks.
+    - Drains/flushes residual bytes before starting a stream.
+    - Optionally starts motor automatically when starting a scan.
+    """
 
-        Parameters
-        ----------
-        port : str
-            Serial port name to which sensor is connected
-        baudrate : int, optional
-            Baudrate for serial connection (the default is 115200)
-        timeout : float, optional
-            Serial port connection timeout in seconds (the default is 1)
-        logger : logging.Logger instance, optional
-            Logger instance, if none is provided new instance is created
-        """
+    def __init__(self, port, baudrate=115200, timeout=0.2, logger=None):
         self._serial = None
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
         self._motor_speed = DEFAULT_MOTOR_PWM
         self.scanning = [False, 0, "normal"]
-        self.express_trame = 32
-        self.express_data = False
         self.motor_running = None
         if logger is None:
             logger = logging.getLogger("rplidar")
         self.logger = logger
         self.connect()
+    
+    def _drain_for(self, duration_s=0.06):
+        """Eat any residual bytes for a short window to ensure clean state."""
+        end = time.time() + duration_s
+        while time.time() < end:
+            try:
+                n = self._serial.in_waiting
+            except AttributeError:
+                n = self._serial.inWaiting()
+            if n:
+                self._serial.read(n)
+            time.sleep(0.003)
 
+    # ---- Serial lifecycle ----------------------------------------------------
     def connect(self):
-        """Connects to the serial port with the name `self.port`. If it was
-        connected to another serial port disconnects from it first."""
         if self._serial is not None:
             self.disconnect()
         try:
             self._serial = serial.Serial(
-                self.port,
-                self.baudrate,
+                self.port, self.baudrate,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
                 timeout=self.timeout,
             )
+            print(f"[diag][connect] open={self._serial.is_open} port={self.port}")
+            # Keep lines deasserted; some USB-serials care
+            self._serial.setDTR(False)
+            try: self._serial.setRTS(False)
+            except Exception: pass
         except serial.SerialException as err:
-            raise RPLidarException(
-                "Failed to connect to the sensor " "due to: %s" % err
-            )
+            raise RPLidarException(f"Failed to connect to the sensor: {err}")
 
     def disconnect(self):
-        """Disconnects from the serial port"""
         if self._serial is None:
             return
         self._serial.close()
 
+    # ---- Motor control -------------------------------------------------------
     def _set_pwm(self, pwm):
         payload = struct.pack("<H", pwm)
         self._send_payload_cmd(SET_PWM_BYTE, payload)
@@ -177,27 +165,25 @@ class RPDriver(object):
             self._set_pwm(self._motor_speed)
 
     def start_motor(self):
-        """Starts sensor motor"""
+        """Spin the motor:
+           - A1: DTR low
+           - A2: PWM set to DEFAULT_MOTOR_PWM"""
         self.logger.info("Starting motor")
-        # For A1
+        # A1: DTR low; A2: PWM
         self._serial.setDTR(False)
-
-        # For A2
         self._set_pwm(self._motor_speed)
         self.motor_running = True
+        print(f"[diag][start_motor] pwm={self._motor_speed}")
 
     def stop_motor(self):
-        """Stops sensor motor"""
+        """Stop the motor and place lines in idle state."""
         self.logger.info("Stopping motor")
-        # For A2
         self._set_pwm(0)
         time.sleep(0.001)
-        # For A1
         self._serial.setDTR(True)
         self.motor_running = False
 
     def _send_payload_cmd(self, cmd, payload):
-        """Sends `cmd` command with `payload` to the sensor"""
         size = struct.pack("B", len(payload))
         req = SYNC_BYTE + cmd + size + payload
         checksum = 0
@@ -208,98 +194,107 @@ class RPDriver(object):
         self.logger.debug("Command sent: %s" % _showhex(req))
 
     def _send_cmd(self, cmd):
-        """Sends `cmd` command to the sensor"""
         req = SYNC_BYTE + cmd
         self._serial.write(req)
         self.logger.debug("Command sent: %s" % _showhex(req))
 
-    def _read_descriptor(self):
-        """Reads descriptor packet"""
-        descriptor = self._serial.read(DESCRIPTOR_LEN)
-        self.logger.debug("Received descriptor: %s", _showhex(descriptor))
-        if len(descriptor) != DESCRIPTOR_LEN:
-            raise RPLidarException("Descriptor length mismatch")
-        elif not descriptor.startswith(SYNC_BYTE + SYNC_BYTE2):
-            raise RPLidarException("Incorrect descriptor starting bytes")
-        is_single = _b2i(descriptor[-2]) == 0
-        return _b2i(descriptor[2]), is_single, _b2i(descriptor[-1])
+    def _read_descriptor(self, deadline_s=1.0):
+        """
+        Robustly read the 7-byte descriptor:
+        - Hunt for the A5 5A sync header
+        - If a short-read happens, keep hunting until deadline
+        """
+        t_end = time.time() + deadline_s
+        header = bytearray()
+        # hunt for SYNC bytes
+        while time.time() < t_end:
+            b = self._serial.read(1)
+            if not b:
+                continue
+            header += b
+            # keep only last 2 bytes to match against A5 5A
+            if len(header) > 2:
+                header = header[-2:]
+            if header == SYNC_BYTE + SYNC_BYTE2:
+                rest = self._serial.read(DESCRIPTOR_LEN - 2)
+                if len(rest) != DESCRIPTOR_LEN - 2:
+                    # try again if short
+                    header.clear()
+                    continue
+                descriptor = (SYNC_BYTE + SYNC_BYTE2 + rest)
+                self.logger.debug("Received descriptor: %s", _showhex(descriptor))
+                is_single = _b2i(descriptor[-2]) == 0
+                return _b2i(descriptor[2]), is_single, _b2i(descriptor[-1])
+        raise RPLidarException("Descriptor sync timeout")
 
-    def _read_response(self, dsize):
-        """Reads response packet with length of `dsize` bytes"""
+    def _read_response(self, dsize, timeout_s=2.0):
+        """
+        Wait for at least dsize bytes with a hard timeout, then read exactly dsize.
+        Raises if a timeout or short-read occurs.
+        """
         self.logger.debug("Trying to read response: %d bytes", dsize)
-        while self._serial.inWaiting() < dsize:
+        dsize = int(dsize)
+
+        def _bytes_waiting():
+            try:
+                return self._serial.in_waiting
+            except AttributeError:
+                return self._serial.inWaiting()
+
+        start = time.time()
+        while True:
+            if _bytes_waiting() >= dsize:
+                break
+            if time.time() - start > timeout_s:
+                raise RPLidarException(f"Timeout waiting for {dsize} bytes; have {_bytes_waiting()}.")
             time.sleep(0.001)
+
         data = self._serial.read(dsize)
+        if len(data) != dsize:
+            raise RPLidarException(f"Short read: expected {dsize} bytes, got {len(data)}.")
         self.logger.debug("Received data: %s", _showhex(data))
         return data
 
     def get_info(self):
-        """Get device information
-
-        Returns
-        -------
-        dict
-            Dictionary with the sensor information
-        """
+        """Read device info block (model/firmware/hardware/serial)."""
         if self._serial.inWaiting() > 0:
             return "Buffer is full! Run clean_input() to empty the buffer."
         self._send_cmd(GET_INFO_BYTE)
         dsize, is_single, dtype = self._read_descriptor()
-        if dsize != INFO_LEN:
-            raise RPLidarException("Wrong get_info reply length")
-        if not is_single:
-            raise RPLidarException("Not a single response mode")
-        if dtype != INFO_TYPE:
-            raise RPLidarException("Wrong response data type")
+        if dsize != INFO_LEN or not is_single or dtype != INFO_TYPE:
+            raise RPLidarException("Bad get_info response")
         raw = self._read_response(dsize)
         serialnumber = codecs.encode(raw[4:], "hex").upper()
         serialnumber = codecs.decode(serialnumber, "ascii")
-        data = {
+        return {
             "model": _b2i(raw[0]),
             "firmware": (_b2i(raw[2]), _b2i(raw[1])),
             "hardware": _b2i(raw[3]),
             "serial number": serialnumber,
         }
-        return data
 
     def get_health(self):
-        """Get device health state. When the core system detects some
-        potential risk that may cause hardware failure in the future,
-        the returned status value will be 'Warning'. But sensor can still work
-        as normal. When sensor is in the Protection Stop state, the returned
-        status value will be 'Error'. In case of warning or error statuses
-        non-zero error code will be returned.
-
-        Returns
-        -------
-        status : str
-            'Good', 'Warning' or 'Error' statuses
-        error_code : int
-            The related error code that caused a warning/error.
-        """
+        """Read device health; returns (status_str, error_code)."""
         if self._serial.inWaiting() > 0:
-            return "Data in buffer. " "Run clean_input() to empty the buffer."
+            return "Data in buffer. Run clean_input() to empty the buffer."
         self.logger.info("Asking for health")
         self._send_cmd(GET_HEALTH_BYTE)
         dsize, is_single, dtype = self._read_descriptor()
-        if dsize != HEALTH_LEN:
-            raise RPLidarException("Wrong get_info reply length")
-        if not is_single:
-            raise RPLidarException("Not a single response mode")
-        if dtype != HEALTH_TYPE:
-            raise RPLidarException("Wrong response data type")
+        if dsize != HEALTH_LEN or not is_single or dtype != HEALTH_TYPE:
+            raise RPLidarException("Bad get_health response")
         raw = self._read_response(dsize)
         status = _HEALTH_STATUSES[_b2i(raw[0])]
         error_code = (_b2i(raw[1]) << 8) + _b2i(raw[2])
         return status, error_code
 
     def clean_input(self):
-        """Clean input buffer by reading all available data"""
-        if self.scanning[0]:
-            return "Cleaning not allowed during active scanning!"
-        self._serial.flushInput()
-        self.express_trame = 32
-        self.express_data = False
+        """Flush input/output buffers (safe even if stream is idle)."""
+        try:
+            self._serial.reset_input_buffer()
+            self._serial.reset_output_buffer()
+        except AttributeError:
+            self._serial.flushInput()
+            self._serial.flushOutput()
 
     def stop(self):
         """Stops scanning process, disables laser diode and the measurement
@@ -311,141 +306,111 @@ class RPDriver(object):
         self.clean_input()
 
     def start(self, scan_type="normal"):
-        """Start the scanning process
-
-        Parameters
-        ----------
-        scan : normal, force, or express.
+        """
+        Start a normal-mode scan:
+        - optional auto motor start (AUTO_START_MOTOR)
+        - health check and auto-reset on 'Error'
+        - STOP+flush+drain to guarantee a clean start
+        - descriptor re-sync with one automatic retry
         """
         if self.scanning[0]:
             return "Scan already running!"
-        """Start the scanning process, enable laser diode and the
-        measurement system"""
-        status, error_code = self.get_health()
-        self.logger.debug("Health status: %s [%d]", status, error_code)
-        if status == _HEALTH_STATUSES[2]:
-            self.logger.warning(
-                "Trying to reset sensor due to error. " "Error code: %d", error_code
-            )
-            self.reset()
+        
+        # (1) Ensure motor is spinning if requested (prevents 'no bytes' state)
+        if AUTO_START_MOTOR and not self.motor_running:
+            self.start_motor()
+            time.sleep(0.4)  # let RPM stabilize
+        
+
+        # (2) Check health and auto-reset on 'Error'
+        try:
             status, error_code = self.get_health()
-            if status == _HEALTH_STATUSES[2]:
-                raise RPLidarException(
-                    "RPLidar hardware failure. " "Error code: %d" % error_code
-                )
-        elif status == _HEALTH_STATUSES[1]:
-            self.logger.warning(
-                "Warning sensor status detected! " "Error code: %d", error_code
-            )
+            self.logger.debug("Health status: %s [%d]", status, error_code)
+            if status == _HEALTH_STATUSES[2]:  # "Error"
+                self.logger.warning("Resetting due to health error: %d", error_code)
+                self.reset()
+                status, error_code = self.get_health()
+                if status == _HEALTH_STATUSES[2]:
+                    raise RPLidarException(f"RPLidar hardware failure. Error: {error_code}")
+            elif status == _HEALTH_STATUSES[1]:  # "Warning"
+                self.logger.warning("Sensor reported WARNING. Error: %d", error_code)
+        except Exception as e:
+            # If health query itself failed (e.g., empty buffer), we still try to start
+            self.logger.warning("Health check failed (continuing anyway): %s", e)
 
-        cmd = _SCAN_TYPE[scan_type]["byte"]
-        print("Starting scan in %s mode" % scan_type)
-        self.logger.info("starting scan process in %s mode" % scan_type)
+        # Stop any old stream, flush, then drain a bit to guarantee silence
+        try:
+            self._send_cmd(STOP_BYTE)
+            time.sleep(0.02)
+        except Exception:
+            pass
+        self.clean_input()
+        self._drain_for(0.06)
 
-        if scan_type == "express":
-            self._send_payload_cmd(cmd, b"\x00\x00\x00\x00\x00")
-        else:
-            self._send_cmd(cmd)
+        # Start normal mode (we force normal for reliability)
+        print("Starting scan in normal mode")
+        self._send_cmd(_SCAN_TYPE["normal"]["byte"])
 
-        dsize, is_single, dtype = self._read_descriptor()
-        if dsize != _SCAN_TYPE[scan_type]["size"]:
-            raise RPLidarException("Wrong get_info reply length")
-        if is_single:
-            raise RPLidarException("Not a multiple response mode")
-        if dtype != _SCAN_TYPE[scan_type]["response"]:
-            raise RPLidarException("Wrong response data type")
-        self.scanning = [True, dsize, scan_type]
+        # Read descriptor; if it fails once, flush & try once more
+        try:
+            dsize, is_single, dtype = self._read_descriptor()
+        except Exception:
+            self.clean_input()
+            self._drain_for(0.06)
+            dsize, is_single, dtype = self._read_descriptor()
+
+        if dsize != _SCAN_TYPE["normal"]["size"] or is_single or dtype != _SCAN_TYPE["normal"]["response"]:
+            raise RPLidarException("Bad scan start response (normal)")
+
+        self.scanning = [True, dsize, "normal"]
+
 
     def reset(self):
-        """Resets sensor core, reverting it to a similar state as it has
-        just been powered up."""
+        """Reset the device core; wait, then flush inputs."""
         self.logger.info("Resetting the sensor")
         self._send_cmd(RESET_BYTE)
         time.sleep(2)
         self.clean_input()
 
     def iter_measures(self, scan_type="normal", max_buf_meas=3000):
-        """Iterate over measurements. Note that consumer must be fast enough,
-        otherwise data will accumulate inside buffer and consumer will get
-        data with increasing lag.
-
-        Parameters
-        ----------
-        max_buf_meas : int or False if you want unlimited buffer
-            Maximum number of bytes to be stored inside the buffer. Once
-            number exceeds this limit buffer will be emptied out.
-
-        Yields
-        ------
-        new_scan : bool
-            True if measurement belongs to a new scan
-        quality : int
-            Reflected laser pulse strength
-        angle : float
-            The measurement heading angle in degree units [0, 360)
-        distance : float
-            Measured object distance related to the sensor's rotation center.
-            In millimeters. Set to 0 when measure is invalid.
-        """
-        self.start_motor()
+        # Caller manages DTR/motor; just ensure stream is started.
         if not self.scanning[0]:
             self.start(scan_type)
+            time.sleep(0.2)
+
+        dsize = self.scanning[1]
+        misses = 0
         while True:
-            dsize = self.scanning[1]
-            # print(f"M: Dsize:{dsize}")
             if max_buf_meas:
-                data_in_buf = self._serial.inWaiting()
+                try:
+                    data_in_buf = self._serial.in_waiting
+                except AttributeError:
+                    data_in_buf = self._serial.inWaiting()
                 if data_in_buf > max_buf_meas:
                     self.logger.warning(
-                        "Too many bytes in the input buffer: %d/%d. "
-                        "Cleaning buffer...",
-                        data_in_buf,
-                        max_buf_meas,
+                        "Too many bytes in input buffer: %d/%d. Cleaning...",
+                        data_in_buf, max_buf_meas
                     )
                     self.stop()
-                    self.start(self.scanning[2])
+                    self.start("normal")
+                    time.sleep(0.1)
+                    dsize = self.scanning[1]
+                    misses = 0
+                    continue
 
-            if self.scanning[2] == "normal":
-                print("M: Normal scanning")
-                raw = self._read_response(dsize)
-                print(f"M: Raw:{raw}")
+            try:
+                raw = self._read_response(dsize, timeout_s=2.5)
+                misses = 0
                 yield _process_scan(raw)
-            if self.scanning[2] == "express":
-                # print("M: Express scanning")
-                if self.express_trame == 32:
-                    self.express_trame = 0
-                    # if not self.express_data or type(self.express_data) == bool:
-                    if not self.express_data:
-                        self.logger.debug("reading first time bytes")
-                        self.express_data = ExpressPacket.from_string(
-                            self._read_response(dsize)
-                        )
-
-                    self.express_old_data = self.express_data
-                    self.logger.debug(
-                        "set old_data with start_angle %f",
-                        self.express_old_data.start_angle,
-                    )
-                    self.express_data = ExpressPacket.from_string(
-                        self._read_response(dsize)
-                    )
-                    self.logger.debug(
-                        "set new_data with start_angle %f",
-                        self.express_data.start_angle,
-                    )
-
-                self.express_trame += 1
-                self.logger.debug(
-                    "process scan of frame %d with angle : " "%f and angle new : %f",
-                    self.express_trame,
-                    self.express_old_data.start_angle,
-                    self.express_data.start_angle,
-                )
-                yield _process_express_scan(
-                    self.express_old_data,
-                    self.express_data.start_angle,
-                    self.express_trame,
-                )
+            except RPLidarException as e:
+                # transient underflow / short read: skip a few before restart
+                if "Timeout waiting" in str(e) or "Short read" in str(e):
+                    misses += 1
+                    if misses <= 5:     # tolerate ~100–200ms of hiccups
+                        time.sleep(0.01)
+                        continue
+                # anything else or too many misses: bubble up
+                raise
 
     def iter_scans(self, scan_type="normal", max_buf_meas=3000, min_len=5):
         """Iterate over scans. Note that consumer must be fast enough,
@@ -468,51 +433,10 @@ class RPDriver(object):
             refer to `iter_measures` method's documentation.
         """
         scan_list = []
-        iterator = self.iter_measures(scan_type, max_buf_meas)
-        for new_scan, quality, angle, distance in iterator:
+        for new_scan, quality, angle, distance in self.iter_measures("normal", max_buf_meas):
             if new_scan:
                 if len(scan_list) > min_len:
                     yield scan_list
                 scan_list = []
             if distance > 0:
                 scan_list.append((quality, angle, distance))
-
-
-class ExpressPacket(
-    namedtuple("express_packet", "distance angle new_scan start_angle")
-):
-    sync1 = 0xA
-    sync2 = 0x5
-    sign = {0: 1, 1: -1}
-
-    @classmethod
-    def from_string(cls, data):
-        packet = bytearray(data)
-
-        if (packet[0] >> 4) != cls.sync1 or (packet[1] >> 4) != cls.sync2:
-            raise ValueError("try to parse corrupted data ({})".format(packet))
-
-        checksum = 0
-        for b in packet[2:]:
-            checksum ^= b
-        if checksum != (packet[0] & 0b00001111) + ((packet[1] & 0b00001111) << 4):
-            raise ValueError("Invalid checksum ({})".format(packet))
-
-        new_scan = packet[3] >> 7
-        start_angle = (packet[2] + ((packet[3] & 0b01111111) << 8)) / 64
-
-        d = a = ()
-        for i in range(0, 80, 5):
-            d += ((packet[i + 4] >> 2) + (packet[i + 5] << 6),)
-            a += (
-                ((packet[i + 8] & 0b00001111) + ((packet[i + 4] & 0b00000001) << 4))
-                / 8
-                * cls.sign[(packet[i + 4] & 0b00000010) >> 1],
-            )
-            d += ((packet[i + 6] >> 2) + (packet[i + 7] << 6),)
-            a += (
-                ((packet[i + 8] >> 4) + ((packet[i + 6] & 0b00000001) << 4))
-                / 8
-                * cls.sign[(packet[i + 6] & 0b00000010) >> 1],
-            )
-        return cls(d, a, new_scan, start_angle)

--- a/system_hw_test/rptest.py
+++ b/system_hw_test/rptest.py
@@ -3,6 +3,7 @@ import math
 import sys
 import threading
 import time
+from queue import Queue, Empty
 
 import numpy as np
 import zenoh
@@ -12,431 +13,358 @@ from matplotlib.patches import Circle, Rectangle
 from rpdriver import RPDriver
 
 sys.path.insert(0, "../src")
-
 try:
     from zenoh_idl import sensor_msgs
 except ImportError:
     print("Please run this script from inside /system_hw_test")
 
+# ---------- CLI ----------
 parser = argparse.ArgumentParser()
-parser.add_argument(
-    "--serial", help="serial port to use, when using the low level driver", type=str
-)
-parser.add_argument(
-    "--zenoh", help="use zenoh to connect to the robot", action="store_true"
-)
-parser.add_argument(
-    "--multicast", help="multicast address for zenoh", type=str, default=None
-)
-parser.add_argument(
-    "--URID", help="your robot's URID, when using Zenoh", type=str, default=""
-)
-parser.add_argument(
-    "--type", help="the type of the robot (go2 or tb4)", type=str, default="go2"
-)
-print(parser.format_help())
-
+parser.add_argument("--serial", type=str, help="serial port to use, when using the low level driver, e.g. /dev/cu.usbserial-0001")
+parser.add_argument("--zenoh", action="store_true", help="use zenoh to connect to the robot")
+parser.add_argument("--multicast", help="multicast address for zenoh", type=str, default=None)
+parser.add_argument("--URID", help="your robot's URID, when using Zenoh", type=str, default="")
+parser.add_argument("--type", type=str, default="go2", help="go2 or tb4")
+# IMPORTANT: only support normal for reliability
+parser.add_argument("--scan", choices=["normal"], default="normal",
+                    help="lidar scan mode (normal only)")
+parser.add_argument("--near-min", type=float, default=0.16, help="min blocking distance (m)")
+parser.add_argument("--near-max", type=float, default=1.1, help="max blocking distance (m)")
 args = parser.parse_args()
 
-
+# ---------- Candidate paths ----------
 def create_straight_line_path_from_angle(angle_degrees, length=1.0, num_points=10):
-    """Create a straight line path from origin at specified angle and length"""
     angle_rad = math.radians(angle_degrees)
-    end_x = length * math.sin(angle_rad)  # sin for x because 0° is forward (positive y)
-    end_y = length * math.cos(angle_rad)  # cos for y because 0° is forward (positive y)
-
+    end_x = length * math.sin(angle_rad)  # 0° forward (+y)
+    end_y = length * math.cos(angle_rad)
     x_vals = np.linspace(0.0, end_x, num_points)
     y_vals = np.linspace(0.0, end_y, num_points)
     return np.array([x_vals, y_vals])
 
-
 # Define 9 straight line paths separated by 15 degrees
 # Center path is 0° (straight forward), then ±15°, ±30°, ±45°, ±60°
-path_angles = [-60, -45, -30, -15, 0, 15, 30, 45, 60, 180]  # degrees
-path_length = 1.05  # meters
-
-paths = [
-    create_straight_line_path_from_angle(angle, path_length) for angle in path_angles
-]
-
+path_angles = [-60, -45, -30, -15, 0, 15, 30, 45, 60, 180]
+path_length = 1.05
+paths = [create_straight_line_path_from_angle(a, path_length) for a in path_angles]
 print(f"Created {len(paths)} paths with angles: {path_angles}")
 print(f"Each path extends {path_length}m from robot center")
 
-pp = []
-for path in paths:
-    pairs = list(zip(path[0], path[1]))
-    pp.append(pairs)
-
-print(paths)
-print(pp)
-
+# ---------- Figure ----------
 fig = plot.figure()
 ax1 = plot.subplot(131)
 ax2 = plot.subplot(132)
 ax3 = plot.subplot(133)
 
-center = ax1.plot([0], [0], "o", color="blue")[0]  # the robot
-circle = ax1.add_patch(Circle((0, 0), 0.20, color="red"))  # the robot
+# Panel 1: overview
+ax1.plot([0],[0],"o",color="blue")
+ax1.add_patch(Circle((0,0), 0.20, color="red"))
 points = ax1.plot([], [], "-", color="black")[0]
-front = ax1.annotate("Front", xytext=(0.1, 0.3), xy=(0, 0.5))
-arrow = ax1.annotate("", xytext=(0, 0), xy=(0, 1.5), arrowprops=dict(arrowstyle="->"))
-ax1.set_xlim(-5, 5)
-ax1.set_ylim(-5, 5)
-ax1.set_aspect("equal")
+ax1.annotate("Front", xytext=(0.1, 0.3), xy=(0, 0.5))
+ax1.annotate("", xytext=(0, 0), xy=(0, 1.5), arrowprops=dict(arrowstyle="->"))
+ax1.set_xlim(-5,5); ax1.set_ylim(-5,5); ax1.set_aspect("equal")
 
-"""
-Robot and sensor configuration
-UNITREE
-"""
+# Robot config
+half_width_robot = 0.20
+relevant_distance_min = args.near_min
+relevant_distance_max = args.near_max
+sensor_mounting_angle = 180.0 if args.type != "tb4" else 270.0
+angles_blanked = [] if args.type != "tb4" else [[-180.0, -160.0], [110.0, 180.0]]
 
-half_width_robot = 0.20  # the width of the robot is 40 cm
-relevant_distance_max = 1.1  # meters
-relevant_distance_min = 0.20  # meters
-sensor_mounting_angle = 172.0  # corrects for how sensor is mounted
-# angles_blanked = [[-180.0, -140.0], [140.0, 180.0]]
-angles_blanked = []
-
-# Figure 2 - the zoom and the possible paths
-centerZoom = ax2.plot([0], [0], "o", color="blue")[0]  # the robot
-
+# Panel 2: zoom
+ax2.plot([0],[0],"o", color="blue", markersize=8, zorder=10)
+ax2.add_patch(Circle((0,0), 0.20, ls="--", lw=1, ec="red", fc="none"))
 if args.type == "tb4":
-    sensor_mounting_angle = 270.0
-    angles_blanked = [[-180.0, -160.0], [110.0, 180.0]]
-    circleZoom = ax2.add_patch(
-        Circle((0, 0), 0.20, ls="--", lw=1, ec="red", fc="none")
-    )  # the robot head
-    outline = ax2.add_patch(
-        Rectangle((-0.05, -0.15), 0.20, 0.06, ls="--", fc="black")
-    )  # the robot electronics
+    ax2.add_patch(Rectangle((-0.05, -0.15), 0.20, 0.06, ls="--", fc="black"))
 else:
-    circleZoom = ax2.add_patch(
-        Circle((0, 0), 0.20, ls="--", lw=1, ec="red", fc="none")
-    )  # the robot head
-    outline = ax2.add_patch(
-        Rectangle((-0.2, -0.7), 0.40, 0.70, ls="--", lw=1, ec="red", fc="none")
-    )  # the robot body
+    ax2.add_patch(Rectangle((-0.2, -0.7), 0.40, 0.70, ls="--", lw=1, ec="red", fc="none"))
 pointsZoom = ax2.plot([], [], ".", color="black")[0]
-ax2.set_xlim(-1.2, 1.2)
-ax2.set_ylim(-1.2, 1.2)
-ax2.set_aspect("equal")
+m = args.near_max + 0.2
+ax2.set_xlim(-m, m); ax2.set_ylim(-m, m); ax2.set_aspect("equal")
 
-lines = []
-for li in list(range(0, len(paths))):
-    lines.append(ax2.plot([0], [0], "-", color="black")[0])
+# Precreate path artists
+lines = [ax2.plot([0],[0], "-", color="black")[0] for _ in paths]
 
+# Panel 3: angle-distance strip
 line = ax3.plot([0], [0], "-", color="red")[0]
-ax3.set_xlim(-180, 180)
-ax3.set_ylim(0, 1.2)
-ax3.set_aspect(300)
+ax3.set_xlim(-180, 180); ax3.set_ylim(0, 1.2); ax3.set_aspect(300)
+ax3.plot([-180.0, -48.0], [1.18, 1.18], "-", color="red",   linewidth=3.0)
+ax3.plot([ -42.0,  42.0], [1.18, 1.18], "-", color="black", linewidth=3.0)
+ax3.plot([  48.0, 180.0], [1.18, 1.18], "-", color="green", linewidth=3.0)
+ax3.annotate("Left",  xytext=(-125, 1.1), xy=(0, 0.5))
+ax3.annotate("Front", xytext=( -20, 1.1), xy=(0, 0.5))
+ax3.annotate("Right", xytext=(  85, 1.1), xy=(0, 0.5))
 
-ax3.plot([-180.0, -48.0], [1.18, 1.18], "-", color="red", linewidth=3.0)[0]
-ax3.plot([-42.0, 42.0], [1.18, 1.18], "-", color="black", linewidth=3.0)[0]
-ax3.plot([48.0, 180.0], [1.18, 1.18], "-", color="green", linewidth=3.0)[0]
-ax3.annotate("Left", xytext=(-125, 1.1), xy=(0, 0.5))
-ax3.annotate("Front", xytext=(-20, 1.1), xy=(0, 0.5))
-ax3.annotate("Right", xytext=(85, 1.1), xy=(0, 0.5))
-
-# display the blanked regions of the scan
+# --- Visualize blanked sectors (if any) on ax2 & ax3 ---
 for b in angles_blanked:
     deg_to_rad = np.pi / 180.0
-
     start_angle = b[0] * deg_to_rad
-    end_angle = b[1] * deg_to_rad
-
+    end_angle   = b[1] * deg_to_rad
     theta = np.linspace(start_angle, end_angle, 50)
     r = relevant_distance_max
 
     x = r * np.sin(theta)
     y = r * np.cos(theta)
 
-    # the arc
+    # arc on the zoom panel
     ax2.plot(x, y, "--", color="grey", linewidth=1.5)
-
-    # the straight lines
-    ax2.plot([0, x[0]], [0, y[0]], "--", color="grey", linewidth=1)
+    # two radial edges
+    ax2.plot([0, x[0]],  [0, y[0]],  "--", color="grey", linewidth=1)
     ax2.plot([0, x[-1]], [0, y[-1]], "--", color="grey", linewidth=1)
 
-    # for panel 3 - this is in the correct units
+    # strip on angle-distance panel
     width = abs(b[1] - b[0])
     ax3.add_patch(Rectangle((b[0], 0.2), width, 1.0, fc="grey"))
 
+# ---------- Queue pipeline ----------
+scan_queue: Queue[np.ndarray] = Queue(maxsize=1)
+def enqueue_latest(data: np.ndarray):
+    try:
+        while True:
+            scan_queue.get_nowait()
+    except Empty:
+        pass
+    try:
+        scan_queue.put_nowait(data)
+    except Exception:
+        pass
+def ensure_streaming(lidar, wait_s=2.0):
+    """Wait for data; if none, flip DTR once (handles inverted boards)."""
+    ser = lidar._serial
+    def have_bytes():
+        try: return ser.in_waiting
+        except AttributeError: return ser.inWaiting()
 
-def continuous_serial(lidar):
+    # wait a moment for first packets
+    t0 = time.time()
+    while time.time() - t0 < wait_s:
+        if have_bytes() >= 5:
+            return True
+        time.sleep(0.01)
 
-    for i, scan in enumerate(
-        lidar.iter_scans(scan_type="express", max_buf_meas=3000, min_len=5)
-    ):
+    # try flipping DTR polarity once
+    try:
+        current = ser.dtr
+        ser.setDTR(not current)
+        print(f"[serial] flipped DTR -> {ser.dtr}")
+        time.sleep(1.0)
+        t0 = time.time()
+        while time.time() - t0 < wait_s:
+            if have_bytes() >= 5:
+                return True
+            time.sleep(0.01)
+    except Exception:
+        pass
+    return False
 
-        array = np.array(scan)
 
-        # the driver sends angles in degrees between from 0 to 360
-        # warning - the driver may send two or more readings per angle,
-        # this can be confusing for the code
-        angles = array[:, 1]
+def log_lidar_banner(lidar: RPDriver):
+    """Best-effort: print model/firmware/health once for diagnostics."""
+    try:
+        print("Info:", lidar.get_info())
+    except Exception as e:
+        print("Info read failed:", e)
+    try:
+        print("Health:", lidar.get_health())
+    except Exception as e:
+        print("Health read failed:", e)
 
-        # distances are in millimeters
-        distances_mm = array[:, 2]
-        distances_m = [i / 1000 for i in distances_mm]
+# ---------- Producers ----------
+def continuous_serial_robust(port: str):
+    """Robust reader: always use NORMAL mode; restart on error."""
+    lidar = None
+    while True:
+        try:
+            if lidar is None:
+                print("[serial] opening", port)
+                lidar = RPDriver(port)
+                # log_lidar_banner(lidar) ###### For DEBUG 
 
-        data = list(zip(angles, distances_m))
-        array_ready = np.array(data)
-        # print(f"Array {array_ready}")
-        process(array_ready)
+            # Hard reset to known-good state
+            try: lidar.stop()
+            except Exception: pass
+            try: lidar.stop_motor()
+            except Exception: pass
+            try: lidar.clean_input()
+            except Exception: pass
+
+            # Spin up & start NORMAL stream
+            lidar.start("normal")
+            time.sleep(0.3)  # settle
+
+            # Verify bytes are arriving; auto-flip DTR once if needed
+            if not ensure_streaming(lidar, wait_s=2.0):
+                raise RuntimeError("No scan bytes after start (even after DTR flip)")
+
+            print("[serial] streaming (normal)...")
+            fps_counter, t0 = 0, time.monotonic()
+
+            # NOTE: iter_scans yields "scan" lists directly in this driver
+            for scan in lidar.iter_scans(scan_type="normal", max_buf_meas=3000, min_len=5):
+                arr = np.array(scan)  # (quality, angle_deg, distance_mm)
+                if arr.size == 0:
+                    continue
+                angles_deg = arr[:, 1]
+                distances_m = arr[:, 2] / 1000.0
+                enqueue_latest(np.column_stack((angles_deg, distances_m)))
+
+                fps_counter += 1
+                now = time.monotonic()
+                if now - t0 >= 1.0:
+                    print(f"[serial] fps={fps_counter}")
+                    fps_counter = 0
+                    t0 = now
+
+        except Exception as e:
+            print(f"[serial] error: {e}  (restarting in 1s)")
+            try:
+                if lidar: lidar.stop()
+            except Exception: pass
+            try:
+                if lidar: lidar.reset()
+            except Exception: pass
+            try:
+                if lidar: lidar.stop_motor()
+            except Exception: pass
+
+            # hard reopen after descriptor-like errors
+            if "Bad scan start response" in str(e) or "Descriptor" in str(e):
+                try:
+                    if lidar: lidar.disconnect()
+                except Exception: pass
+                try:
+                    if lidar: lidar.connect()
+                except Exception: pass
+
+            time.sleep(1.0)  # keep this
+
 
 
 def zenoh_scan(sample):
-
     scan = sensor_msgs.LaserScan.deserialize(sample.payload.to_bytes())
-    # print(f"Scan {scan}")
+    angles = 360.0 * (np.arange(scan.angle_min, scan.angle_max, scan.angle_increment) + math.pi) / (2*math.pi)
+    angles = np.flip(angles)
+    enqueue_latest(np.column_stack((angles, np.array(scan.ranges))))
 
-    # angle_min=-3.1241390705108643, angle_max=3.1415927410125732
-    angles = list(
-        map(
-            lambda x: 360.0 * (x + math.pi) / (2 * math.pi),
-            np.arange(scan.angle_min, scan.angle_max, scan.angle_increment),
-        )
-    )
-
-    angles_final = np.flip(angles)
-    # angles now run from 360.0 to 0 degress
-    data = list(zip(angles_final, scan.ranges))
-    array_ready = np.array(data)
-    # print(f"Array {array_ready}")
-    process(array_ready)
-
-
+# ---------- Geometry ----------
 def distance_point_to_line_segment(px, py, x1, y1, x2, y2):
-    # Vector from line start to line end
-    dx = x2 - x1
-    dy = y2 - y1
-
-    # If the line segment has zero length, return distance to point
+    dx, dy = x2 - x1, y2 - y1
     if dx == 0 and dy == 0:
-        return math.sqrt((px - x1) ** 2 + (py - y1) ** 2)
+        return math.hypot(px - x1, py - y1)
+    t = ((px - x1)*dx + (py - y1)*dy) / (dx*dx + dy*dy)
+    t = max(0.0, min(1.0, t))
+    cx, cy = x1 + t*dx, y1 + t*dy
+    return math.hypot(px - cx, py - cy)
 
-    # Calculate the parameter t that represents the projection of the point onto the line
-    t = ((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy)
-
-    # Clamp t to [0, 1] to stay within the line segment
-    t = max(0, min(1, t))
-
-    # Find the closest point on the line segment
-    closest_x = x1 + t * dx
-    closest_y = y1 + t * dy
-
-    # Return the distance from the point to the closest point on the line segment
-    return math.sqrt((px - closest_x) ** 2 + (py - closest_y) ** 2)
-
-
-def process(data):
+# ---------- Processing (GUI thread) ----------
+def process(data: np.ndarray):
 
     complexes = []
-
     for angle, distance in data:
-
-        d_m = distance
-
+        d_m = float(distance)
         # don't worry about distant objects
         if d_m > 5.0:
             continue
 
         # first, correctly orient the sensor zero to the robot zero
         angle = angle + sensor_mounting_angle
-        if angle >= 360.0:
-            angle = angle - 360.0
-        elif angle < 0.0:
-            angle = 360.0 + angle
+        if angle >= 360.0: angle -= 360.0
+        elif angle < 0.0:  angle += 360.0
 
         # then, convert to radians
-        a_rad = angle * math.pi / 180.0
-
-        v1 = d_m * math.cos(a_rad)
-        v2 = d_m * math.sin(a_rad)
-
+        a_rad = math.radians(angle)
+        v1 = d_m * math.cos(a_rad); v2 = d_m * math.sin(a_rad)
         # convert to x and y
         # x runs backwards to forwards, y runs left to right
-        x = -1 * v2
-        y = -1 * v1
+        x = -v2; y = -v1
 
         # convert the angle to -180 to + 180 range
-        angle = angle - 180.0
+        angle = angle - 180.0  # convert to [-180, 180]
 
-        keep = True
+        # this is too close, disregard
+        keep = d_m >= relevant_distance_min
         for b in angles_blanked:
-            if angle >= b[0] and angle <= b[1]:
+            if b[0] <= angle <= b[1]:
                 # this is a permanent reflection based on the robot
                 # disregard
                 keep = False
                 break
-
-        if d_m < relevant_distance_min:
-            # this is too close, disregard
-            keep = False
-
+        
         # the final data ready to use for path planning
         if keep:
             complexes.append([x, y, angle, d_m])
 
-    array = np.array(complexes)
+    if not complexes:
+        points.set_data([], []); pointsZoom.set_data([], []); line.set_data([], [])
+        for idx, p in enumerate(paths):
+            lines[idx].set_data(p[0], p[1]); lines[idx].set_color("black")
+        return
+
 
     # sort data into strictly increasing angles to deal with sensor issues
     # the sensor sometimes reports part of the previous scan and part of the next scan
     # so you end up with multiple slightly different values for some angles at the
     # junction
-    sorted_indices = array[:, 2].argsort()
-    array = array[sorted_indices]
+    array = np.array(complexes)
+    array = array[array[:,2].argsort()]  # sort by angle
+    X, Y, A, D = array[:,0], array[:,1], array[:,2], array[:,3]
 
-    X = array[:, 0]
-    Y = array[:, 1]
-    A = array[:, 2]
-    D = array[:, 3]
-
-    global points
     points.set_data(X, Y)
-
-    global pointsZoom
     pointsZoom.set_data(X, Y)
-
-    global line
     line.set_data(A, D)
 
     """
     Determine set of possible paths
     """
-    possible_paths = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    bad_paths = []
+    possible_paths = np.array(range(len(paths)))
+    for x, y, d in zip(X, Y, D):
+        if d > relevant_distance_max or d < relevant_distance_min:
+            continue
+        for apath in possible_paths.copy():
+            ps = paths[apath]
+            if distance_point_to_line_segment(
+                x, y,
+                ps[0][0], ps[1][0],
+                ps[0][-1], ps[1][-1]
+            ) < half_width_robot:
+                possible_paths = np.setdiff1d(possible_paths, np.array([apath]))
+                break
 
-    # all the possible conflicting points
-    for x, y, d in list(zip(X, Y, D)):
-        for apath in possible_paths:
+    for idx, p in enumerate(paths):
+        lines[idx].set_data(p[0], p[1])
+        lines[idx].set_color("green" if idx in possible_paths else "red")
 
-            # too far away - we do not care
-            if d > relevant_distance_max:
-                continue
-
-            # also don't worry about things that are very close
-            if d < relevant_distance_min:
-                continue
-
-            # Get the start and end points of this straight line path
-            path_points = paths[apath]
-            start_x, start_y = (
-                path_points[0][0],
-                path_points[1][0],
-            )
-            end_x, end_y = path_points[0][-1], path_points[1][-1]
-
-            # Calculate distance from obstacle to the line segment
-            dist_to_line = distance_point_to_line_segment(
-                x, y, start_x, start_y, end_x, end_y
-            )
-
-            if dist_to_line < half_width_robot:
-                # too close - this path will not work
-                path_to_remove = np.array([apath])
-                bad_paths.append(apath)
-                possible_paths = np.setdiff1d(possible_paths, path_to_remove)
-                break  # no need to keep checking this path - we know this path is bad
+    ppl = possible_paths.tolist()
+    left    = [p for p in ppl if path_angles[p] in (-60,-45,-30)]
+    forward = [p for p in ppl if path_angles[p] in (-15,0,15)]
+    right   = [p for p in ppl if path_angles[p] in (30,45,60)]
+    back    = [p for p in ppl if path_angles[p] == 180]
 
     print(f"possible_paths: {possible_paths}")
-
-    # convert to simple list
-    ppl = possible_paths.tolist()
-
-    left = []
-    forward = []
-    right = []
-    backward = []
-
-    for p in ppl:
-        # Categorize paths based on angle
-        angle = path_angles[p]
-        if angle == -60:
-            left.append(p)
-        elif angle == -45:
-            left.append(p)
-        elif angle == -30:
-            left.append(p)
-        elif angle == -15:
-            forward.append(p)
-        elif angle == 0:
-            forward.append(p)
-        elif angle == 15:
-            forward.append(p)
-        elif angle == 30:
-            right.append(p)
-        elif angle == 45:
-            right.append(p)
-        elif angle == 60:
-            right.append(p)
-        elif angle == 180:
-            backward.append(p)
-
-        lines[p].set_data(paths[p][0], paths[p][1])
-        lines[p].set_color("green")
-
-    if len(ppl) > 0:
-        print(f"There are {len(ppl)} possible paths.")
-        if len(left) > 0:
-            print(
-                f"You can turn left using paths: {left} ({[path_angles[p] for p in left]}°)."
-            )
-        if len(forward) > 0:
-            print(
-                f"You can go forward using paths: {forward} ({[path_angles[p] for p in forward]}°)."
-            )
-        if len(right) > 0:
-            print(
-                f"You can turn right using paths: {right} ({[path_angles[p] for p in right]}°)."
-            )
-        if len(backward) > 0:
-            print(
-                f"You can go backward using paths: {backward} ({[path_angles[p] for p in backward]}°)."
-            )
+    if ppl:
+        if left:    print(f"You can turn left using paths: {left} ({[path_angles[p] for p in left]}°).")
+        if forward: print(f"You can go forward using paths: {forward} ({[path_angles[p] for p in forward]}°).")
+        if right:   print(f"You can turn right using paths: {right} ({[path_angles[p] for p in right]}°).")
+        if back:    print(f"You can go backward using paths: {back} ({[path_angles[p] for p in back]}°).")
     else:
-        print(
-            "You are surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
-        )
-
-    for p in bad_paths:
-        # these are all the bad paths
-        lines[p].set_data(paths[p][0], paths[p][1])
-        lines[p].set_color("red")
+        print("You are surrounded by objects and cannot safely move.")
 
 
+def animate(_):
+    try:
+        data = scan_queue.get_nowait()
+    except Empty:
+        return []
+    process(data)
+    return [points, pointsZoom, line, *lines]
+
+# ---------- Main ----------
 if __name__ == "__main__":
-
     if args.serial:
-        PORT_NAME = args.serial
-        print(f"Using {PORT_NAME} as the serial port")
-        try:
-            lidar = RPDriver(PORT_NAME)
-            info = lidar.get_info()
-            print(f"Info: {info}")
-
-            health = lidar.get_health()
-            print(f"Health: {health}")
-
-            # reset to clear buffers
-            lidar.reset()
-
-            subscribe_thread = threading.Thread(target=continuous_serial, args=(lidar,))
-            subscribe_thread.daemon = True
-            subscribe_thread.start()
-
-            ani = FuncAnimation(fig, lambda _: None)
-            plot.show()
-
-        except KeyboardInterrupt:
-            print("Program interrupted")
-
-        finally:
-            print("Exiting program")
-            lidar.stop()
-            lidar.disconnect()
-            time.sleep(0.5)
-            sys.exit(0)
-
+        print(f"Using {args.serial} as the serial port")
+        t = threading.Thread(target=continuous_serial_robust, args=(args.serial,), daemon=True)
+        t.start()
+        ani = FuncAnimation(fig, animate, interval=50, blit=False, cache_frame_data=False)
+        plot.show()
         sys.exit(0)
 
     if args.zenoh:
@@ -444,27 +372,19 @@ if __name__ == "__main__":
         print("[INFO] Opening zenoh session...")
         conf = zenoh.Config()
         if args.multicast:
-            conf.insert_json5(
-                "scouting", f'{{"multicast": {{"address": "{args.multicast}"}}}}'
-            )
-
+            conf.insert_json5("scouting", f'{{"multicast": {{"address": "{args.multicast}"}}}}')
         z = zenoh.open(conf)
-
         if args.type == "go2":
             print("[INFO] Creating Subscribers for Go2")
-            scans = z.declare_subscriber("scan", zenoh_scan)
-
-        if args.type == "tb4":
+            z.declare_subscriber("scan", zenoh_scan)
+        elif args.type == "tb4":
             print("[INFO] Creating Subscribers for TB4")
-            scans = z.declare_subscriber(f"{args.URID}/pi/scan", zenoh_scan)
-
-        if args.type != "go2" and args.type != "tb4":
+            z.declare_subscriber(f"{args.URID}/pi/scan", zenoh_scan)
+        else:
             print(f"[ERROR] Unsupported robot type: {args.type}")
             sys.exit(1)
-
-        ani = FuncAnimation(fig, lambda _: None)
+        ani = FuncAnimation(fig, animate, interval=50, blit=False, cache_frame_data=False)
         plot.show()
-
         sys.exit(0)
 
     raise ValueError("You must specify either --serial or --zenoh to run this script.")


### PR DESCRIPTION
## Overview
This PR makes our RPLidar reading and GUI much more robust.
- Test app (rptest.py) moves to a producer/consumer design: a background thread feeds a Queue with the latest scan, while the GUI thread renders and does path filtering. Also adds optional DTR auto-flip when no bytes arrive.
- Driver (rpdriver.py) now forces normal mode, adds descriptor re-sync, hard read timeouts, short-read detection, and a pre-start drain/flush. It can optionally auto-start the motor and auto-recover from bad start responses (incl. reconnect).

These changes eliminate frequent stalls with “express” mode, reduce buffer overruns, and make the GUI responsive even under serial hiccups.

## Why
- “Express” mode was fragile on our USB-serial adapters and occasionally returned corrupted frames or partial packets, causing GUI freezes.
- Missing timeouts and short-read checks made the old driver hang waiting for bytes that never arrived.
- GUI work in the same loop as serial IO risked blocking the plot on slow reads.

## Changes
rptest.py
- Producer/consumer design.
New: a background producer thread (continuous_serial_robust) reads the lidar and pushes the latest frame into a tiny queue (Queue(maxsize=1)). The GUI thread is the consumer (via FuncAnimation) that always pulls the newest data.
Benefit: low latency (no backlog), no UI freezes, smoother plotting.

- Normal mode only.
New: reads in normal mode and verifies bytes are arriving before rendering.
Benefit: more predictable, stable scans than “express”.

- Startup robustness.
New: ensure_streaming() waits for bytes and auto-flips DTR once if nothing arrives.
Benefit: fewer “no data” stalls caused by USB-serial quirks.

- Compared to old: the old version read in the main path with less protection (and often in express mode). It could backlog or stall; the new producer/consumer setup decouples IO from rendering and throws away stale data for smoother UI.

rpdriver.py
- Normal mode only (removed express)
New: Use only “normal” scanning; deleted ExpressPacket and express parsing.
Benefit: Fewer code paths, fewer edge cases, more stable across devices.

- Stronger syncing & reads

New: _read_descriptor() actively looks for the A5 5A header with a timeout; _read_response() waits for the exact byte count with a hard timeout; _drain_for() clears leftover bytes before starting.
Benefit: Avoids desync/short-read lockups and recovers faster from line noise.

- Clean start + health check
New: start() does STOP → flush → drain → start; also checks health and auto-resets on device “Error”.
Benefit: Always starts from a known-good state and auto-recovers from common device faults.

- Compared to old: the old driver blocked on inWaiting() and did naive descriptor reads; express mode added complexity. The new driver adds timeouts, re-sync, clean startup, and recovery, which together make the stream much more robust.


## Testing
python rptest.py --serial /dev/cu.usbserial-0001 
- Before / After (behavioral)
Before: express scans occasionally hang; GUI freezes when serial blocks; no clear recovery on bad descriptors.
After: normal mode with re-sync + timeouts; GUI stays smooth; automatic recovery and DTR flip reduce “no bytes” cases; fewer stalls.

## Impact
- More robust. Clean starts, health checks, strict reads, and auto DTR flip → far fewer stalls and quicker self-recovery.
- Snappier UI. Queue keeps only the newest frame → steady FPS, responsive plots.
- Simpler code. Dropped express mode → fewer edge cases, easier maintenance.
- Trade-off. No express mode; normal-only is more reliable in practice.


