### PR TITLE
fix(llm): correct NearAI plugin docstring and logging

### DIFF
--- a/src/llm/plugins/near_ai_llm.py
+++ b/src/llm/plugins/near_ai_llm.py
@@ -16,9 +16,9 @@ R = T.TypeVar("R", bound=BaseModel)
 
 class NearAILLM(LLM[R]):
     """
-    An NearAI-based Language Learning Model implementation.
+    A NearAI-based Large Language Model implementation.
 
-    This class implements the LLM interface for Near AI's open-source models, handling
+    This class implements the LLM interface for NearAI's open-source models, handling
     configuration, authentication, and async API communication.
 
     Parameters
@@ -122,7 +122,7 @@ class NearAILLM(LLM[R]):
                 actions = convert_function_calls_to_actions(function_call_data)
 
                 result = CortexOutputModel(actions=actions)
-                logging.info(f"OpenAI LLM function call output: {result}")
+                logging.info(f"NearAI LLM function call output: {result}")
                 return T.cast(R, result)
 
             return None


### PR DESCRIPTION
## Summary
Fixes documentation and logging inconsistencies in the NearAI LLM plugin that could confuse developers during debugging.

## Changes Made
1. **Docstring Improvements** (lines 19-21):
   - Grammar: "An NearAI" → "A NearAI"
   - Terminology: "Language Learning Model" → "Large Language Model"
   - Branding: "Near AI" → "NearAI" (consistent with class name)

2. **Log Message Correction** (line 125):
   - Fixed copy-paste error: "OpenAI LLM" → "NearAI LLM"
   - This log appears when function calls are processed

## Why This Matters
- **Debugging Clarity**: The incorrect log message ("OpenAI LLM") in NearAI plugin could mislead developers troubleshooting multi-provider setups
- **Professional Documentation**: "Large Language Model" is the correct industry term
- **Code Consistency**: Aligns branding (NearAI) throughout the codebase

## Testing
- [x] Documentation-only changes
- [x] No functional behavior modified
- [x] Code compiles without errors
- [x] Log output verified (manual inspection)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] No new dependencies added

## Related Issues
Fixes potential confusion when debugging LLM provider selection.