### PR TITLE
docs: fix typos and documentation inconsistencies in GalleryIdentitiesProvider

### DIFF
--- a/src/providers/gallery_identities_provider.py
+++ b/src/providers/gallery_identities_provider.py
@@ -92,7 +92,7 @@ class GalleryIdentitiesProvider:
 
     def register_message_callback(self, fn: Callable[[str], None]) -> None:
         """
-        Subscribe a consumer to receive each emitted galleryidentities line.
+        Subscribe a consumer to receive each emitted gallery identities line.
 
         Parameters
         ----------
@@ -129,7 +129,7 @@ class GalleryIdentitiesProvider:
         self._thread.start()
 
     def stop(self, *, wait: bool = False) -> None:
-        """Request the background thread to strop"""
+        """Request the background thread to stop"""
         self._stop.set()
         if wait and self._thread:
             self._thread.join(timeout=3.0)


### PR DESCRIPTION
This PR addresses minor typographical and naming inconsistencies within the `GalleryIdentitiesProvider` documentation to maintain professional standards and ensure the codebase is easily searchable.

The change i made : 

Typo Correction: In the `stop` method docstring (Line 132), the word  "strop" has been corrected to "stop".
Naming Unification: In the `register_message_callback` docstring (Line 95), "galleryidentities" was updated to "gallery identities" to remain consistent with the naming used throughout the rest of the documentation.