### PR TITLE
update script to refine hook definitions

### DIFF
--- a/.github/workflows/generate_config_schema.yml
+++ b/.github/workflows/generate_config_schema.yml
@@ -10,7 +10,7 @@ on:
       - 'src/backgrounds/plugins/**'
       - 'src/llm/plugins/**'
       - 'src/hooks/**'
-      - 'src/providers/config_schema_provider.py'
+      - 'config/schema/multi_mode_schema.json'
       - 'scripts/generate_schema.py'
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request refactors the hooks scanning logic in `scripts/generate_schema.py` to improve schema extraction and function discovery. The main changes involve separating the extraction of hook schema from the listing of available hook functions, and updating the workflow trigger paths to reflect the new schema location.

**Hooks schema extraction and function scanning:**

* Refactored the `scan_hooks` method to return a dictionary with both the hooks schema (parsed from `config/schema/multi_mode_schema.json`) and a list of available hook functions, instead of just a list of hook modules. This improves clarity and extensibility for future schema changes.
* Added a new method `_get_hooks_schema` that loads and parses the hooks schema from the JSON file, including error handling for missing or malformed schema files.
* Added a new method `_scan_hook_functions` that scans the hooks directory and returns only the names of async functions (potential lifecycle hooks) grouped by module, simplifying the previous structure. 

**Workflow and logging updates:**

* Updated the workflow trigger path in `.github/workflows/generate_config_schema.yml` to monitor changes to `config/schema/multi_mode_schema.json` instead of the old provider file, ensuring the workflow runs on relevant schema changes.
* Improved logging in the `generate` method to correctly report the number of hook modules found by referencing the new structure.

**Other improvements:**

* Stored the schema file path in a new instance variable `self.schema_path` for easier access throughout the script.