### PR TITLE
Update configurations and fix config tests

### DIFF
--- a/config/unitree_go2_autonomy_advance.json5
+++ b/config/unitree_go2_autonomy_advance.json5
@@ -51,7 +51,7 @@
     {
       "name": "navigate_location",
       "llm_label": "navigate_location",
-      "connector": "nav",
+      "connector": "unitree_go2_nav",
     },
     {
      "name": "speak",

--- a/src/backgrounds/plugins/rplidar.py
+++ b/src/backgrounds/plugins/rplidar.py
@@ -41,7 +41,6 @@ class RPLidar(Background):
             "relevant_distance_min": getattr(config, "relevant_distance_min", 0.08),
             "sensor_mounting_angle": getattr(config, "sensor_mounting_angle", 180.0),
             "URID": getattr(config, "URID", ""),
-            "multicast_address": getattr(config, "multicast_address", ""),
             "machine_type": getattr(config, "machine_type", "go2"),
             "log_file": getattr(config, "log_file", False),
         }

--- a/src/inputs/plugins/rplidar.py
+++ b/src/inputs/plugins/rplidar.py
@@ -142,7 +142,6 @@ class RPLidar(FuserInput[Optional[str]]):
             "relevant_distance_min": getattr(config, "relevant_distance_min", 0.08),
             "sensor_mounting_angle": getattr(config, "sensor_mounting_angle", 180.0),
             "URID": getattr(config, "URID", ""),
-            "multicast_address": getattr(config, "multicast_address", ""),
             "machine_type": getattr(config, "machine_type", "go2"),
             "log_file": getattr(config, "log_file", False),
         }

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -67,9 +67,7 @@ def assert_action_classes_exist(action_config):
             connector is not None
         ), f"No connector found for action {action_config['name']}"
     except (ImportError, ModuleNotFoundError):
-        # Skip connectors that fail to import due to missing optional dependencies
-        # This allows tests to pass even when optional SDKs are not installed
-        pass
+        assert False, f"Connector module not found for action {action_config['name']}"
 
 
 def find_subclass_in_module(module, parent_class: Type) -> Optional[Type]:


### PR DESCRIPTION
This pull request updates configuration and test logic related to connectors, and cleans up unused configuration fields for lidar plugins. The most important changes include updating the connector name for navigation actions, enforcing stricter test validation for connector imports, and removing the unused `multicast_address` field from lidar configuration extraction.

**Connector configuration and validation:**

* Changed the connector for the `navigate_location` action from `nav` to `unitree_go2_nav` in `config/unitree_go2_autonomy_advance.json5`, ensuring the correct connector is used for navigation actions.
* Updated the test logic in `tests/config/test_config.py` to fail if a connector module cannot be imported, instead of silently passing when optional dependencies are missing. This enforces stricter validation of connector availability.

**Lidar plugin configuration cleanup:**

* Removed the unused `multicast_address` field from the lidar configuration extraction in both `src/backgrounds/plugins/rplidar.py` and `src/inputs/plugins/rplidar.py`, simplifying the configuration dictionary. [[1]](diffhunk://#diff-0c4717c9ecd4b8b3326269e5e7d0a5b5445d5027daf33555aa8181321fed6566L44) [[2]](diffhunk://#diff-f19a283ec2d632a0f9b7f3c14bc9dce09f811e948ca200de7a1b89e7aa736864L145)
