### PR TITLE
Fix: Add .env file support to keyboard remote control script

### DIFF
--- a/system_hw_test/om_keyboard_remote_control.py
+++ b/system_hw_test/om_keyboard_remote_control.py
@@ -25,7 +25,18 @@ logging.basicConfig(
 
 OM_API_KEY = os.environ.get("OM_API_KEY", None)
 if not OM_API_KEY:
-    logging.error("OM_API_KEY environment variable not set.")
+    # Try to load from .env file in parent directory
+    env_path = os.path.join(os.path.dirname(__file__), "..", ".env")
+    if os.path.exists(env_path):
+        with open(env_path, "r") as f:
+            for line in f:
+                if line.startswith("OM_API_KEY="):
+                    OM_API_KEY = line.split("=", 1)[1].strip()
+                    break
+
+if not OM_API_KEY:
+    logging.error("OM_API_KEY not found in environment or .env file.")
+    logging.error("Please set OM_API_KEY environment variable or add it to .env file")
     sys.exit(1)
 
 


### PR DESCRIPTION
The om_keyboard_remote_control.py script was only checking environment variables for OM_API_KEY, causing failures even when users had a .env file.

This commit adds support for loading OM_API_KEY from the .env file in the parent directory, matching the behavior of other scripts in the project.

Changes:
- Added .env file parsing when OM_API_KEY is not in environment
- Improved error messages to mention both environment and .env options
- Maintains backward compatibility with environment variable approach

## Overview
[Provide a brief overview of the changes in this pull request.]

## Changes
[Detail the changes you have made in this pull request. Include any new features, bug fixes, or improvements.]

## Testing
[Describe the testing you have done to verify your changes. Include any relevant details about the test environment and the results of your tests.]

## Impact
[Explain the impact of your changes. Include any potential risks or side effects that reviewers should be aware of.]

## Additional Information
[Include any additional information that may be relevant to reviewers. This could include links to related issues or pull requests, references to documentation, or other context that may help reviewers understand your changes.]
