### PR TITLE
set tts interrupt to false

### DIFF
--- a/config/conversation.json5
+++ b/config/conversation.json5
@@ -10,7 +10,7 @@
     {
       "type": "GoogleASRInput",
       "config": {
-        "enable_tts_interrupt": true
+        "enable_tts_interrupt": false
       }
     }
   ],
@@ -28,7 +28,7 @@
       "implementation": "passthrough",
       "connector": "elevenlabs_tts",
       "config": {
-        "enable_tts_interrupt": true
+        "enable_tts_interrupt": false
       }
     },
     {


### PR DESCRIPTION
This pull request makes a small configuration update to the `config/conversation.json5` file. The main change is disabling the TTS (Text-to-Speech) interrupt feature for both the Google ASR input and the ElevenLabs TTS connector. This means that ongoing TTS playback will no longer be interrupted by user speech or other triggers.

- Disabled TTS interrupt for `GoogleASRInput` by setting `enable_tts_interrupt` to `false` in its configuration.
- Disabled TTS interrupt for the `elevenlabs_tts` connector by setting `enable_tts_interrupt` to `false` in its configuration.