### PR TITLE
docs(license): normalize LICENSE header and add SPDX identifier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
+SPDX-License-Identifier: MIT
+
 The MIT License (MIT)
 
-Copyright (c) 2024, 2025 OPENMIND.ORG
+Copyright (c) 2024-2025 OpenMind.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR improves the LICENSE file metadata for clarity and consistency.

### Changes
- Added `SPDX-License-Identifier: MIT` for better automated license detection
- Normalized copyright range from `2024, 2025` → `2024–2025`
- Corrected project name casing to `OpenMind.org`

### Why this change?
These adjustments follow common open-source conventions and ensure that
tooling (e.g., license scanners, CI analyzers) can reliably identify the
project's license without altering any legal terms.

No functional or legal changes were made only metadata cleanup.
