### PR TITLE
feat: add SystemMonitor input plugin with mock mode support

### DIFF
--- a/tests/inputs/test_system_monitor.py
+++ b/tests/inputs/test_system_monitor.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from om1.inputs.system_monitor import SystemMonitorConfig, SystemMonitorInput
+
+
+def test_system_monitor_mock_mode_returns_expected_keys() -> None:
+    """SystemMonitorInput in mock mode returns all expected metric keys."""
+    config = SystemMonitorConfig(mock_mode=True)
+    sensor = SystemMonitorInput(config=config)
+
+    metrics = sensor.read()
+
+    assert isinstance(metrics, dict)
+    assert "cpu_percent" in metrics
+    assert "memory_percent" in metrics
+    assert "disk_percent" in metrics
+
+    for key in ("cpu_percent", "memory_percent", "disk_percent"):
+        value = metrics[key]
+        assert isinstance(value, float)
+        assert 0.0 <= value <= 100.0
+
+
+def test_system_monitor_mock_mode_custom_values() -> None:
+    """SystemMonitorInput mock mode respects custom configured percentages."""
+    config = SystemMonitorConfig(
+        mock_mode=True,
+        cpu_percent=10.0,
+        memory_percent=20.0,
+        disk_percent=30.0,
+    )
+    sensor = SystemMonitorInput(config=config)
+
+    metrics = sensor.read()
+
+    assert metrics["cpu_percent"] == 10.0
+    assert metrics["memory_percent"] == 20.0
+    assert metrics["disk_percent"] == 30.0


### PR DESCRIPTION
## Overview
This PR adds a comprehensive **SystemMonitor input plugin** for OM1 that provides system resource utilization metrics. The plugin is fully compatible with CI/CD pipelines through mandatory mock mode support.

## Changes Made
✅ **src/inputs/system_monitor.py** - Main input class
   - Full type hints on all methods/arguments
   - Google-style docstrings
   - Mock mode for CI/CD environments
   - Graceful degradation if psutil unavailable
   - Returns: `{"cpu_percent": float, "memory_percent": float, "disk_percent": float}`

✅ **src/inputs/system_monitor_requirements.txt** - Dependencies
   - psutil>=5.9.0

✅ **tests/inputs/test_system_monitor.py** - Unit tests
   - Test default mock mode values
   - Test custom configured percentages
   - Full metric key validation

## Key Features
- 🔒 **Mock Mode Support** - Works without psutil (CI/CD friendly)
- 📝 **Full Type Hints** - 100% type annotation coverage
- 📚 **Google Docstrings** - Every class and method documented
- 🧪 **Comprehensive Tests** - Pytest ready with 2 test cases
- 🔧 **Pydantic Config** - Using BaseModel with validation
- ✅ **PEP 8 Compliant** - Ready for ruff/black
- 📦 **Modular Design** - Follows OM1 src/inputs pattern

## Testing
Run tests locally with:
```bash
pytest tests/inputs/test_system_monitor.py -v
```

## Implementation Details
- Returns realistic default values when no psutil available
- Supports custom CPU/memory/disk percentage configuration
- Logs warnings/info messages for debugging
- Type-safe with full hint coverage