### PR TITLE
Add detailed logging to OpenAI and Qwen LLM plugins

### DIFF
--- a/src/llm/plugins/openai_llm.py
+++ b/src/llm/plugins/openai_llm.py
@@ -84,6 +84,9 @@ class OpenAILLM(LLM[R]):
             parsing fails.
         """
         try:
+            logging.info(f"OpenAI input: {prompt}")
+            logging.info(f"OpenAI messages: {messages}")
+
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
 
@@ -105,6 +108,8 @@ class OpenAILLM(LLM[R]):
             self.io_provider.llm_end_time = time.time()
 
             if message.tool_calls:
+                logging.info(f"Received {len(message.tool_calls)} function calls")
+                logging.info(f"Function calls: {message.tool_calls}")
 
                 function_call_data = [
                     {

--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -123,7 +123,9 @@ class QwenLLM(LLM[R]):
             Parsed response with actions, or None if parsing fails.
         """
         try:
-            logging.info(f"Qwen LLM input: {prompt}")
+            logging.info(f"Qwen input: {prompt}")
+            logging.info(f"Qwen messages: {messages}")
+
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
 
@@ -160,6 +162,9 @@ class QwenLLM(LLM[R]):
                 tool_calls = _parse_qwen_tool_calls(message.content)
 
             if tool_calls:
+                logging.info(f"Received {len(tool_calls)} function calls")
+                logging.info(f"Function calls: {tool_calls}")
+
                 function_call_data = [
                     {
                         "function": {


### PR DESCRIPTION
This pull request improves logging for both the OpenAI and Qwen LLM plugins to provide better visibility into the prompts, messages, and function calls being processed. The changes make it easier to debug and trace LLM interactions.

Logging enhancements for LLM plugins:

* Added detailed logging of input prompts and messages before sending requests in both `openai_llm.py` and `qwen_llm.py`. [[1]](diffhunk://#diff-22a5072ccf9095ac61ecd5c4dae49f5dea1866b1f3886d1a0bf3e2a0e3c2c18fR87-R89) [[2]](diffhunk://#diff-1da9870ddc90d8577a382e0e618e2d6d0a66ab1bcace29a1847cb6e3d8ef87dcL126-R128)
* Added logging of the number and content of function calls received in responses for both plugins. [[1]](diffhunk://#diff-22a5072ccf9095ac61ecd5c4dae49f5dea1866b1f3886d1a0bf3e2a0e3c2c18fR111-R112) [[2]](diffhunk://#diff-1da9870ddc90d8577a382e0e618e2d6d0a66ab1bcace29a1847cb6e3d8ef87dcR165-R167)
