### PR TITLE
docs: add Windows and macOS development setup guide

### DIFF
--- a/docs/development/windows-macos.md
+++ b/docs/development/windows-macos.md
@@ -1,0 +1,119 @@
+🪟 Windows / 🍎 macOS Development Setup Guide for OM1
+
+This guide describes how to set up OpenMind OM1 on Windows and macOS for local development.
+
+🪟 Windows Setup (Tested on Windows 10 / 11)
+
+Recommended: WSL2 (Ubuntu 22.04)
+Native Windows Python is not recommended due to audio & dependency issues.
+
+1️⃣ Install WSL2 (Ubuntu)
+
+Open PowerShell (Admin):
+
+wsl --install
+
+
+Reboot, then install Ubuntu 22.04 from Microsoft Store.
+
+2️⃣ Install system dependencies
+
+Inside WSL Ubuntu:
+
+sudo apt update
+sudo apt install -y \
+  git \
+  python3 \
+  python3-venv \
+  build-essential \
+  portaudio19-dev \
+  ffmpeg
+
+3️⃣ Install uv
+curl -Ls https://astral.sh/uv/install.sh | sh
+source ~/.bashrc
+uv --version
+
+4️⃣ Clone OM1
+git clone https://github.com/OpenMind/OM1.git
+cd OM1
+git submodule update --init
+
+5️⃣ Create virtual environment & install deps
+uv venv
+uv pip install -r requirements.txt
+
+6️⃣ Configure environment variables
+cp env.example .env
+
+
+Edit .env and set your API keys.
+
+7️⃣ Run a sample agent
+uv run src/run.py conversation
+
+⚠️ Windows Notes
+
+Audio input/output requires WSL + PulseAudio
+
+USB microphones may need additional WSL configuration
+
+Native Windows Python is not officially supported
+
+🍎 macOS Setup (Tested on macOS 13+)
+1️⃣ Install Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+2️⃣ Install system dependencies
+brew update
+brew install python ffmpeg portaudio git
+
+3️⃣ Install uv
+curl -Ls https://astral.sh/uv/install.sh | sh
+source ~/.zshrc
+uv --version
+
+4️⃣ Clone OM1
+git clone https://github.com/OpenMind/OM1.git
+cd OM1
+git submodule update --init
+
+5️⃣ Create virtual environment
+uv venv
+uv pip install -r requirements.txt
+
+6️⃣ Configure .env
+cp env.example .env
+
+
+Set required API keys.
+
+7️⃣ Run agent
+uv run src/run.py conversation
+
+🍎 macOS Notes
+
+Grant Microphone Access to Terminal
+
+Apple Silicon (M1/M2/M3) works without Rosetta
+
+If pyaudio fails, ensure portaudio is installed
+
+✅ Common Issues
+❌ ModuleNotFoundError
+uv add <missing_package>
+
+❌ pyaudio build error
+
+Ensure:
+
+portaudio19-dev (Linux)
+brew install portaudio (macOS)
+
+📌 Contribution Status
+
+This guide was tested on:
+
+Windows 11 (WSL2 Ubuntu 22.04)
+
+macOS 13+ (Apple Silicon)


### PR DESCRIPTION
## Overview
This pull request adds a clear development setup guide for running OpenMind OM1 on Windows and macOS.

The goal is to reduce onboarding friction for new contributors by documenting platform-specific dependencies, tooling (`uv`), and common setup issues (audio, Python environment, etc.).

Linked issue: #670

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
- Added a new development guide: `docs/development/windows-macos.md`
- Documented recommended Windows setup using WSL2 (Ubuntu 22.04)
- Added macOS setup instructions (Intel & Apple Silicon)
- Included installation steps for `uv`, `ffmpeg`, `portaudio`, and Python dependencies
- Added notes for common issues such as audio and `pyaudio` build errors

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact
This change improves the contributor experience by providing clear, tested setup instructions for Windows and macOS users.

It lowers the barrier to entry for new developers and helps avoid common environment-related issues.  
There is no impact on runtime logic or existing functionality.

## Additional Information
- Tested on:
  - Windows 11 + WSL2 (Ubuntu 22.04)
  - macOS 13+ (Apple Silicon)
- This PR is documentation-only and does not modify core OM1 code.

