### PR TITLE
fix: replace print statement with logging in ROS2PublisherProvider

### DIFF
--- a/src/providers/ros2_publisher_provider.py
+++ b/src/providers/ros2_publisher_provider.py
@@ -17,7 +17,7 @@ class ROS2PublisherProvider(Node):
         try:
             super().__init__("ROS2_publisher_provider")
         except Exception as e:
-            print(f"Node initialization error: {e}")
+            logging.error(f"Node initialization error: {e}")
 
         # Initialize the publisher.
         try:


### PR DESCRIPTION
## Summary
Replaced `print()` with `logging.error()` for consistent error handling in ROS2PublisherProvider.

## Problem
Line 20 used `print()` for error output, which is inconsistent with the logging pattern used elsewhere in the same file (lines 25, 27).

## Solution
Changed:
```python
print(f"Node initialization error: {e}")
```

To:
```python
logging.error(f"Node initialization error: {e}")
```

## Benefits
- ✅ Consistent error handling across the file
- ✅ Proper logging for production code
- ✅ Better debugging and monitoring capabilities

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement
