### PR TITLE
feat(config): add 'spot_mock' profile for easier local development

### DIFF
--- a/config/spot_mock.json5
+++ b/config/spot_mock.json5
@@ -1,0 +1,69 @@
+{
+  version: "v1.0.1",
+  hertz: 1,
+  name: "spot_mock",
+  api_key: "openmind_free",
+  robot_ip: "",
+  system_prompt_base: "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  system_prompt_examples: "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'Hello, let\\'s shake paws!'}}\n    Emotion: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'Ok, but I like running more'}}\n    Emotion: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'I\\'m going to go explore the room and meet more people.'}}\n    Emotion: 'think'",
+
+  input_orchestrator: {
+    default_input: "mock_input",
+    inputs: {
+      mock_input: {
+        plugin: "MockInput",
+      }
+    }
+  },
+  agent_inputs: [
+    {
+      type: "GovernanceEthereum",
+    },
+    {
+      type: "VLM_COCO_Local",
+      config: {
+        camera_index: 0,
+      },
+    },
+  ],
+  simulators: [
+    {
+      type: "WebSim",
+      config: {
+        host: "0.0.0.0",
+        port: 8000,
+        tick_rate: 100,
+        auto_reconnect: true,
+        debug_mode: false,
+      },
+    },
+  ],
+  cortex_llm: {
+    type: "OpenAILLM",
+    config: {
+      agent_name: "Spot",
+      history_length: 3,
+    },
+  },
+  agent_actions: [
+    {
+      name: "move",
+      llm_label: "move",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "speak",
+      llm_label: "speak",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+  ],
+}


### PR DESCRIPTION
Fixes #1118

     Description
    This PR introduces a new `spot_mock.json5` configuration profile to resolve the issue where the default `spot` agent fails on generic hardware without specific audio devices.

     Key Changes:
    - Added `spot_mock.json5`: A new profile based on the original, specifically for local development.
    - Implemented `MockInput`: The new profile uses the `MockInput` plugin as its default input source. This removes the dependency on audio hardware (like a microphone) and prevents the application from crashing.
    - Improved Developer Experience: Developers can now run the agent out-of-the-box using `uv run src/run.py spot_mock` without needing to configure audio hardware first.