### PR TITLE
docs: .env hygiene + ASR WebSocket pitfalls; add evaluator README (no creds)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ logs/
 *.jpg
 /zenohdb
 saved_locations.json
+tools/asr-eval/*.wav
+tools/asr-eval/*/*.wav

--- a/docs/dev/asr-pitfalls.md
+++ b/docs/dev/asr-pitfalls.md
@@ -1,0 +1,16 @@
+# ASR Quick Notes & Pitfalls (Beta)
+
+- **Gunakan WebSocket**, bukan HTTP. Contoh:
+
+wss://api.openmind.org/api/core/google/asr?api_key=<YOUR_API_KEY>
+Simpan base URL di `.env` (tanpa `api_key`), lalu tambahkan `api_key` sebagai query saat runtime.
+
+- **Format payload** bisa bervariasi. Jika koneksi ditutup/empty:
+- `{"audio":"<base64>","rate":16000,"language":"id-ID"}`
+- `{"audio":"<base64>","rate":16000}`
+- `{"audio":"<base64>"}`
+
+- **Audio pendek** (≤10s), WAV 16 kHz mono.
+
+- **Keamanan**: `OM_API_KEY` hanya di `.env`.  
+Jangan taruh kredensial di README, PR, issue, atau log.

--- a/docs/dev/getting-started-env.md
+++ b/docs/dev/getting-started-env.md
@@ -1,0 +1,17 @@
+# Environment & Credential Hygiene (OM1)
+
+## .env (jangan di-commit)
+Buat file `.env` di root project:
+
+OM_API_KEY=om1_live_xxx
+OM1_ASR_ENDPOINT=wss://api.openmind.org/api/core/google/asr
+
+**Jangan** commit `.env`. Tambahkan ke `.gitignore`:
+
+.env
+tools/asr-eval/.wav
+tools/asr-eval//*.wav
+
+## Rotasi kunci
+Jika perlu rotasi, hapus key di portal, buat yang baru, lalu update `.env`.  
+Jangan taruh key di kode, PR, issue, atau log.

--- a/tools/asr-eval/README.md
+++ b/tools/asr-eval/README.md
@@ -1,0 +1,16 @@
+# ASR Multilingual Mini-Benchmark (OM1)
+
+## Cara jalan singkat
+
+python -m venv .venv
+source .venv/bin/activate
+pip install -r tools/asr-eval/requirements.txt
+python tools/asr-eval/evaluate_asr.py
+
+Output:
+- `tools/asr-eval/out/results.csv`
+- `tools/asr-eval/out/REPORT.md`
+
+## Catatan
+- Audio contoh *tidak* di-commit; isi sendiri `tools/asr-eval/<lang>/...`.
+- Pastikan `.env` dan `*.wav` di-ignore oleh git.


### PR DESCRIPTION
- Add .env & credential hygiene doc
- Note ASR WebSocket endpoint and payload variants
- Add evaluator README

Security:
- .env and *.wav added to .gitignore
- No credentials or private endpoints included

