### PR TITLE
docs: add macOS Zenoh troubleshooting section (issue #639)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,34 @@ docker-compose up watchdog -d --no-build
 cd OM1-avatar
 docker-compose up om1_avatar -d --no-build
 ```
+
+### Troubleshooting: macOS Zenoh error (issue #639)
+
+If you run OM1 on macOS **without a physical robot** and you see a Zenoh error like:
+
+```text
+Unable to connect to any of [tcp/127.0.0.1:7447]
+```
+you can try the following:
+
+1. Use Python 3.10 on macOS (Python 3.11 is not fully supported yet).
+
+2. For local experiments, temporarily remove the `GovernanceEthereum` item from the `agent_inputs` array in your agent config, for example:
+
+```json5
+"agent_inputs": [
+  // {
+  //   "type": "GovernanceEthereum"
+  // },
+  {
+    "type": "VLM_COCO_Local",
+    "config": {
+      "camera_index": 0
+    }
+  }
+]
+```
+
 ## Detailed Documentation
 
 More detailed documentation can be accessed at [docs.openmind.org](https://docs.openmind.org/).


### PR DESCRIPTION
## Overview

This pull request addresses issue **#639** by improving the documentation for macOS users who run OM1 without physical robot hardware.

Instead of changing core behavior for `GovernanceEthereum`, this PR clarifies the supported Python version and adds a troubleshooting section for the Zenoh connection error reported in the issue.

Closes #639

## Changes

- Updated the installation / environment notes in `README.md` to mention that OM1 currently supports **Python 3.10** on macOS and that using Python 3.11 may cause connection issues when `GovernanceEthereum` is enabled.
- Added a small "Troubleshooting: macOS Zenoh error (issue #639)" subsection under "Starting the system" that:
  - Shows the Zenoh error message (`Unable to connect to any of [tcp/127.0.0.1:7447]`) from the original issue.
  - Recommends using Python 3.10 on macOS.
  - Documents a simple configuration-only workaround by temporarily removing (commenting out) the `GovernanceEthereum` entry from the `agent_inputs` array in the agent config.

## Testing

- Changes are limited to `README.md` (documentation only).
- Verified that the updated Markdown renders correctly in the GitHub preview.
- No Python code or runtime behavior has been modified in this PR.
