### PR TITLE
feat(config): Add spot_dev.json5 for hardware-free development

### DIFF
--- a/config/spot_dev.json5
+++ b/config/spot_dev.json5
@@ -1,0 +1,97 @@
+{
+  // Spot Development Configuration
+  // Use this config to test Spot agent without hardware dependencies
+  // - No webcam required (uses DummyVLMLocal)
+  // - No microphone required (uses MockInput via WebSocket)
+  // - No Google Cloud credentials required
+  //
+  // Usage: uv run src/run.py spot_dev
+  //
+  // To send messages to the agent, connect to WebSocket at ws://localhost:8765
+  // Example: websocat ws://localhost:8765
+  // Then type messages and press Enter
+
+  version: "v1.0.1",
+  hertz: 1,
+  name: "spot_dev",
+  api_key: "openmind_free",
+  URID: "default",
+  robot_ip: "",
+
+  system_prompt_base: "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+
+  system_prompt_examples: "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'Hello, let\\'s shake paws!'}}\n    Emotion: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'Ok, but I like running more'}}\n    Emotion: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'I\\'m going to go explore the room and meet more people.'}}\n    Emotion: 'think'",
+
+  agent_inputs: [
+    {
+      // Blockchain governance rules
+      type: "GovernanceEthereum",
+    },
+    {
+      // Mock vision input - generates fake data, no camera needed
+      type: "DummyVLMLocal",
+    },
+    {
+      // Mock text input via WebSocket (ws://localhost:8765)
+      // Use this to simulate speech/text input without microphone
+      type: "MockInput",
+      config: {
+        input_name: "User Speech",
+        host: "localhost",
+        port: 8765,
+      },
+    },
+    {
+      // Reports online status to Portal
+      type: "StatusHeartbeat",
+      config: {
+        machine_name: "Spot Dev Agent",
+      },
+    },
+  ],
+
+  simulators: [
+    {
+      // Web-based visualization at http://localhost:8000
+      type: "WebSim",
+      config: {
+        host: "0.0.0.0",
+        port: 8000,
+        tick_rate: 100,
+        auto_reconnect: true,
+        debug_mode: false,
+      },
+    },
+  ],
+
+  cortex_llm: {
+    type: "OpenAILLM",
+    config: {
+      agent_name: "Spot",
+      history_length: 3,
+    },
+  },
+
+  agent_actions: [
+    {
+      name: "move",
+      llm_label: "move",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "speak",
+      llm_label: "speak",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+  ],
+}


### PR DESCRIPTION
## Summary
Adds a development configuration (`spot_dev.json5`) for Spot agent that works without hardware dependencies.

Fixes #1118

## Changes
- Added `config/spot_dev.json5` with:
  - `DummyVLMLocal` - generates fake vision data (no webcam required)
  - `MockInput` - accepts text via WebSocket on port 8765 (no microphone/ASR required)
  - `StatusHeartbeat` - reports online status to Portal
  - `WebSim` - visualization at localhost:8000

## Features
- No webcam required
- No microphone required
- No Google Cloud credentials needed
- Works on any MacOS/Linux machine

## Usage
```bash
uv run src/run.py spot_dev
```

To send messages to the agent:
```bash
# Install websocat (or use any WebSocket client)
brew install websocat

# Connect and send messages
websocat ws://localhost:8765
> Hello Spot!
```

## Test Plan
- [x] Tested locally - agent starts without hardware errors
- [x] MockInput WebSocket server starts at ws://localhost:8765
- [x] DummyVLMLocal generates fake vision data
- [x] WebSim visualization works at http://localhost:8000
- [x] StatusHeartbeat reports to Portal
