### PR TITLE
Free disk to build images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,15 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo docker system prune -af
+          sudo apt-get clean
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@v5
 
@@ -57,6 +66,15 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo docker system prune -af
+          sudo apt-get clean
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@v5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     pkg-config \
     libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN python3 -m pip install --upgrade pip
 


### PR DESCRIPTION
This pull request introduces optimizations to free up disk space during the build and release processes, both in the GitHub Actions workflow and in the Docker image build. These changes help prevent storage-related issues and ensure more efficient use of resources.

**Disk space optimizations:**

* Added a "Free disk space" step to the `.github/workflows/release.yml` workflow, which removes unnecessary tools and files, prunes unused Docker resources, and cleans up apt caches before checking out the repository. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20-R28) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R69-R77)
* Enhanced the Dockerfile cleanup by running `apt-get clean` and removing additional temporary directories (`/tmp/*`, `/var/tmp/*`) after installing dependencies, further reducing image size.