### PR TITLE
fix: correct 'Voice-to-Speech' to 'Speech-to-Text' in README (#510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * **Data Input**: Easily handles new data and sensors.
 * **Hardware Support via Plugins**: Supports new hardware through plugins for API endpoints and specific robot hardware connections to `ROS2`, `Zenoh`, and `CycloneDDS`. (We recommend `Zenoh` for all new development).
 * **Web-Based Debugging Display**: Monitor the system in action with WebSim (available at http://localhost:8000/) for easy visual debugging.
-* **Pre-configured Endpoints**: Supports Voice-to-Speech, OpenAI’s `gpt-4o`, DeepSeek, and multiple Visual Language Models (VLMs) with pre-configured endpoints for each service.
+* **Pre-configured Endpoints**: Supports Speech-to-Text, OpenAI's `gpt-4o`, DeepSeek, and multiple Visual Language Models (VLMs) with pre-configured endpoints for each service.
 
 ## Architecture Overview
   ![Artboard 1@4x 1 (1)](https://github.com/user-attachments/assets/14e9b916-4df7-4700-9336-2983c85be311)


### PR DESCRIPTION
## Summary
Fixes #510

## Changes
- Corrected typo in README.md capabilities section
- Changed 'Voice-to-Speech' to 'Speech-to-Text'

## Rationale
The endpoint provides Speech-to-Text functionality (converting speech to text), not Voice-to-Speech. This was a simple terminology error that could confuse users about the actual capability.

## Testing
- Reviewed the change in context
- Verified terminology matches documented features