### PR TITLE
Fix WebSocket callback registration order in Go2 connector

### DIFF
--- a/src/actions/move_go2_teleops/connector/remote.py
+++ b/src/actions/move_go2_teleops/connector/remote.py
@@ -47,7 +47,6 @@ class MoveGo2Remote(ActionConnector[MoveInput]):
         self.ws_client = ws.Client(
             url=f"wss://api.openmind.org/api/core/teleops/action?api_key={api_key}"
         )
-
         self.ws_client.register_message_callback(self._on_message)
         self.ws_client.start()
 


### PR DESCRIPTION
This fix ensures that the WebSocket callback is registered before starting
the client in the MoveGo2Remote connector, preventing missed messages
during initialization. Only one line change: callback registration order.