### PR TITLE
Format pre-commit command as code block in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,11 @@ Before contributing, please take a moment to read through the following guidelin
 
 7. **Local Testing**
 
-    Install pre-commit and execute `pre-commit install`. This ensures that pre-commit checks run before each commit. Alternatively, you can manually trigger all checks by running pre-commit run --all-files.
+    Install pre-commit and execute `pre-commit install`. This ensures that pre-commit checks run before each commit. Alternatively, you can manually trigger all checks by running
+
+    ```bash
+    pre-commit run --all-files
+    ```
 
     After you have updated the core documentation, make sure to run:
     ```bash


### PR DESCRIPTION
The pre-commit run command in CONTRIBUTING.md is now displayed as a bash code block for improved readability and clarity.
