### PR TITLE
docs: fix typo in mintlify zenoh documentation

### DIFF
--- a/mintlify/robotics/zenoh.md
+++ b/mintlify/robotics/zenoh.md
@@ -40,7 +40,7 @@ zenohd --help
 
 See https://github.com/eclipse-zenoh/zenoh-backend-filesystem?tab=readme-ov-file#how-to-install-it
 
-On Mac, you might need to allow `libzenoh_backend_fs.dylib` to run via `Privacy and Security`. Just try to run it separately - e.g. via the terminal and then `approve` the various popup messages. Once you have run `libzenoh_backend_fs.dylib` once, it will be cached and then `zenoh` can find it the next time. This is good, but can be confusing if you are tryinmg to upgrade `libzenoh_backend_fs.dylib` but it keeps using an older cached version.
+On Mac, you might need to allow `libzenoh_backend_fs.dylib` to run via `Privacy and Security`. Just try to run it separately - e.g. via the terminal and then `approve` the various popup messages. Once you have run `libzenoh_backend_fs.dylib` once, it will be cached and then `zenoh` can find it the next time. This is good, but can be confusing if you are trying to upgrade `libzenoh_backend_fs.dylib` but it keeps using an older cached version.
 
 The RocksDB database is where ever you set the path to:
 


### PR DESCRIPTION

docs: fix typo 'tryinmg' to 'trying' in mintlify zenoh documentation
thanks