### PR TITLE
docs: add Troubleshooting Guide for common OM1 errors

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -78,7 +78,7 @@ ffmpeg not found
 Audio backend initialization failed
 ```
 
-###Cause
+### Cause
 FFmpeg is required for:
 - Text-to-Speech
 - Audio playback


### PR DESCRIPTION
## Overview

This PR adds a new `TROUBLESHOOTING.md` document under the `docs/` folder.  
It consolidates several common errors encountered when setting up or running OM1, especially on macOS and Linux environments.

## Why this is useful

- Reduces repetitive GitHub issues for the same environment problems  
- Helps new contributors set up OM1 faster  
- Aligns the project with standard documentation structure found in other large OSS repos (PyTorch, LangChain, ROS2)

## Content Added

- Python version mismatch (macOS)
- Zenoh connection errors
- PortAudio missing
- FFmpeg missing
- Docker permission errors
- WebSim startup issues

## Testing

- Markdown renders properly in GitHub preview
- No code changes were made
- No behavior of OM1 is affected
