### PR TITLE
fix: correct Zenoh message type from Paths to Path

### DIFF
--- a/src/providers/simple_paths_provider.py
+++ b/src/providers/simple_paths_provider.py
@@ -39,7 +39,7 @@ def simple_paths_processor(
         msg: zenoh.Sample
             The message containing paths data.
         """
-        paths = sensor_msgs.Paths.deserialize(msg.payload.to_bytes())
+        paths = sensor_msgs.Path.deserialize(msg.payload.to_bytes())
         msg_time = paths.header.stamp.sec + paths.header.stamp.nanosec * 1e-9
         current_time = time.time()
         latency = current_time - msg_time


### PR DESCRIPTION
I found a critical typo in ``src/providers/simple_paths_provider.py`` on the line handling Zenoh message deserialize . The code currently calls sensor_msgs.Paths.deserialize, but the correct message type is sensor_msgs.Path.
This is a "stoppage" bug that causes an immediate crash when data is received. I have updated it to the singular form to match the zenoh_msgs specification.


File and Line Location
File: ``src/providers/simple_paths_provider.py``
The Change:
Old: paths = ``sensor_msgs.Paths.deserialize(msg.payload.to_bytes())``
New: paths = ``sensor_msgs.Path.deserialize(msg.payload.to_bytes())``