### PR TITLE
Fix AttributeError in ROS2PublisherProvider stop method

### DIFF
--- a/src/providers/ros2_publisher_provider.py
+++ b/src/providers/ros2_publisher_provider.py
@@ -85,5 +85,6 @@ class ROS2PublisherProvider(Node):
         self.running = False
         if self._thread:
             self._thread.join(timeout=5)
-        self._publisher.Close()
+        if hasattr(self, "publisher_"):
+            self.destroy_publisher(self.publisher_)
         logging.info("ROS2 Publisher Provider stopped")


### PR DESCRIPTION
## Problem

The `stop()` method in `ROS2PublisherProvider` has a bug that causes an `AttributeError` when called.

**Current code (line 88):**
```python
self._publisher.Close()
```

This fails because:
1. The attribute is named `publisher_` (not `_publisher`) - see line 24 where it's created
2. rclpy publishers don't have a `Close()` method - the correct way to clean up is `Node.destroy_publisher()`

## Solution

Replace the broken cleanup call with:
```python
if hasattr(self, 'publisher_'):
    self.destroy_publisher(self.publisher_)
```

This follows the standard rclpy cleanup pattern and includes a safety check in case publisher creation failed during init.

## Impact

This bug would cause crashes in any code that calls `stop()` on a `ROS2PublisherProvider` instance. The provider is currently used in `src/actions/move_sim/connector/ros2_full.py`.

## Testing

Verified by:
- Checking rclpy documentation for proper cleanup methods
- Confirming the correct attribute name from line 24
- Reviewing how the publisher is used throughout the class