### PR TITLE
docs: Add missing tutorial pages to navigation

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -49,7 +49,9 @@
                         "pages": [
                             "examples/overview",
                             "examples/conversation",
-                            "examples/gazebo"
+                            "examples/gazebo",
+                            "examples/smart_toy",
+                            "examples/llm_models"
                         ]
                     },
                     {


### PR DESCRIPTION
## Summary
Added missing tutorial pages to the documentation navigation menu.

## Problem
The following documentation files exist in the repository but are not accessible via the navigation menu, making them undiscoverable by users:

- `docs/examples/smart_toy.mdx` - Smart Toy tutorial (Cubly example)
- `docs/examples/llm_models.mdx` - LLM Models tutorial (DeepSeek, Gemini, Grok examples)

## Changes
Updated `mintlify/docs.json` to include these pages in the **Tutorials** navigation group.

```diff
"group": "Tutorials",
"pages": [
    "examples/overview",
    "examples/conversation",
    "examples/gazebo",
+   "examples/smart_toy",
+   "examples/llm_models"
]
```

## Test Plan
- [ ] Verify documentation builds correctly
- [ ] Confirm new pages are accessible in Tutorials navigation