### PR TITLE
Fix motor_speed setter validation in RPLidar driver

### DIFF
--- a/src/providers/rplidar_driver.py
+++ b/src/providers/rplidar_driver.py
@@ -182,7 +182,10 @@ class RPDriver(object):
 
     @motor_speed.setter
     def motor_speed(self, pwm):
-        assert 0 <= pwm <= MAX_MOTOR_PWM
+        if not (0 <= pwm <= MAX_MOTOR_PWM):
+            raise ValueError(
+                f"PWM value must be between 0 and {MAX_MOTOR_PWM}, got {pwm}"
+            )
         self._motor_speed = pwm
         if self.motor_running:
             self._set_pwm(self._motor_speed)


### PR DESCRIPTION
## Problem

The `motor_speed` setter in the RPLidar driver was using `assert` for input validation (line 185). This causes issues in production environments when Python is run with the `-O` flag, which disables assertions. Invalid PWM values would pass through validation and potentially damage the hardware or cause unexpected behavior.

## Solution

Replaced the assertion with explicit `ValueError` exception that:
- Always executes regardless of Python optimization flags
- Provides clear error message with actual and expected values
- Follows Python best practices for input validation

## Changes

- Updated `motor_speed` setter to use `if not (0 <= pwm <= MAX_MOTOR_PWM)` check
- Raises `ValueError` with descriptive message when PWM is out of valid range [0, 1023]

## Testing

The validation logic correctly:
- Accepts PWM values from 0 to 1023
- Rejects negative values with clear error message
- Rejects values above 1023 with clear error message

---

This PR contains only the RPLidar fix as requested in PR #476 review feedback.