### PR TITLE
Add example for microphone_device_id in Unitree G1 config (fixes #682)

### DIFF
--- a/config/unitree_g1_humanoid.json5
+++ b/config/unitree_g1_humanoid.json5
@@ -9,6 +9,11 @@
   agent_inputs: [
     {
       type: "GoogleASRInput",
+      config: {
+        api_key: "YOUR_API_KEY",
+        microphone_device_id: "default", // or specific device id on your system
+        // microphone_name: "USB PnP Sound Device" // optional
+      },
     },
     {
       type: "UnitreeG1Basic",


### PR DESCRIPTION
Adds a minimal example of microphone_device_id in unitree_g1_humanoid.json5