### PR TITLE
docs(README): add related repositories table

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ docker-compose up om1_avatar -d --no-build
 
 More detailed documentation can be accessed at [docs.openmind.org](https://docs.openmind.org/).
 
+### Related Repositories
+
+| Component | Repository | Description |
+|----------|------------|-------------|
+| OM1 Core | https://github.com/OpenMind/OM1 | Main robotics runtime and agent framework. |
+| OM1 Avatar | https://github.com/OpenMind/OM1-avatar | React-based UI for robot status visualization and avatar control. |
+| OM1 Video Processor | https://github.com/OpenMind/OM1-video-processor | Handles camera streaming, face detection, and audio capture. |
+| Unitree SDK | https://github.com/OpenMind/unitree-sdk | Navigation, SLAM and robot hardware integration for Unitree robots. |
+
 ## Contributing
 
 Please make sure to read the [Contributing Guide](./CONTRIBUTING.md) before making a pull request.


### PR DESCRIPTION
## Overview

This PR improves the documentation by adding a "Related Repositories" table to the README.  
OM1 is part of a larger ecosystem (OM1-avatar, OM1-video-processor, unitree-sdk), but the README only links to the main documentation site.  

This addition helps new developers quickly discover the relevant modules in the OM1 ecosystem.

## Changes

- Added a new "Related Repositories" subsection under **Detailed Documentation**
- Added a simple table with links and descriptions for:
  - OM1 Core
  - OM1 Avatar
  - OM1 Video Processor
  - Unitree SDK

## Testing

- README.md renders correctly in GitHub preview
- Table formatting verified
- No code changes were made
