### PR TITLE
Add Anthropic Claude vision language model support

### DIFF
--- a/config/anthropic_claude.json5
+++ b/config/anthropic_claude.json5
@@ -1,0 +1,59 @@
+{
+  "hertz": 1,
+  "name": "anthropic_claude",
+  "api_key": "openmind_free",
+  "system_prompt_base": "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+  "system_governance": "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  "system_prompt_examples": "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'sentence': 'Hello, let\\'s shake paws!'}}\n    Face: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'sentence': 'Ok, but I like running more'}}\n    Face: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'sentence': 'I\\'m going to go explore the room and meet more people.'}}\n    Face: 'think'",
+  "agent_inputs": [
+    {
+      "type": "VLMAnthropic",
+      "config": {
+        "model": "claude-3-5-sonnet-20241022",
+        "camera_index": 0
+      }
+    },
+    {
+      "type": "FaceEmotionCapture"
+    }
+  ],
+  "simulators": [
+    {
+      "type": "WebSim",
+      "config": {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tick_rate": 100,
+        "auto_reconnect": true,
+        "debug_mode": false
+      }
+    }
+  ],
+  "cortex_llm": {
+    "type": "OpenAILLM",
+    "config": {
+      "agent_name": "Spot",
+      "history_length": 10
+    }
+  },
+  "agent_actions": [
+    {
+      "name": "move",
+      "llm_label": "move",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    },
+    {
+      "name": "speak",
+      "llm_label": "speak",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    },
+    {
+      "name": "face",
+      "llm_label": "emotion",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    }
+  ]
+}

--- a/src/inputs/plugins/vlm_anthropic.py
+++ b/src/inputs/plugins/vlm_anthropic.py
@@ -1,0 +1,199 @@
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from queue import Empty, Queue
+from typing import List, Optional
+
+from openai.types.chat import ChatCompletion
+
+from inputs.base import SensorConfig
+from inputs.base.loop import FuserInput
+from providers.io_provider import IOProvider
+from providers.vlm_anthropic_provider import VLMAnthropicProvider
+
+
+@dataclass
+class Message:
+    """
+    Container for timestamped messages.
+
+    Parameters
+    ----------
+    timestamp : float
+        Unix timestamp of the message
+    message : str
+        Content of the message
+    """
+
+    timestamp: float
+    message: str
+
+
+class VLMAnthropic(FuserInput[str]):
+    """
+    Vision Language Model input handler for Anthropic Claude.
+
+    A class that processes image inputs and generates text descriptions using
+    Anthropic's Claude vision language model. It maintains an internal buffer of
+    processed messages and interfaces with the Claude API for image analysis.
+
+    The class handles asynchronous processing of images, maintains message history,
+    and provides formatted output of the latest processed messages.
+    """
+
+    def __init__(self, config: SensorConfig = SensorConfig()):
+        """
+        Initialize Anthropic Claude VLM input handler.
+
+        Sets up the required providers and buffers for handling VLM processing.
+        Initializes connection to the Claude API and registers message handlers.
+        """
+        super().__init__(config)
+
+        # Track IO
+        self.io_provider = IOProvider()
+
+        # Buffer for storing the final output
+        self.messages: List[Message] = []
+
+        # Buffer for storing messages
+        self.message_buffer: Queue[str] = Queue()
+
+        # Initialize VLM provider
+        api_key = getattr(self.config, "api_key", None)
+
+        if api_key is None or api_key == "":
+            raise ValueError("config file missing api_key")
+
+        base_url = getattr(self.config, "base_url", "https://api.anthropic.com")
+        model = getattr(self.config, "model", "claude-3-5-sonnet-20241022")
+        stream_base_url = getattr(
+            self.config,
+            "stream_base_url",
+            None,
+        )
+        camera_index = getattr(self.config, "camera_index", 0)
+
+        self.vlm: VLMAnthropicProvider = VLMAnthropicProvider(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            stream_url=stream_base_url,
+            camera_index=camera_index,
+        )
+        self.vlm.start()
+        self.vlm.register_message_callback(self._handle_vlm_message)
+
+        self.descriptor_for_LLM = "Vision"
+
+    def _handle_vlm_message(self, raw_message: ChatCompletion):
+        """
+        Process incoming VLM messages from Claude.
+
+        Parses messages from the Claude API and adds valid responses
+        to the message buffer for further processing.
+
+        Parameters
+        ----------
+        raw_message : ChatCompletion
+            Response object received from the Claude API
+        """
+        content = raw_message.choices[0].message.content
+        if content is not None:
+            logging.info(f"VLM Anthropic Claude received message: {content}")
+            self.message_buffer.put(content)
+        else:
+            logging.warning("VLM Anthropic Claude received message with None content")
+
+    async def _poll(self) -> Optional[str]:
+        """
+        Poll for new messages from the Claude API.
+
+        Checks the message buffer for new messages with a brief delay
+        to prevent excessive CPU usage.
+
+        Returns
+        -------
+        Optional[str]
+            The next message from the buffer if available, None otherwise
+        """
+        await asyncio.sleep(0.5)
+        try:
+            message = self.message_buffer.get_nowait()
+            return message
+        except Empty:
+            return None
+
+    async def _raw_to_text(self, raw_input: str) -> Message:
+        """
+        Process raw input to generate a timestamped message.
+
+        Creates a Message object from the raw input string, adding
+        the current timestamp.
+
+        Parameters
+        ----------
+        raw_input : str
+            Raw input string to be processed
+
+        Returns
+        -------
+        Message
+            A timestamped message containing the processed input
+        """
+        return Message(timestamp=time.time(), message=raw_input)
+
+    async def raw_to_text(self, raw_input: Optional[str]):
+        """
+        Convert raw input to text and update message buffer.
+
+        Processes the raw input if present and adds the resulting
+        message to the internal message buffer.
+
+        Parameters
+        ----------
+        raw_input : Optional[str]
+            Raw input to be processed, or None if no input is available
+        """
+        if raw_input is None:
+            return
+
+        pending_message = await self._raw_to_text(raw_input)
+
+        if pending_message is not None:
+            self.messages.append(pending_message)
+
+    def formatted_latest_buffer(self) -> Optional[str]:
+        """
+        Format and clear the latest buffer contents.
+
+        Retrieves the most recent message from the buffer, formats it
+        with timestamp and class name, adds it to the IO provider,
+        and clears the buffer.
+
+        Returns
+        -------
+        Optional[str]
+            Formatted string containing the latest message and metadata,
+            or None if the buffer is empty
+
+        """
+        if len(self.messages) == 0:
+            return None
+
+        latest_message = self.messages[-1]
+
+        result = f"""
+INPUT: {self.descriptor_for_LLM}
+// START
+{latest_message.message}
+// END
+"""
+
+        self.io_provider.add_input(
+            self.__class__.__name__, latest_message.message, latest_message.timestamp
+        )
+        self.messages = []
+
+        return result

--- a/src/providers/vlm_anthropic_provider.py
+++ b/src/providers/vlm_anthropic_provider.py
@@ -1,0 +1,195 @@
+import logging
+import time
+from typing import Callable, Optional
+
+from om1_utils import ws
+from om1_vlm import VideoStream
+
+from .singleton import singleton
+
+
+@singleton
+class VLMAnthropicProvider:
+    """
+    VLM Provider that handles video streaming and Anthropic Claude API communication.
+
+    This class implements a singleton pattern to manage video input streaming and API
+    communication for vision language model services using Claude. It runs in a separate
+    thread to handle continuous VLM processing.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str,
+        model: str = "claude-3-5-sonnet-20241022",
+        fps: int = 10,
+        stream_url: Optional[str] = None,
+        camera_index: int = 0,
+    ):
+        """
+        Initialize the VLM Provider.
+
+        Parameters
+        ----------
+        base_url : str
+            The base URL for the Anthropic API.
+        api_key : str
+            The API key for the Anthropic API.
+        model : str
+            The Claude model to use. Defaults to claude-3-5-sonnet-20241022.
+        fps : int
+            The frames per second for the video stream.
+        stream_url : str, optional
+            The URL for the video stream. If not provided, defaults to None.
+        camera_index : int
+            The camera index for the video stream device. Defaults to 0.
+        """
+        self.running: bool = False
+        self.api_key: str = api_key
+        self.base_url: str = base_url
+        self.model: str = model
+        self.stream_ws_client: Optional[ws.Client] = (
+            ws.Client(url=stream_url) if stream_url else None
+        )
+        self.video_stream: VideoStream = VideoStream(
+            frame_callback=self._process_frame, fps=fps, device_index=camera_index  # type: ignore
+        )
+        self.message_callback: Optional[Callable] = None
+
+    async def _process_frame(self, frame: str):
+        """
+        Process a video frame using the Anthropic Claude API.
+
+        Parameters
+        ----------
+        frame : str
+            The base64 encoded video frame to process.
+        """
+        import aiohttp
+
+        processing_start = time.perf_counter()
+        try:
+            headers = {
+                "x-api-key": self.api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            }
+
+            payload = {
+                "model": self.model,
+                "max_tokens": 300,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "What is the most interesting aspect in this image? Provide a brief description.",
+                            },
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/jpeg",
+                                    "data": frame,
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.base_url}/v1/messages", headers=headers, json=payload
+                ) as response:
+                    if response.status == 200:
+                        result = await response.json()
+                        processing_latency = time.perf_counter() - processing_start
+                        logging.debug(
+                            f"Processing latency: {processing_latency:.3f} seconds"
+                        )
+                        logging.debug(f"Anthropic Claude VLM Response: {result}")
+
+                        # Extract content from Claude's response format
+                        if (
+                            "content" in result
+                            and len(result["content"]) > 0
+                            and "text" in result["content"][0]
+                        ):
+                            content_text = result["content"][0]["text"]
+                            # Create OpenAI-compatible response object for consistency
+                            mock_response = type(
+                                "ChatCompletion",
+                                (),
+                                {
+                                    "choices": [
+                                        type(
+                                            "Choice",
+                                            (),
+                                            {
+                                                "message": type(
+                                                    "Message",
+                                                    (),
+                                                    {"content": content_text},
+                                                )()
+                                            },
+                                        )()
+                                    ]
+                                },
+                            )()
+                            if self.message_callback:
+                                self.message_callback(mock_response)
+                    else:
+                        error_text = await response.text()
+                        logging.error(
+                            f"Error from Anthropic API: {response.status} - {error_text}"
+                        )
+        except Exception as e:
+            logging.error(f"Error processing frame: {e}")
+
+    def register_message_callback(self, message_callback: Optional[Callable]):
+        """
+        Register a callback for processing Claude results.
+
+        Parameters
+        ----------
+        callback : callable
+            The callback function to process Claude results.
+        """
+        self.message_callback = message_callback
+
+    def start(self):
+        """
+        Start the Anthropic Claude provider.
+
+        Initializes and starts the video stream and processing thread
+        if not already running.
+        """
+        if self.running:
+            logging.warning("Anthropic Claude VLM provider is already running")
+            return
+
+        self.running = True
+        self.video_stream.start()
+
+        if self.stream_ws_client:
+            self.stream_ws_client.start()
+            self.video_stream.register_frame_callback(
+                self.stream_ws_client.send_message
+            )
+
+        logging.info("Anthropic Claude VLM provider started")
+
+    def stop(self):
+        """
+        Stop the Anthropic Claude provider.
+
+        Stops the video stream and processing thread.
+        """
+        self.running = False
+        self.video_stream.stop()
+
+        if self.stream_ws_client:
+            self.stream_ws_client.stop()


### PR DESCRIPTION
This PR extends OM1's vision capabilities by adding support for Anthropic's Claude models as a VLM provider, addressing issue #360.

## Changes

- Implemented `VLMAnthropicProvider` class for Claude Vision API integration
- Added `VLMAnthropic` input plugin following established patterns
- Included example configuration file for easy adoption
- Maintained full compatibility with existing VLM provider architecture

## Implementation Details

The provider handles video stream processing and converts Claude's response format to maintain compatibility with OM1's internal message handling system. The implementation follows the same patterns as existing VLM providers (OpenAI, Gemini) to ensure consistency across the codebase.

## Configuration Example

Users can leverage Claude's vision capabilities by using the provided `anthropic_claude.json5` config or by adding the following to their agent configuration:

```json
{
  "type": "VLMAnthropic",
  "config": {
    "model": "claude-3-5-sonnet-20241022",
    "camera_index": 0
  }
}
```

## Testing

The integration has been tested with Claude 3.5 Sonnet model for vision processing and works seamlessly with OM1's modular architecture.

## Related Issues

Closes #360