### PR TITLE
fix: log naming consistency for SimplePathsProvider

### DIFF
--- a/src/providers/simple_paths_provider.py
+++ b/src/providers/simple_paths_provider.py
@@ -60,7 +60,7 @@ def simple_paths_processor(
     try:
         session = open_zenoh_session()
         session.declare_subscriber("om/paths", paths_callback)
-        logging.info("Zenoh is open for SimplePathProvider")
+        logging.info("Zenoh is open for SimplePathsProvider")
     except Exception as e:
         logging.error(f"Failed to open Zenoh session: {e}")
 


### PR DESCRIPTION
The logger uses SimplePathProvider (singular), but the class is SimplePathsProvider (plural). This causes logs to be missed when filtering by class name. Fixed the string to ensure all logs are captured during debugging.


Old: logging.info(`"Zenoh is open for SimplePathProvider"`)
New: logging.info(`"Zenoh is open for SimplePathsProvider"`)