### PR TITLE
perf: clean up mock object setup in tests

### DIFF
--- a/tests/runtime/multi_mode/test_cortex.py
+++ b/tests/runtime/multi_mode/test_cortex.py
@@ -25,12 +25,14 @@ def sample_mode_config():
 def mock_mode_config():
     """Mock mode config for testing."""
     mock_config = Mock(spec=ModeConfig)
-    mock_config.name = "test_mode"
-    mock_config.display_name = "Test Mode"
-    mock_config.description = "A test mode"
-    mock_config.system_prompt_base = "You are a test agent"
-    mock_config.load_components = Mock()
-    mock_config.to_runtime_config = Mock()
+    mock_config.__dict__.update({  # type: ignore
+        "name": "test_mode",
+        "display_name": "Test Mode",
+        "description": "A test mode",
+        "system_prompt_base": "You are a test agent",
+        "load_components": Mock(),
+        "to_runtime_config": Mock(),
+    })
     return mock_config
 
 
@@ -38,12 +40,14 @@ def mock_mode_config():
 def mock_system_config(mock_mode_config):
     """Mock system configuration for testing."""
     config = Mock(spec=ModeSystemConfig)
-    config.name = "test_system"
-    config.default_mode = "default"
-    config.modes = {
-        "default": mock_mode_config,
-        "advanced": mock_mode_config,
-    }
+    config.__dict__.update({  # type: ignore
+        "name": "test_system",
+        "default_mode": "default",
+        "modes": {
+            "default": mock_mode_config,
+            "advanced": mock_mode_config,
+        },
+    })
     return config
 
 
@@ -563,8 +567,10 @@ class TestModeCortexRuntimeHotReload:
             mock_manager_class.return_value = mock_manager
 
             new_mock_config = Mock(spec=ModeSystemConfig)
-            new_mock_config.default_mode = "test_mode"
-            new_mock_config.modes = {"test_mode": Mock()}
+            new_mock_config.__dict__.update({  # type: ignore
+                "default_mode": "test_mode",
+                "modes": {"test_mode": Mock()},
+            })
             mock_load_config.return_value = new_mock_config
 
             runtime = ModeCortexRuntime(
@@ -609,8 +615,10 @@ class TestModeCortexRuntimeHotReload:
             mock_manager_class.return_value = mock_manager
 
             new_mock_config = Mock(spec=ModeSystemConfig)
-            new_mock_config.default_mode = "default_mode"
-            new_mock_config.modes = {"default_mode": Mock()}
+            new_mock_config.__dict__.update({  # type: ignore
+                "default_mode": "default_mode",
+                "modes": {"default_mode": Mock()},
+            })
             mock_load_config.return_value = new_mock_config
 
             runtime = ModeCortexRuntime(

--- a/tests/runtime/multi_mode/test_cortex_mode_transition.py
+++ b/tests/runtime/multi_mode/test_cortex_mode_transition.py
@@ -89,12 +89,14 @@ def sample_transition_rules():
 def mock_system_config(sample_mode_configs, sample_transition_rules):
     """Mock system configuration with proper mode transition setup."""
     config = Mock(spec=ModeSystemConfig)
-    config.name = "test_system"
-    config.default_mode = "default"
-    config.modes = sample_mode_configs
-    config.transition_rules = sample_transition_rules
-    config.allow_manual_switching = True
-    config.execute_global_lifecycle_hooks = AsyncMock(return_value=True)
+    config.__dict__.update({  # type: ignore
+        "name": "test_system",
+        "default_mode": "default",
+        "modes": sample_mode_configs,
+        "transition_rules": sample_transition_rules,
+        "allow_manual_switching": True,
+        "execute_global_lifecycle_hooks": AsyncMock(return_value=True),
+    })
 
     for mode_config in sample_mode_configs.values():
         mode_config.load_components = Mock()

--- a/tests/runtime/single_mode/test_cortex.py
+++ b/tests/runtime/single_mode/test_cortex.py
@@ -12,10 +12,13 @@ from runtime.single_mode.cortex import CortexRuntime
 
 @pytest.fixture
 def mock_config():
-    config = Mock(spec=RuntimeConfig, hertz=10.0)
-    config.name = "test_config"
-    config.cortex_llm = Mock()
-    config.agent_inputs = []
+    config = Mock(spec=RuntimeConfig)
+    config.__dict__.update({
+        "hertz": 10.0,
+        "name": "test_config",
+        "cortex_llm": Mock(),
+        "agent_inputs": [],
+    })
     return config
 
 
@@ -437,7 +440,7 @@ class TestCortexRuntimeHotReload:
             patch("runtime.single_mode.cortex.load_config") as mock_load_config,
         ):
             new_mock_config = Mock(spec=RuntimeConfig)
-            new_mock_config.hertz = 20.0
+            new_mock_config.__dict__.update({"hertz": 20.0})  # type: ignore
             mock_load_config.return_value = new_mock_config
 
             runtime = CortexRuntime(mock_config, "test_config", hot_reload=True)

--- a/tests/simulators/test_orchestrator.py
+++ b/tests/simulators/test_orchestrator.py
@@ -29,7 +29,9 @@ def mock_config():
     config = Mock(spec=RuntimeConfig)
     simulator1 = MockSimulator(config=SimulatorConfig(name="sim1"))
     simulator2 = MockSimulator(config=SimulatorConfig(name="sim2"))
-    config.simulators = [simulator1, simulator2]
+    config.__dict__.update({
+        "simulators": [simulator1, simulator2],
+    })
     return config
 
 


### PR DESCRIPTION
found a few test files using __dict__.update() for setting mock attributes and it seemed like a cleaner approach than doing it one by one. updated similar patterns in runtime and simulator tests to match.

touched 4 test files