### PR TITLE
docs: add clarifying comments to spot.json5 config parameters

### DIFF
--- a/config/spot.json5
+++ b/config/spot.json5
@@ -1,59 +1,91 @@
 {
+  // Configuration version identifier
   "version": "v1.0.1",
+  // Update frequency in Hz (1 Hz = updates every 1 second, suitable for real-time robot control)
   "hertz": 1,
+  // Agent configuration name identifier
   "name": "spot_speak",
+  // API Key for authentication (use "openmind_free" for free tier, or get your key from https://openmind.ai)
   "api_key": "openmind_free",
+  // Robot IP address for direct connection (leave empty "" to use default or auto-discovery)
   "robot_ip": "",
+  // Core personality and behavior prompt that defines the agent's character and interaction style
   "system_prompt_base": "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+  // Safety constraints and governance rules (Asimov's Three Laws of Robotics)
   "system_governance": "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  // Example interactions to guide the LLM's response patterns
   "system_prompt_examples": "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'Hello, let\\'s shake paws!'}}\n    Emotion: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'Ok, but I like running more'}}\n    Emotion: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'I\\'m going to go explore the room and meet more people.'}}\n    Emotion: 'think'",
+  // Input sources: sensors, cameras, microphones, or other data streams that feed into the agent
   "agent_inputs": [
     {
+      // Ethereum governance input for blockchain-based decision making
       "type": "GovernanceEthereum"
     },
     {
+      // Local Vision-Language Model using COCO dataset for object detection
       "type": "VLM_COCO_Local",
       "config": {
+        // Camera device index (0 = first camera, 1 = second camera, etc.)
         "camera_index": 0
       }
     }
   ],
+  // Simulator configuration for testing and visualization (optional)
   "simulators": [
     {
+      // Web-based simulator for browser visualization
       "type": "WebSim",
       "config": {
+        // Network host address (0.0.0.0 = listen on all interfaces)
         "host": "0.0.0.0",
+        // Network port for simulator web interface
         "port": 8000,
+        // Simulation update rate in Hz (100 Hz = 100 updates per second)
         "tick_rate": 100,
+        // Automatically reconnect if connection is lost
         "auto_reconnect": true,
+        // Enable debug logging for troubleshooting
         "debug_mode": false
       }
     }
   ],
+  // Large Language Model configuration for the agent's "brain"
   "cortex_llm": {
+    // LLM provider type (OpenAILLM, DeepSeekLLM, etc.)
     "type": "OpenAILLM",
     "config": {
+      // Agent's name used in conversation context
       "agent_name": "Spot",
+      // Number of previous conversation turns to keep in memory (affects token usage and context)
       "history_length": 3
     }
   },
+  // Actions the agent can execute (movements, speech, expressions, etc.)
   "agent_actions": [
     {
+      // Internal action name (used in code)
       "name": "move",
+      // Label shown to LLM (what the LLM sees when deciding actions)
       "llm_label": "move",
+      // Implementation mode: "passthrough" = LLM output directly passed to connector
       "implementation": "passthrough",
+      // Connector type: ROS2 for robot control commands
       "connector": "ros2"
     },
     {
+      // Speech action: converts text to speech
       "name": "speak",
       "llm_label": "speak",
       "implementation": "passthrough",
+      // ROS2 connector for speech output
       "connector": "ros2"
     },
     {
+      // Facial expression/emotion display action
       "name": "face",
       "llm_label": "emotion",
       "implementation": "passthrough",
+      // ROS2 connector for emotion/face control
       "connector": "ros2"
     }
   ]


### PR DESCRIPTION
## Overview
Added detailed comments to `config/spot.json5` config parameters to improve developer experience and readability.

## Changes
- Added explanatory comments for 32 lines in `config/spot.json5`.
- Clarified key parameters including:
  - `version` & `hertz` (frequency requirements)
  - `robot_ip` (direct connection setup)
  - `agent_inputs` & `agent_actions` (governance and capabilities)
  - `simulators` (WebSim debugging options)

## Type of change
- [x] Documentation improvement

## Checklist
- [x] Code complies with style guidelines
- [x] Documentation updated