### PR TITLE
fix: correct typo in simple_paths.py (lattency -> latency)

### DIFF
--- a/system_hw_test/simple_paths.py
+++ b/system_hw_test/simple_paths.py
@@ -23,8 +23,8 @@ class SimplePaths:
                 paths_msg.header.stamp.sec + paths_msg.header.stamp.nanosec * 1e-9
             )
             current_time = time.time()
-            lattency = current_time - msg_time
-            logging.debug(f"Received paths with latency: {lattency:.6f} seconds")
+            latency = current_time - msg_time
+            logging.debug(f"Received paths with latency: {latency:.6f} seconds")
             logging.debug(f"Received paths: {paths_msg.paths}")
         except Exception as e:
             logging.error(f"Error processing paths: {e}")


### PR DESCRIPTION
Fixed a typo in the variable name 'lattency' to the correct spelling 'latency'  in system_hw_test/simple_paths.py.

The variable is used to calculate the network latency between the message  timestamp and the current time. This fix ensures consistency with the same  calculation pattern used in src/providers/simple_paths_provider.py, which  uses the correct spelling.

Changes:
- Changed variable name from 'lattency' to 'latency' on line 26
- Updated the logging statement to use the corrected variable name on line 27

## Overview
[Provide a brief overview of the changes in this pull request.]

## Changes
[Detail the changes you have made in this pull request. Include any new features, bug fixes, or improvements.]

## Testing
[Describe the testing you have done to verify your changes. Include any relevant details about the test environment and the results of your tests.]

## Impact
[Explain the impact of your changes. Include any potential risks or side effects that reviewers should be aware of.]

## Additional Information
[Include any additional information that may be relevant to reviewers. This could include links to related issues or pull requests, references to documentation, or other context that may help reviewers understand your changes.]
