### PR TITLE
feat(runtime): Add text message output and validation for empty messa…

### DIFF
--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -507,5 +507,14 @@ class CortexRuntime:
 
             # Trigger the actions
             await self.action_orchestrator.promise(output.actions)
+	    # Handle text message output if available
+            message = getattr(output, 'message', None)  # Assuming LLM output object has 'message' attribute
+
+            if message and isinstance(message, str) and message.strip():
+                # Send valid message to output provider
+                await self.io_provider.send_message(message)
+            else:
+                # Log a warning if the message is empty, addressing Issue #671
+                logging.warning("Agent produced an empty or non-string message. Skipping output processing.")
         except Exception as error:
             logging.error(f"Error in cortex tick: {error}")


### PR DESCRIPTION
### Summary of Changes

This update addresses [Issue #671](https://github.com/OpenMind/OM1/issues/671) by adding logic to check and process text messages from the Cortex LLM within the single-agent mode (`single_mode`).

Specifically, this change introduces two main improvements:

1.  **New Feature:** Enables the Agent to send text messages externally via the `IOProvider` (assuming the LLM output includes a `message` field).
2.  **Bugfix (Closes #671):** Prevents errors when the Agent returns a message that is either `None` (empty) or contains only whitespace, ensuring the `_tick` processing continues smoothly.

---

### Technical Details

The validation logic has been inserted at the end of the `async def _tick(self)` function in the file `src/runtime/single_mode/cortex.py`.

```python
# Handle text message output if available
message = getattr(output, 'message', None)

if message and isinstance(message, str) and message.strip():
    # Send valid message to output provider
    await self.io_provider.send_message(message)
else:
    # Log a warning if the message is empty or invalid
    logging.warning("Agent produced an empty or non-string message. Skipping output processing.")