### PR TITLE
Discord's invitation link modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![OM_Banner_X2 (1)](https://github.com/user-attachments/assets/853153b7-351a-433d-9e1a-d257b781f93c)
 
-<p align="center">  <a href="https://arxiv.org/abs/2412.18588"  target="_blank">Technical Paper</a> |  <a href="https://docs.openmind.org/" target="_blank">Documentation</a> |  <a href="https://x.com/openmind_agi" target="_blank">X</a> | <a href="https://discord.gg/qbvKUmBz" target="_blank">Discord</a> </p>
+<p align="center">  <a href="https://arxiv.org/abs/2412.18588"  >Technical Paper</a> |  <a href="https://docs.openmind.org/" >Documentation</a> |  <a href="https://x.com/openmind_agi">X</a> | <a href="https://discord.gg/CBBCDEZMs4">Discord</a> </p>
 
 **OpenMind's OM1 is a modular AI runtime that empowers developers to create and deploy multimodal AI agents across digital environments and physical robots**, including Humanoids, Phone Apps, websites, Quadrupeds, and educational robots such as TurtleBot 4. OM1 agents can process diverse inputs like web data, social media, camera feeds, and LIDAR, while enabling physical actions including motion, autonomous navigation, and natural conversations. The goal of OM1 is to make it easy to create highly capable human-focused robots, that are easy to upgrade and (re)configure to accommodate different physical form factors.
 


### PR DESCRIPTION
I have modified the invitation link for Discord on OpenMind to https://discord.gg/CBBCDEZMs4 Convenient for users to join, the link is permanently valid.