### PR TITLE
Fix: Correct message placement in CortexRuntime, ensuring communicati…

### DIFF
--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -496,6 +496,16 @@ class CortexRuntime:
                 logging.debug("No output from LLM")
                 return
 
+            # --- CORRECTION FOR ISSUE #737 ---
+            # Architecture rule: Decide -> Communicate -> Act
+            # The message must be sent *before* triggering actions/simulators
+            # to ensure the message is delivered before any resulting action/simulator
+            # promises are generated.
+            if output.message and isinstance(output.message, str) and output.message.strip():
+                logging.debug(f"Sending message: {output.message}")
+                self.io_provider.send_message(output.message)
+            # ----------------------------------
+
             # Trigger the simulators
             await self.simulator_orchestrator.promise(output.actions)
 


### PR DESCRIPTION
…on precedes actions (Closes #737)

**Summary:** "Fix: Correct message placement in `CortexRuntime`."

**Detail:** "This PR resolves the issue where the LLM's text output (`message`) was being processed *after* the `simulator_orchestrator.promise` and `action_orchestrator.promise` calls. This violated the architecture's rule (Decide -> Communicate -> Act) and could lead to lost messages. The fix moves the `io_provider.send_message(message)` logic to immediately follow LLM inference. This PR replaces the closed PR **#739** and addresses **Issue #737**."
