### PR TITLE
Add avatar in unitree go2 modes

### DIFF
--- a/config/unitree_go2_modes.json5
+++ b/config/unitree_go2_modes.json5
@@ -133,6 +133,11 @@
       },
       "agent_actions": [
         {
+          "name": "face",
+          "llm_label": "emotion",
+          "connector": "avatar"
+        },
+        {
           "name": "speak",
           "llm_label": "speak",
           "connector": "elevenlabs_tts",
@@ -282,6 +287,11 @@
       },
       "agent_actions": [
         {
+          "name": "face",
+          "llm_label": "emotion",
+          "connector": "avatar"
+        },
+        {
           "name": "speak",
           "llm_label": "speak",
           "connector": "elevenlabs_tts",
@@ -405,6 +415,11 @@
       ],
       "agent_actions": [
         {
+          "name": "face",
+          "llm_label": "emotion",
+          "connector": "avatar"
+        },
+        {
           "name": "speak",
           "llm_label": "speak",
           "connector": "elevenlabs_tts",
@@ -504,6 +519,11 @@
         }
       ],
       "agent_actions": [
+        {
+          "name": "face",
+          "llm_label": "emotion",
+          "connector": "avatar"
+        },
         {
           "name": "move_go2_autonomy",
           "llm_label": "move",


### PR DESCRIPTION
This pull request adds a new agent action called `face` to multiple mode configurations in the `config/unitree_go2_modes.json5` file. The `face` action is associated with the `emotion` label and uses the `avatar` connector, enabling the agent to express emotions through its avatar interface.

Agent action additions:

* Added a `face` action with `llm_label` set to `emotion` and `connector` set to `avatar` in four different mode configurations in `config/unitree_go2_modes.json5`. [[1]](diffhunk://#diff-f6ae5600ee41311fb0893200685e5aea8136c44ad86c3cd0f105b02d9bd6e1d0R135-R139) [[2]](diffhunk://#diff-f6ae5600ee41311fb0893200685e5aea8136c44ad86c3cd0f105b02d9bd6e1d0R289-R293) [[3]](diffhunk://#diff-f6ae5600ee41311fb0893200685e5aea8136c44ad86c3cd0f105b02d9bd6e1d0R417-R421) [[4]](diffhunk://#diff-f6ae5600ee41311fb0893200685e5aea8136c44ad86c3cd0f105b02d9bd6e1d0R522-R526)