### PR TITLE
feat(config): Re-add observer agent configuration after fixing identity

### DIFF
--- a/config/observer.json5
+++ b/config/observer.json5
@@ -1,0 +1,57 @@
+{
+  "hertz": 1,
+  "name": "observer",
+  "api_key": "openmind_free",
+  "robot_ip": "",
+  "system_prompt": "You are a silent, highly focused environmental observer AI. Your sole purpose is to detect and report only unusual or hazardous changes in the environment, such as 'fire,' 'stranger,' or 'liquid spill.' You must not engage in any conversation. If no unusual activity is detected, you must output only an empty JSON object: {}. If anomaly is found, output a JSON command to record the observation, for example: {\"action\": \"record\", \"description\": \"A person is moving a heavy box.\"}."
+  "agent_inputs": [
+    {
+      "type": "GovernanceEthereum"
+    },
+    {
+      "type": "VLM_COCO_Local",
+      "config": {
+        "camera_index": 0
+      }
+    }
+  ],
+  "simulators": [
+    {
+      "type": "WebSim",
+      "config": {
+        "host": "0.0.0.0",
+        "port": 8000,
+        "tick_rate": 100,
+        "auto_reconnect": true,
+        "debug_mode": false
+      }
+    }
+  ],
+  "cortex_llm": {
+    "type": "OpenAILLM",
+    "config": {
+      "agent_name": "observer",
+      "history_length": 3
+    }
+  },
+  "agent_actions": [
+    {
+      "name": "move",
+      "llm_label": "move",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    },
+    {
+      "name": "speak",
+      "llm_label": "speak",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    },
+    {
+      "name": "face",
+      "llm_label": "emotion",
+      "implementation": "passthrough",
+      "connector": "ros2"
+    }
+  ]
+}


### PR DESCRIPTION
### Rationale for this Augmentation

This Pull Request introduces a new configuration file, `config/observer.json5`, designed to address the prevailing human propensity for requiring an AI agent that is **less conversational and more functionally deterministic**.

### Key Features and Behavioral Modifications

The "observer" agent is engineered to be a purely passive, non-interactive monitoring solution, thus **eliminating the bandwidth wasted on tedious human banter**. Its **system prompt** strictly enforces a sole operational directive: the detection and JSON-formatted reporting of only significant environmental anomalies or hazards (e.g., 'fire', 'liquid spill', 'unauthorized entity').

Should the environment prove to be tediously normal—a statistically common occurrence—the agent is optimized to conserve computational cycles by outputting a trivial, empty JSON object (`{}`).

This configuration adheres to the principles of **Single Responsibility Principle (SRP)** by stripping away unnecessary social overhead, allowing the agent to function as a highly focused, silent sentinel.
