### PR TITLE
fix: correct multiple typos in documentation and code

### DIFF
--- a/docs/developer_cookbook/config.mdx
+++ b/docs/developer_cookbook/config.mdx
@@ -150,7 +150,7 @@ You can configure any subset of the available five modes, just two, or all five,
 
     #### **implementation** *string* — Optional
 
-    This defines the business logic, if any. If there's none defined, we use default value `passthough`.
+    This defines the business logic, if any. If there's none defined, we use default value `passthrough`.
 
     **Example: "passthrough"**
 

--- a/docs/full_autonomy_guidelines/brainpack_introduction.mdx
+++ b/docs/full_autonomy_guidelines/brainpack_introduction.mdx
@@ -8,8 +8,8 @@ description: "Introduction to the BrainPack"
 - From research to real-world autonomy, the **OM1 BrainPack** is a plug-and-play module that brings full autonomy to your robots.
 - It is designed to be mounted directly onto a robot to bring together mapping, object recognition, remote control, and self charging, giving humanoids and quadrupeds what they need to navigate, remember, and act with purpose.
 - The BrainPack makes your robot smarter — a system that **learns, moves, and builds with you.**
-- These BrainPacks provide Nvidia Thor to Unitree dogs and humanoids. Each of them comes with on open reference design, speakers, and connectivity to other sensors via Ethernet and USB, with multiple power options.
-- The BrainPack supports modern and future Nvidia hardware(Nvidia Thor) and software (JetPack 7.05), current and future versions of ROS2, and is robot agnositc to control different form factors.
+- These BrainPacks provide NVIDIA Thor to Unitree dogs and humanoids. Each of them comes with on open reference design, speakers, and connectivity to other sensors via Ethernet and USB, with multiple power options.
+- The BrainPack supports modern and future NVIDIA hardware(NVIDIA Thor) and software (JetPack 7.05), current and future versions of ROS2, and is robot agnostic to control different form factors.
 
 ![Architecture Diagram](../assets/brainpack.png)
 ![Architecture Diagram](../assets/brainpack_2.png)

--- a/mintlify/developer_cookbook/config.mdx
+++ b/mintlify/developer_cookbook/config.mdx
@@ -150,7 +150,7 @@ You can configure any subset of the available five modes, just two, or all five,
 
     #### **implementation** *string* — Optional
 
-    This defines the business logic, if any. If there's none defined, we use default value `passthough`.
+    This defines the business logic, if any. If there's none defined, we use default value `passthrough`.
 
     **Example: "passthrough"**
 

--- a/mintlify/full_autonomy_guidelines/brainpack_introduction.mdx
+++ b/mintlify/full_autonomy_guidelines/brainpack_introduction.mdx
@@ -8,8 +8,8 @@ description: "Introduction to the BrainPack"
 - From research to real-world autonomy, the **OM1 BrainPack** is a plug-and-play module that brings full autonomy to your robots.
 - It is designed to be mounted directly onto a robot to bring together mapping, object recognition, remote control, and self charging, giving humanoids and quadrupeds what they need to navigate, remember, and act with purpose.
 - The BrainPack makes your robot smarter — a system that **learns, moves, and builds with you.**
-- These BrainPacks provide Nvidia Thor to Unitree dogs and humanoids. Each of them comes with on open reference design, speakers, and connectivity to other sensors via Ethernet and USB, with multiple power options.
-- The BrainPack supports modern and future Nvidia hardware(Nvidia Thor) and software (JetPack 7.05), current and future versions of ROS2, and is robot agnositc to control different form factors.
+- These BrainPacks provide NVIDIA Thor to Unitree dogs and humanoids. Each of them comes with on open reference design, speakers, and connectivity to other sensors via Ethernet and USB, with multiple power options.
+- The BrainPack supports modern and future NVIDIA hardware(NVIDIA Thor) and software (JetPack 7.05), current and future versions of ROS2, and is robot agnostic to control different form factors.
 
 ![Architecture Diagram](../assets/brainpack.png)
 ![Architecture Diagram](../assets/brainpack_2.png)

--- a/src/actions/move_game_controller/connector/go2_game_controller.py
+++ b/src/actions/move_game_controller/connector/go2_game_controller.py
@@ -349,7 +349,7 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
         # special case for no data if the D-pad or LT and RT is kept pressed
         if data is None or len(data) == 0:
             if self.rt_previous > 0 or self.lt_previous > 0:
-                # we always excute the left turn first
+                # we always execute the left turn first
                 if self.lt_previous > 0:
                     logging.info(
                         "Left Trigger is kept pressed - Counter-clockwise rotation"

--- a/src/inputs/plugins/serial_reader.py
+++ b/src/inputs/plugins/serial_reader.py
@@ -86,7 +86,7 @@ class SerialReader(FuserInput[SensorConfig, Optional[str]]):
 
     async def _raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
         """
-        Process raw string to higer level text description.
+        Process raw string to higher level text description.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixed some typos I noticed while reading through the docs and code:

- passthough -> passthrough in config documentation
- agnositc -> agnostic in brainpack documentation
- excute -> execute in game controller connector
- higer -> higher in serial reader plugin
