### PR TITLE
Bump latest runtime version to v1.0.1

### DIFF
--- a/src/runtime/version.py
+++ b/src/runtime/version.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-latest_runtime_version = "v1.0.0"
+latest_runtime_version = "v1.0.1"
 
 
 def get_runtime_version() -> str:


### PR DESCRIPTION
This pull request updates the `latest_runtime_version` in the `src/runtime/version.py` file to reflect a new runtime release.

- Versioning update:
  * Updated `latest_runtime_version` from `"v1.0.0"` to `"v1.0.1"` in `src/runtime/version.py`.