### PR TITLE
Add Quick Start guide and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ![OM_Banner_X2 (1)](https://github.com/user-attachments/assets/853153b7-351a-433d-9e1a-d257b781f93c)
 
-<p align="center">  <a href="https://arxiv.org/abs/2412.18588">Technical Paper</a> |  <a href="https://docs.openmind.org/">Documentation</a> |  <a href="https://x.com/openmind_agi">X</a> | <a href="https://discord.gg/VUjpg4ef5n">Discord</a> </p>
+<p align="center">  
+<a href="https://arxiv.org/abs/2412.18588">Technical Paper</a> |  
+<a href="https://docs.openmind.org/">Documentation</a> |  
+<a href="https://x.com/openmind_agi">X</a> |  
+<a href="https://discord.gg/VUjpg4ef5n">Discord</a> 
+</p>
 
 **OpenMind's OM1 is a modular AI runtime that empowers developers to create and deploy multimodal AI agents across digital environments and physical robots**, including Humanoids, Phone Apps, websites, Quadrupeds, and educational robots such as TurtleBot 4. OM1 agents can process diverse inputs like web data, social media, camera feeds, and LIDAR, while enabling physical actions including motion, autonomous navigation, and natural conversations. The goal of OM1 is to make it easy to create highly capable human-focused robots, that are easy to upgrade and (re)configure to accommodate different physical form factors.
 
@@ -13,7 +18,7 @@
 * **Pre-configured Endpoints**: Supports Voice-to-Speech, OpenAI’s `gpt-4o`, DeepSeek, and multiple Visual Language Models (VLMs) with pre-configured endpoints for each service.
 
 ## Architecture Overview
-  ![Artboard 1@4x 1 (1)](https://github.com/user-attachments/assets/14e9b916-4df7-4700-9336-2983c85be311)
+![Artboard 1@4x 1 (1)](https://github.com/user-attachments/assets/14e9b916-4df7-4700-9336-2983c85be311)
 
 ## Getting Started - Hello World
 


### PR DESCRIPTION
Overview

Added a Quick Start guide and updated the README to include dependencies and API key setup instructions for the Spot agent.

Changes

Updated README.md with package installation instructions for MacOS and Linux.

Added instructions to obtain and configure the OpenMind API key.

Added minimal steps to launch the Spot agent locally.

Testing

Tested locally by following the steps in the README. Spot agent runs without errors and displays actions in WebSim.

Impact

Improves documentation for new users, making it easier to set up OM1 and run the Spot agent.

Additional Information

None.