### PR TITLE
docs: Add detailed docstrings to modes and list_configs in cli.py

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -14,11 +14,22 @@ app = typer.Typer()
 @app.command()
 def modes(config_name: str) -> None:
     """
-    Show information about available modes in a mode-aware configuration.
+    Show detailed information about available modes, transition rules,
+    and settings within a specified mode-aware configuration file.
+
+    This command is crucial for debugging and understanding the current
+    state of the multi-mode system configuration.
 
     Parameters
     ----------
     config_name : str
+        The name of the configuration file (e.g., 'example' for 'example.json5')
+        located in the '../config' directory.
+
+    Raises
+    ------
+    typer.Exit(1)
+        If the configuration file is not found or fails to load.
     """
     try:
         mode_config = load_mode_config(config_name)
@@ -82,7 +93,11 @@ def modes(config_name: str) -> None:
 @app.command()
 def list_configs() -> None:
     """
-    List all available configuration files.
+    List all available configuration files found in the '../config' directory.
+
+    It categorizes the files into 'Mode-Aware Configurations' (those containing
+    'modes' and 'default_mode' keys) and 'Standard Configurations' (all others).
+    This helps the user quickly identify configurations for the multi-mode runtime.
     """
     config_dir = os.path.join(os.path.dirname(__file__), "../config")
 


### PR DESCRIPTION
## Overview

I added detailed Docstrings to the `modes` and `list_configs` functions in `src/cli.py`.

## Changes

* **`modes` function:** Enhanced the Docstring to clearly explain its purpose (showing mode details, transition rules) and added the `Parameters` and `Raises` sections for better command-line documentation.
* **`list_configs` function:** Expanded the Docstring to describe how it categorizes configuration files into "Mode-Aware" and "Standard" types.

## Impact

This improves code readability and maintainability, helping users and developers better understand the CLI command usage and configuration structure.

## Additional Information

This is my third contribution to the project. My previous Pull Request (#808), which also focused on documentation, is currently pending review.

This PR is a continuation of my effort to improve the project's documentation quality, focusing specifically on adding detailed Docstrings for better function clarity in the CLI module.