### PR TITLE
Add venv cache to lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,16 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
 
+      - name: Cache uv dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: ${{ runner.os }}-uv-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
       - name: Run Ruff
         run: uv run ruff check .
 


### PR DESCRIPTION
This pull request introduces a caching step to the lint workflow to optimize dependency management and speed up CI runs.

**CI/CD improvements:**

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R64-R73): Added a cache step for `uv` dependencies and the virtual environment, using `actions/cache@v4` and a key based on the OS and hashes of `pyproject.toml` and `uv.lock`. This helps reduce redundant installs and speeds up linting jobs.