### PR TITLE
feat: fixed conversation.json5

### DIFF
--- a/config/conversation.json5
+++ b/config/conversation.json5
@@ -7,12 +7,7 @@
   "system_governance": "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
   "system_prompt_examples": "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'sentence': 'Hello, let\\'s shake paws!'}}\n    Face: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'sentence': 'Ok, but I like running more'}}\n    Face: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'sentence': 'I\\'m going to go explore the room and meet more people.'}}\n    Face: 'think'",
   "agent_inputs": [
-    {
-      "type": "GoogleASRInput",
-      "config": {
-        "enable_tts_interrupt": true
-      }
-    }
+    
   ],
   "cortex_llm": {
     "type": "OpenAILLM",


### PR DESCRIPTION
## Overview
Audio input fails on WSL/headless due to missing ALSA/mic devices OM1's GoogleASRInput tries to access non-existent hardware, crashing the node.

## Changes
1. Open config/conversation.json5 with nano config/conversation.json5.
2. Locate "agent_inputs" array, typically:
      "agent_inputs": [
     {
       "type": "GoogleASRInput",
       "config": {
         "enable_tts_interrupt": true
       }
     }
   ]
   
3. Delete inner objects, leaving empty: "agent_inputs": [  ].
4. Save/exit nano
5. Restart node runs without audio dependency.

## Testing
- WSL Headless: No more "ALSA device not found" error
- Cloud VM and other VPS: Full uptime, API costs accumulate normally.

## Impact
- Risks: None ASR can be re-added later, no data loss
- Affects only audio module; core OM1 

## Additional Information
Video POC: https://drive.google.com/file/d/1QK_qOZg9Q1hMz9YdqVLt-JoF1Xtkdf5Q/view?usp=sharing
