### PR TITLE
Fix docstring indentation in DualLLM class

### DIFF
--- a/src/llm/plugins/dual_llm.py
+++ b/src/llm/plugins/dual_llm.py
@@ -84,12 +84,13 @@ class DualLLM(LLM[R]):
                 "cloud_llm_config": {"model": "gpt-4.1"}
             }
         }
-        Parameters
-        ----------
-        config : LLMConfig, optional
-            Configuration settings for the LLM.
-        available_actions : list[AgentAction], optional
-            List of available actions for function calling.
+
+    Parameters
+    ----------
+    config : LLMConfig, optional
+        Configuration settings for the LLM.
+    available_actions : list[AgentAction], optional
+        List of available actions for function calling.
     """
 
     TIMEOUT_THRESHOLD = 3.2


### PR DESCRIPTION
Corrected the indentation of the Parameters section in the DualLLM class docstring to improve readability and maintain consistency with docstring formatting standards.
