### PR TITLE
Hot-reload runtime config based on changed fields in CortexRuntime

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,106 @@
+import threading
+from typing import Any, Callable, Dict
+
+import json5
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+def _diff_dict(old: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Return a dict containing only keys whose values changed.
+    Nested dicts are diffed recursively.
+    """
+    patch: Dict[str, Any] = {}
+
+    for key, new_value in new.items():
+        if key not in old:
+            patch[key] = new_value
+            continue
+
+        old_value = old[key]
+
+        if isinstance(old_value, dict) and isinstance(new_value, dict):
+            sub = _diff_dict(old_value, new_value)
+            if sub:
+                patch[key] = sub
+        else:
+            if old_value != new_value:
+                patch[key] = new_value
+
+    return patch
+
+
+class _ConfigFileHandler(FileSystemEventHandler):
+    def __init__(
+        self,
+        path: str,
+        load_fn: Callable[[], Dict[str, Any]],
+        on_patch: Callable[[Dict[str, Any]], None],
+    ) -> None:
+        self._path = path
+        self._load_fn = load_fn
+        self._on_patch = on_patch
+        self._last_config = load_fn()
+
+    def on_modified(self, event) -> None:
+        if event.src_path != self._path:
+            return
+
+        try:
+            new_config = self._load_fn()
+        except Exception:
+            # ignore transient / partial writes
+            return
+
+        patch = _diff_dict(self._last_config, new_config)
+        if patch:
+            self._last_config = new_config
+            self._on_patch(patch)
+
+
+class ConfigManager:
+    """
+    Watches a JSON5 config file and emits patches on change.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        on_patch: Callable[[Dict[str, Any]], None],
+        poll_interval: float = 0.25,
+    ) -> None:
+        self._path = path
+        self._on_patch = on_patch
+        self._poll_interval = poll_interval
+        self._observer: Observer | None = None
+
+    def _load(self) -> Dict[str, Any]:
+        with open(self._path, "r", encoding="utf-8") as f:
+            return json5.load(f)
+
+    def start(self) -> None:
+        if self._observer is not None:
+            return
+
+        handler = _ConfigFileHandler(
+            path=self._path,
+            load_fn=self._load,
+            on_patch=self._on_patch,
+        )
+
+        observer = Observer(timeout=self._poll_interval)
+        watch_dir = self._path.rsplit("/", 1)[0]
+        observer.schedule(handler, path=watch_dir, recursive=False)
+        observer.start()
+
+        self._observer = observer
+
+    def stop(self) -> None:
+        if self._observer is None:
+            return
+
+        self._observer.stop()
+        self._observer.join()
+        self._observer = None
+	

--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -15,6 +15,7 @@ from providers.sleep_ticker_provider import SleepTickerProvider
 from runtime.single_mode.config import RuntimeConfig, load_config
 from simulators.orchestrator import SimulatorOrchestrator
 
+from src.config_manager import ConfigManager
 
 class CortexRuntime:
     """
@@ -88,8 +89,37 @@ class CortexRuntime:
             self.config_path = self._create_runtime_config_file()
             self.last_modified = self._get_file_mtime()
             logging.info(
-                f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
+                f"Hot-reload enabled for runtime config: {self.config_path} "
+                f"(check interval: {check_interval}s)"
             )
+
+            self._config_manager = ConfigManager(
+                path=self.config_path,
+                on_patch=self.reload_from_patch,
+            )
+            self._config_manager.start()
+
+    def reload_from_patch(self, patch: dict) -> None:
+        """
+        Reload runtime based on changed config fields.
+        """
+        if not patch:
+            return
+
+        safe_fields = {
+            "system_prompt_base",
+            "system_prompt_examples",
+        }
+
+        if not set(patch.keys()).issubset(safe_fields):
+            asyncio.create_task(self._reload_config())
+            return
+
+        if "system_prompt_base" in patch:
+            self.config.system_prompt_base = patch["system_prompt_base"]
+
+        if "system_prompt_examples" in patch:
+            self.config.system_prompt_examples = patch["system_prompt_examples"]
 
     def _get_runtime_config_path(self) -> str:
         """


### PR DESCRIPTION
This PR supersedes the previously closed hot-reload attempt (#1031) and directly
addresses the maintainer feedback on issue #984.

The key requirement was that reload decisions must live in
`src/runtime/single_mode/cortex.py`, and be made explicitly based on the set of
changed configuration fields.

This implementation introduces a minimal runtime-level API:

- Config changes are diffed into a field-level patch
- The patch is passed to `CortexRuntime.reload_from_patch(...)`
- `CortexRuntime` decides whether:
  - the change is safe for in-place reload (e.g. system_prompt_base, system_prompt_examples), or
  - a full reload is required (fallback to existing reload_config)

The config watcher is intentionally kept generic and does not make reload decisions.
All partial vs full reload logic is owned by `CortexRuntime`, as requested.

Key properties:
- Explicit ownership in cortex.py
- Field-based reload decisions
- Backward-compatible full reload fallback
- Clean history: one commit, two files, no unrelated changes

This directly implements the requested solution:
“a solution where src/runtime/single_mode/cortex.py can reload based on the changed fields”.
