### PR TITLE
Fix typo in cli.py docstring

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -782,7 +782,7 @@ def _print_config_summary(raw_config: dict, is_multi_mode: bool):
     raw_config : dict
         Raw configuration dictionary
     is_multi_mode : bool
-        Whether this is is a multi multi-mode configuration
+        Whether this is a multi-mode configuration
     """
     print()
     print("Configuration Summary:")


### PR DESCRIPTION
## Description
This PR fixes a typo in the docstring of the `_print_config_summary` function in `src/cli.py`.

## Changes
- Fixed duplicate words "is" and "multi" in the parameter description
- Changed "Whether this is is a multi multi-mode configuration" to "Whether this is a multi-mode configuration"

## Files Modified
- `src/cli.py`: Line 785 - corrected docstring typo

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation update

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested that my changes work as expected