### PR TITLE
ci(turtlebot): free disk space to prevent docker build failures

### DIFF
--- a/.github/workflows/turtlebot-bridge.yml
+++ b/.github/workflows/turtlebot-bridge.yml
@@ -15,6 +15,15 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium /usr/local/lib/node_modules
+          sudo docker system prune -af
+          sudo apt-get clean
+          df -h
+
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Overview
This PR improves CI robustness for the Turtlebot bridge workflow by preventing
disk exhaustion during multi-platform Docker builds.

The release workflow already includes a disk cleanup step, but the
turtlebot-bridge workflow did not, which can lead to
"No space left on device" failures on GitHub-hosted runners.

## Changes
- Added a "Free disk space" step to `.github/workflows/turtlebot-bridge.yml`
- Aligns the workflow setup with the proven configuration in `release.yml`

## Testing
- Verified YAML syntax
- Change mirrors an existing, stable pattern used in the release pipeline

## Impact
- Reduces CI flakiness caused by limited runner disk space
- No impact on runtime behavior or Docker image contents

## Additional Information
This is a CI-only change with no effect on application logic or deployment artifacts.
