### PR TITLE
test: Add comprehensive unit tests for QwenLLM plugin

### DIFF
--- a/tests/llm/plugins/test_qwen_llm.py
+++ b/tests/llm/plugins/test_qwen_llm.py
@@ -1,12 +1,3 @@
-"""Unit tests for QwenLLM plugin.
-
-Tests cover:
-- Tool call parsing from Qwen-style XML blocks
-- LLM initialization and configuration
-- API request handling and response parsing
-- Error handling scenarios
-"""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,11 +10,6 @@ from llm.plugins.qwen_llm import QwenLLM, _parse_qwen_tool_calls
 
 class DummyOutputModel(BaseModel):
     test_field: str
-
-
-# =============================================================================
-# Tests for _parse_qwen_tool_calls helper function
-# =============================================================================
 
 
 class TestParseQwenToolCalls:
@@ -131,11 +117,6 @@ class TestParseQwenToolCalls:
         assert len(ids) == len(set(ids)), "Tool call IDs should be unique"
 
 
-# =============================================================================
-# Fixtures
-# =============================================================================
-
-
 @pytest.fixture
 def config():
     """Fixture providing a basic LLM configuration."""
@@ -226,11 +207,6 @@ def llm(config):
     return QwenLLM(config, available_actions=None)
 
 
-# =============================================================================
-# Tests for QwenLLM class
-# =============================================================================
-
-
 class TestQwenLLMInit:
     """Tests for QwenLLM initialization."""
 
@@ -243,6 +219,7 @@ class TestQwenLLMInit:
         """Test default model is set when not provided."""
         config = LLMConfig()
         llm = QwenLLM(config, available_actions=None)
+        assert llm._config.model is not None
         assert "Qwen" in llm._config.model
 
     def test_init_extra_body_config(self, llm):


### PR DESCRIPTION
## Summary
  - Add 25 unit tests for QwenLLM plugin to improve test coverage
  - Tests cover `_parse_qwen_tool_calls()` helper function edge cases
  - Tests cover QwenLLM initialization and `ask()` method behavior

  ## Changes
  - New file: `tests/llm/plugins/test_qwen_llm.py`

  ## Test Categories

  ### `TestParseQwenToolCalls` (12 tests)
  - Single/multiple tool call parsing
  - Edge cases: empty string, invalid JSON, missing fields
  - Unicode character support
  - Unique ID generation

  ### `TestQwenLLMInit` (5 tests)
  - Default model configuration
  - Placeholder API key for local server
  - Extra body configuration (thinking mode)

  ### `TestQwenLLMAsk` (8 tests)
  - Native and XML-style tool call handling
  - Error handling and API exceptions
  - IO provider timing metrics
  - Function schema inclusion

  ## Test plan
  - [x] `uv run pytest tests/llm/plugins/test_qwen_llm.py -v` - All 25 tests pass
  - [x] `uv run pre-commit run --all-files` - All checks pass
  - [x] All existing LLM tests still pass (83/83)