### PR TITLE
Refactor zenoh session management

### DIFF
--- a/src/zenoh_msgs/session.py
+++ b/src/zenoh_msgs/session.py
@@ -1,42 +1,8 @@
-import atexit
 import logging
-import weakref
 
 import zenoh
 
 logging.basicConfig(level=logging.INFO)
-
-_active_sessions = weakref.WeakSet()
-
-
-def _cleanup_session(session_ref):
-    """
-    Cleanup callback for weakref when session is garbage collected.
-    """
-    try:
-        session = session_ref()
-        if session is not None:
-            session.close()
-            logging.info("Zenoh session closed automatically via weakref callback")
-    except Exception as e:
-        logging.warning(f"Error during automatic session cleanup: {e}")
-
-
-def _cleanup_all_sessions():
-    """
-    Cleanup all active sessions on program exit.
-    """
-    sessions_to_close = list(_active_sessions)
-    for session in sessions_to_close:
-        try:
-            if hasattr(session, "close"):
-                session.close()
-                logging.info("Zenoh session closed automatically on exit")
-        except Exception as e:
-            logging.warning(f"Error during exit cleanup: {e}")
-
-
-atexit.register(_cleanup_all_sessions)
 
 
 def create_zenoh_config(network_discovery: bool = True) -> zenoh.Config:
@@ -63,12 +29,12 @@ def create_zenoh_config(network_discovery: bool = True) -> zenoh.Config:
 
 def open_zenoh_session() -> zenoh.Session:
     """
-    Open a Zenoh session with automatic cleanup.
+    Open a Zenoh session with a local connection first, then fall back to network discovery.
 
     Returns
     -------
     zenoh.Session
-        The opened Zenoh session with automatic cleanup.
+        The opened Zenoh session.
 
     Raises
     ------
@@ -76,29 +42,28 @@ def open_zenoh_session() -> zenoh.Session:
         If unable to open a Zenoh session.
     """
     local_config = create_zenoh_config(network_discovery=False)
-
     try:
         session = zenoh.open(local_config)
         logging.info("Zenoh client opened without network discovery")
+        return session
     except Exception as e:
         logging.warning(f"Local connection failed: {e}")
         logging.info("Falling back to network discovery...")
 
-        config = create_zenoh_config()
-        try:
-            session = zenoh.open(config)
-            logging.info("Zenoh client opened with network discovery")
-        except Exception as e:
-            logging.error(f"Error opening Zenoh client: {e}")
-            raise Exception("Failed to open Zenoh session") from e
-
-    _active_sessions.add(session)
-
-    weakref.finalize(session, _cleanup_session, weakref.ref(session))
-
-    return session
+    config = create_zenoh_config()
+    try:
+        session = zenoh.open(config)
+        logging.info("Zenoh client opened with network discovery")
+        return session
+    except Exception as e:
+        logging.error(f"Error opening Zenoh client: {e}")
+        raise Exception("Failed to open Zenoh session") from e
 
 
 if __name__ == "__main__":
     session = open_zenoh_session()
-    logging.info("Session opened successfully with automatic cleanup")
+    if session:
+        logging.info("Session opened successfully")
+        session.close()
+    else:
+        logging.error("Failed to open Zenoh session")

--- a/tests/integration/test_case_runner.py
+++ b/tests/integration/test_case_runner.py
@@ -5,6 +5,7 @@ import re
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+from unittest.mock import MagicMock, patch
 
 import json5
 import openai
@@ -38,6 +39,50 @@ TEST_CASES_DIR = DATA_DIR / "test_cases"
 
 # Global client to be created once for all test cases
 _llm_client = None
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.openai_llm.AvatarLLMState.trigger_thinking", mock_decorator),
+        patch("llm.plugins.openrouter.AvatarLLMState.trigger_thinking", mock_decorator),
+        patch("llm.plugins.gemini_llm.AvatarLLMState.trigger_thinking", mock_decorator),
+        patch(
+            "llm.plugins.near_ai_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.xai_llm.AvatarLLMState.trigger_thinking", mock_decorator),
+        patch(
+            "providers.avatar_llm_state_provider.AvatarLLMState"
+        ) as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 # Movement types that should be considered movement commands

--- a/tests/llm/plugins/test_deepseek_llm.py
+++ b/tests/llm/plugins/test_deepseek_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -45,6 +45,41 @@ def mock_response_with_tool_calls():
         )
     ]
     return response
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.deepseek_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 @pytest.fixture

--- a/tests/llm/plugins/test_gemini_llm.py
+++ b/tests/llm/plugins/test_gemini_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -45,6 +45,41 @@ def mock_response_with_tool_calls():
         )
     ]
     return response
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.deepseek_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 @pytest.fixture

--- a/tests/llm/plugins/test_openai_llm.py
+++ b/tests/llm/plugins/test_openai_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -45,6 +45,41 @@ def mock_response_with_tool_calls():
         )
     ]
     return response
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.deepseek_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 @pytest.fixture

--- a/tests/llm/plugins/test_openrouter.py
+++ b/tests/llm/plugins/test_openrouter.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -45,6 +45,41 @@ def mock_response_with_tool_calls():
         )
     ]
     return response
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.deepseek_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 @pytest.fixture

--- a/tests/llm/plugins/test_xai_llm.py
+++ b/tests/llm/plugins/test_xai_llm.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -46,6 +46,41 @@ def mock_response_with_tool_calls():
         )
     ]
     return response
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation"""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.deepseek_llm.AvatarLLMState.trigger_thinking", mock_decorator
+        ),
+        patch("llm.plugins.deepseek_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
This pull request refactors the Zenoh session management logic and introduces robust mocking of avatar and IO components across integration and LLM plugin tests. The main goals are to simplify session handling, prevent unwanted side effects during testing, and ensure tests run reliably without creating real Zenoh sessions.

**Zenoh session management refactor:**

* Removed global session tracking and automatic cleanup logic from `src/zenoh_msgs/session.py`, simplifying session lifecycle management and eliminating use of `atexit` and `weakref`.
* Updated `open_zenoh_session()` to first attempt a local connection, then fall back to network discovery, and removed automatic cleanup on exit. The session must now be closed manually. [[1]](diffhunk://#diff-9cfcf72b8485e1e4ad2cb9398fa6c6cad48fd71b4bdac0df7298447e2250f741L53-R48) [[2]](diffhunk://#diff-9cfcf72b8485e1e4ad2cb9398fa6c6cad48fd71b4bdac0df7298447e2250f741R57-R69)

**Test infrastructure improvements:**

* Added `mock_avatar_components` pytest fixture (autouse) to integration and LLM plugin tests, which mocks avatar and IO-related components to prevent Zenoh session creation and side effects during test runs. This fixture is consistently applied across all plugin test files. [[1]](diffhunk://#diff-b8506c74d298e0f248c9313528ee564f10948c5b903acf6724f26c15a49fc127R44-R87) [[2]](diffhunk://#diff-48bbf6b653adbb5a4587378bfc83d6a83386e5b5bfb02fc2701258c1a8015ed8R50-R84) [[3]](diffhunk://#diff-406d25159b5d480ee0b51fab106c1a93cb82cd11720db4d2967b7e6715d044fbR50-R84) [[4]](diffhunk://#diff-25485b6f19157a46ed7a5175562babc5f52025223fea91af66fcaa8db2b29eefR50-R84) [[5]](diffhunk://#diff-75a3f5c83813868e6e2cd33308c24f3a0d51209e5036770f232caa1a7be516d5R50-R84) [[6]](diffhunk://#diff-c9493cfae94a9fe63f5a65242e2f90a3b64c1b94602b31e2bb6de3c37efa84aeR51-R85)
* Updated imports in test files to include `patch` from `unittest.mock` for mocking purposes. [[1]](diffhunk://#diff-b8506c74d298e0f248c9313528ee564f10948c5b903acf6724f26c15a49fc127R8) [[2]](diffhunk://#diff-48bbf6b653adbb5a4587378bfc83d6a83386e5b5bfb02fc2701258c1a8015ed8L1-R1) [[3]](diffhunk://#diff-406d25159b5d480ee0b51fab106c1a93cb82cd11720db4d2967b7e6715d044fbL1-R1) [[4]](diffhunk://#diff-25485b6f19157a46ed7a5175562babc5f52025223fea91af66fcaa8db2b29eefL1-R1) [[5]](diffhunk://#diff-75a3f5c83813868e6e2cd33308c24f3a0d51209e5036770f232caa1a7be516d5L1-R1) [[6]](diffhunk://#diff-c9493cfae94a9fe63f5a65242e2f90a3b64c1b94602b31e2bb6de3c37efa84aeL1-R1)

These changes improve code clarity, reduce test flakiness, and make session management more explicit for both production and testing environments.