### PR TITLE
docs: polish introduction and normalize terminology

### DIFF
--- a/mintlify/developing/0_introduction.mdx
+++ b/mintlify/developing/0_introduction.mdx
@@ -2,13 +2,15 @@
 title: Introduction
 description: "OpenMind builds open-source software that helps machines think, learn, and collaborate"
 ---
+
 ![Logo](../assets/openmind-intro-cover.png)
+
 
 ## What is OM1?
 
-OM1 allows AI agents to be configured and deployed in both the digital and physical worlds. You can create *one* AI persona and run it in the cloud but also on physical robot hardware such as Quadrupeds, TurtleBot 4, and Humanoids.
+OM1 allows AI agents to be configured and deployed in both the digital and physical worlds. You can create *one* AI persona and run it in the cloud but also on physical robot hardware such as quadrupeds, TurtleBot 4, and humanoids.
 
-With OM1, you can interact with OpenAI's `gpt-4o` (or Gemini, Claude, or DeepSeek) and shake hands with it, mediated by physical robot hardware controlled by one or more LLMs. Agents/robots built on OM1 can ingest data from multiple sources (the web, X/Twitter, cameras, and LIDAR) and can then tweet, explore your house, and help your kids with their math homework.
+With OM1, you can interact with OpenAI's `gpt-4o` (or Gemini, Claude, or DeepSeek) and shake hands with it, mediated by physical robot hardware controlled by one or more LLMs. Agents/robots built on OM1 can ingest data from multiple sources (the web, X (Twitter), cameras, and LiDAR) and can then tweet, explore your house, and help your kids with their math homework.
 
 Since it's open source, *you* have control and can optimize the system for your home or workplace.
 
@@ -24,9 +26,9 @@ Whether you're just getting started with OM1 or looking to optimize an existing 
 | All Python                               | Independent modules that are easy to maintain, debug, and extend.              |
 | Easy to add new data inputs              | Seamlessly integrate new data without major changes to the existing architecture. |
 | Easy to support new hardware             | Via plugins for API endpoints and specific robot hardware.                      |
-| Supports Standard Middleware                      | `ROS2`, `Zenoh`, and `CycloneDDS`                                               |
+| Supports standard middleware             | `ROS2`, `Zenoh`, and `CycloneDDS`                                             |
 | Includes a simple web-based debug display| Watch the system work (`WebSim` at [http://localhost:8000](http://localhost:8000)). |
-| Preconfigured endpoints                  | Voice-to-Speech, OpenAI's `gpt-4o`, DeepSeek, and multiple VLMs.                |
+| Preconfigured endpoints                  | Text-to-Speech, OpenAI's `gpt-4o`, DeepSeek, and multiple VLMs.                |
 
 ## CLI
 
@@ -69,4 +71,4 @@ To unit test the system, run:
 uv run pytest --log-cli-level=DEBUG -s
 ```
 
-Use type `hints` and `docstrings` for better code maintainability.
+Use type hints and docstrings for better code maintainability.


### PR DESCRIPTION
## Overview
Polishes the OM1 introduction documentation for clarity and consistency.
Normalizes line endings and standardizes terminology across the document.

## Changes
- Fixes CRLF → LF line endings
- Standardizes terminology (ROS2, Text-to-Speech)
- Minor wording and casing improvements

## Testing
Documentation-only change. No runtime or build impact.

## Impact
No functional impact. Improves readability and consistency of developer documentation.

## Additional Information
None.
