### PR TITLE
feat(telegram): Add Telegram Bot integration for remote agent control

### DIFF
--- a/config/spot_telegram.json5
+++ b/config/spot_telegram.json5
@@ -1,0 +1,85 @@
+{
+  // Spot Telegram Bot Configuration
+  // Control your Spot agent via Telegram!
+  //
+  // Setup:
+  // 1. Create a bot via @BotFather on Telegram
+  // 2. Copy the bot token to your .env file as TELEGRAM_BOT_TOKEN
+  // 3. Run: uv run src/run.py spot_telegram
+  // 4. Send /start to your bot on Telegram
+  //
+  // Optional: Set TELEGRAM_CHAT_ID in .env to auto-send responses
+
+  version: "v1.0.1",
+  hertz: 1,
+  name: "spot_telegram",
+  api_key: "openmind_free",
+  URID: "default",
+  robot_ip: "",
+
+  system_prompt_base: "You are Spot, a smart and friendly AI assistant available on Telegram. You respond to messages from users with helpful, concise, and friendly replies. Keep responses under 200 characters when possible, as this is a chat interface.",
+
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.",
+
+  system_prompt_examples: "Here are some examples of Telegram interactions:\n\n1. If a user says 'Hello!', you might:\n    Speak: 'Hey there! How can I help you today?'\n    Emotion: 'happy'\n\n2. If a user asks 'What can you do?', you might:\n    Speak: 'I can chat, answer questions, and keep you company! Just send me a message.'\n    Emotion: 'excited'\n\n3. If a user says something you don't understand:\n    Speak: 'Hmm, I'm not sure I follow. Could you rephrase that?'\n    Emotion: 'confused'",
+
+  agent_inputs: [
+    {
+      // Blockchain governance rules
+      type: "GovernanceEthereum",
+    },
+    {
+      // Telegram message input
+      type: "TelegramInput",
+      config: {
+        input_name: "Telegram Message",
+        // bot_token: "your-bot-token-here",  // Or set TELEGRAM_BOT_TOKEN in .env
+        // allowed_users: [123456789],  // Optional: restrict to specific user IDs
+      },
+    },
+    {
+      // Reports online status to Portal
+      type: "StatusHeartbeat",
+      config: {
+        machine_name: "Spot Telegram Bot",
+      },
+    },
+  ],
+
+  simulators: [
+    {
+      // Web-based visualization at http://localhost:8000
+      type: "WebSim",
+      config: {
+        host: "0.0.0.0",
+        port: 8000,
+        tick_rate: 100,
+        auto_reconnect: true,
+        debug_mode: false,
+      },
+    },
+  ],
+
+  cortex_llm: {
+    type: "OpenAILLM",
+    config: {
+      agent_name: "Spot",
+      history_length: 5,  // Keep more history for chat context
+    },
+  },
+
+  agent_actions: [
+    {
+      name: "speak",
+      llm_label: "speak",
+      implementation: "passthrough",
+      connector: "telegram",  // Send responses to Telegram
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      implementation: "passthrough",
+      connector: "ros2",  // Emotions shown in WebSim
+    },
+  ],
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dds = [
     "cyclonedds==0.10.2"
 ]
 macos = ["osascript"]
+telegram = ["python-telegram-bot>=21.0"]
 
 [dependency-groups]
 dev = [

--- a/src/actions/speak/connector/telegram.py
+++ b/src/actions/speak/connector/telegram.py
@@ -1,0 +1,125 @@
+"""
+Telegram Speak Connector - Send agent responses to Telegram.
+
+This connector allows OM1 agents to send responses back to Telegram users.
+It works in conjunction with the TelegramInput plugin.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+from pydantic import Field
+
+from actions.base import ActionConfig, ActionConnector
+from actions.speak.interface import SpeakInput
+
+# Try to import telegram library
+try:
+    from telegram import Bot
+
+    TELEGRAM_AVAILABLE = True
+except ImportError:
+    TELEGRAM_AVAILABLE = False
+
+
+class TelegramSpeakConfig(ActionConfig):
+    """
+    Configuration for Telegram Speak Connector.
+
+    Parameters
+    ----------
+    bot_token : Optional[str]
+        Telegram Bot Token. Falls back to TELEGRAM_BOT_TOKEN env var.
+    default_chat_id : Optional[int]
+        Default chat ID to send messages to.
+    """
+
+    bot_token: Optional[str] = Field(
+        default=None,
+        description="Telegram Bot Token. Falls back to TELEGRAM_BOT_TOKEN env var.",
+    )
+    default_chat_id: Optional[int] = Field(
+        default=None,
+        description="Default Telegram chat ID to send messages to.",
+    )
+
+
+class TelegramSpeakConnector(ActionConnector[TelegramSpeakConfig, SpeakInput]):
+    """
+    A "Speak" connector that sends messages to Telegram.
+
+    This connector sends the agent's spoken responses to Telegram users.
+    """
+
+    def __init__(self, config: TelegramSpeakConfig):
+        """
+        Initialize the Telegram speak connector.
+
+        Parameters
+        ----------
+        config : TelegramSpeakConfig
+            Configuration for the connector.
+        """
+        super().__init__(config)
+
+        if not TELEGRAM_AVAILABLE:
+            raise ImportError(
+                "python-telegram-bot is required. "
+                "Install with: pip install python-telegram-bot"
+            )
+
+        # Get bot token
+        self.bot_token = config.bot_token or os.getenv("TELEGRAM_BOT_TOKEN")
+        if not self.bot_token:
+            raise ValueError(
+                "Telegram bot token not provided. "
+                "Set TELEGRAM_BOT_TOKEN in .env or provide bot_token in config."
+            )
+
+        self.default_chat_id = config.default_chat_id or os.getenv(
+            "TELEGRAM_CHAT_ID", None
+        )
+        if self.default_chat_id:
+            self.default_chat_id = int(self.default_chat_id)
+
+        self.bot = Bot(token=self.bot_token)
+        self._active_chat_id: Optional[int] = None
+
+        logging.info("Telegram Speak Connector initialized")
+
+    def set_active_chat(self, chat_id: int):
+        """Set the active chat ID for responses."""
+        self._active_chat_id = chat_id
+
+    async def connect(self, output_interface: SpeakInput) -> None:
+        """
+        Send a speak action to Telegram.
+
+        Parameters
+        ----------
+        output_interface : SpeakInput
+            The SpeakInput interface containing the text to send.
+        """
+        text = output_interface.action
+
+        if not text or text.strip() == "":
+            logging.debug("Empty speak action, skipping Telegram message")
+            return
+
+        # Determine which chat to send to
+        chat_id = self._active_chat_id or self.default_chat_id
+
+        if not chat_id:
+            logging.warning(
+                "No Telegram chat ID available. "
+                "Set TELEGRAM_CHAT_ID or wait for a user to message the bot."
+            )
+            return
+
+        try:
+            await self.bot.send_message(chat_id=chat_id, text=text)
+            logging.info(f"Sent to Telegram ({chat_id}): {text[:50]}...")
+        except Exception as e:
+            logging.error(f"Failed to send Telegram message: {e}")

--- a/src/inputs/plugins/telegram_input.py
+++ b/src/inputs/plugins/telegram_input.py
@@ -1,0 +1,326 @@
+"""
+Telegram Input Plugin - Receive messages from Telegram Bot.
+
+This plugin allows OM1 agents to receive messages from Telegram users,
+enabling remote interaction with your AI agent through Telegram.
+
+Setup:
+1. Create a bot via @BotFather on Telegram
+2. Get your bot token
+3. Add the token to your .env file as TELEGRAM_BOT_TOKEN
+4. Add TelegramInput to your config's agent_inputs
+"""
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from queue import Empty, Queue
+from typing import List, Optional
+
+from pydantic import Field
+
+from inputs.base import Message, SensorConfig
+from inputs.base.loop import FuserInput
+from providers.io_provider import IOProvider
+
+# Try to import telegram library
+try:
+    from telegram import Update
+    from telegram.ext import (
+        Application,
+        CommandHandler,
+        ContextTypes,
+        MessageHandler,
+        filters,
+    )
+
+    TELEGRAM_AVAILABLE = True
+except ImportError:
+    TELEGRAM_AVAILABLE = False
+    logging.warning(
+        "python-telegram-bot not installed. "
+        "Install with: pip install python-telegram-bot"
+    )
+
+
+class TelegramInputConfig(SensorConfig):
+    """
+    Configuration for Telegram Input.
+
+    Parameters
+    ----------
+    bot_token : Optional[str]
+        Telegram Bot Token from @BotFather.
+        If not provided, reads from TELEGRAM_BOT_TOKEN env var.
+    input_name : str
+        Name of the input for LLM context.
+    allowed_users : Optional[List[int]]
+        List of allowed Telegram user IDs. If empty, allows all users.
+    """
+
+    bot_token: Optional[str] = Field(
+        default=None,
+        description="Telegram Bot Token. Falls back to TELEGRAM_BOT_TOKEN env var.",
+    )
+    input_name: str = Field(
+        default="Telegram Message",
+        description="Name of the input for LLM context",
+    )
+    allowed_users: Optional[List[int]] = Field(
+        default=None,
+        description="List of allowed Telegram user IDs. None = allow all.",
+    )
+
+
+class TelegramInput(FuserInput[TelegramInputConfig, Optional[str]]):
+    """
+    Telegram Input - Receive messages from Telegram Bot.
+
+    This plugin connects to Telegram Bot API and receives messages
+    from users, passing them to the LLM for processing.
+    """
+
+    def __init__(self, config: TelegramInputConfig):
+        """Initialize TelegramInput instance."""
+        super().__init__(config)
+
+        if not TELEGRAM_AVAILABLE:
+            raise ImportError(
+                "python-telegram-bot is required. "
+                "Install with: pip install python-telegram-bot"
+            )
+
+        # Get bot token from config or environment
+        self.bot_token = self.config.bot_token or os.getenv("TELEGRAM_BOT_TOKEN")
+        if not self.bot_token:
+            raise ValueError(
+                "Telegram bot token not provided. "
+                "Set TELEGRAM_BOT_TOKEN in .env or provide bot_token in config."
+            )
+
+        # Buffer for storing messages
+        self.messages: List[Message] = []
+        self.message_buffer: Queue[dict] = Queue()
+
+        # IO Provider for tracking
+        self.descriptor_for_LLM = self.config.input_name
+        self.io_provider = IOProvider()
+
+        # Allowed users (None = allow all)
+        self.allowed_users = self.config.allowed_users
+
+        # Telegram application
+        self.application: Optional[Application] = None
+        self.bot_thread: Optional[threading.Thread] = None
+        self.running = False
+
+        # Store chat IDs for responses
+        self.active_chats: dict = {}
+
+        logging.info("Telegram Input initialized")
+
+        # Start the bot in a separate thread
+        self._start_bot_thread()
+
+    def _start_bot_thread(self):
+        """Start the Telegram bot in a separate thread."""
+        self.bot_thread = threading.Thread(target=self._run_bot, daemon=True)
+        self.bot_thread.start()
+
+    def _run_bot(self):
+        """Run the Telegram bot (in separate thread)."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        try:
+            loop.run_until_complete(self._start_bot())
+        except Exception as e:
+            logging.error(f"Telegram bot error: {e}")
+        finally:
+            loop.close()
+
+    async def _start_bot(self):
+        """Start the Telegram bot application."""
+        self.application = Application.builder().token(self.bot_token).build()
+
+        # Add handlers
+        self.application.add_handler(
+            CommandHandler("start", self._handle_start_command)
+        )
+        self.application.add_handler(
+            CommandHandler("help", self._handle_help_command)
+        )
+        self.application.add_handler(
+            MessageHandler(filters.TEXT & ~filters.COMMAND, self._handle_message)
+        )
+
+        self.running = True
+        logging.info("Telegram bot started. Send /start to your bot to begin.")
+
+        # Start polling
+        await self.application.initialize()
+        await self.application.start()
+        await self.application.updater.start_polling(drop_pending_updates=True)
+
+        # Keep running
+        while self.running:
+            await asyncio.sleep(1)
+
+        # Cleanup
+        await self.application.updater.stop()
+        await self.application.stop()
+        await self.application.shutdown()
+
+    def _is_user_allowed(self, user_id: int) -> bool:
+        """Check if user is allowed to interact with the bot."""
+        if self.allowed_users is None or len(self.allowed_users) == 0:
+            return True
+        return user_id in self.allowed_users
+
+    async def _handle_start_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /start command."""
+        if update.effective_user is None or update.effective_chat is None:
+            return
+
+        user_id = update.effective_user.id
+        chat_id = update.effective_chat.id
+
+        if not self._is_user_allowed(user_id):
+            await update.message.reply_text(
+                "Sorry, you are not authorized to use this bot."
+            )
+            return
+
+        # Store chat for responses
+        self.active_chats[user_id] = chat_id
+
+        username = update.effective_user.first_name or "there"
+        await update.message.reply_text(
+            f"Hello {username}! I'm connected to an OM1 AI agent.\n\n"
+            "Send me a message and I'll respond!\n"
+            "Type /help for more information."
+        )
+        logging.info(f"Telegram user {user_id} started chat")
+
+    async def _handle_help_command(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle /help command."""
+        if update.effective_user is None:
+            return
+
+        if not self._is_user_allowed(update.effective_user.id):
+            return
+
+        await update.message.reply_text(
+            "OM1 Telegram Bot\n\n"
+            "Commands:\n"
+            "/start - Start the bot\n"
+            "/help - Show this help message\n\n"
+            "Just send any message and I'll respond!"
+        )
+
+    async def _handle_message(
+        self, update: Update, context: ContextTypes.DEFAULT_TYPE
+    ):
+        """Handle incoming text messages."""
+        if update.effective_user is None or update.message is None:
+            return
+
+        user_id = update.effective_user.id
+        chat_id = update.effective_chat.id
+
+        if not self._is_user_allowed(user_id):
+            await update.message.reply_text(
+                "Sorry, you are not authorized to use this bot."
+            )
+            return
+
+        # Store chat for responses
+        self.active_chats[user_id] = chat_id
+
+        text = update.message.text
+        username = update.effective_user.first_name or "User"
+
+        logging.info(f"Telegram message from {username} ({user_id}): {text}")
+
+        # Add message to buffer for LLM processing
+        self.message_buffer.put(
+            {
+                "text": text,
+                "user_id": user_id,
+                "chat_id": chat_id,
+                "username": username,
+                "timestamp": time.time(),
+            }
+        )
+
+        # Send typing indicator
+        await update.message.chat.send_action("typing")
+
+    async def send_response(self, chat_id: int, text: str):
+        """Send a response to a Telegram chat."""
+        if self.application and self.application.bot:
+            try:
+                await self.application.bot.send_message(chat_id=chat_id, text=text)
+            except Exception as e:
+                logging.error(f"Failed to send Telegram message: {e}")
+
+    async def _poll(self) -> Optional[str]:
+        """Poll for new messages from Telegram."""
+        await asyncio.sleep(0.5)
+
+        try:
+            msg_data = self.message_buffer.get_nowait()
+            # Format: "Username says: message"
+            return f"{msg_data['username']} says: {msg_data['text']}"
+        except Empty:
+            return None
+
+    async def _raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
+        """Process raw input to generate a timestamped message."""
+        if raw_input is None:
+            return None
+
+        return Message(timestamp=time.time(), message=raw_input)
+
+    async def raw_to_text(self, raw_input: Optional[str]):
+        """Convert raw input to text and update message buffer."""
+        if raw_input is None:
+            return
+
+        pending_message = await self._raw_to_text(raw_input)
+
+        if pending_message is not None:
+            self.messages.append(pending_message)
+
+    def formatted_latest_buffer(self) -> Optional[str]:
+        """Format and clear the latest buffer contents."""
+        if len(self.messages) == 0:
+            return None
+
+        latest_message = self.messages[-1]
+
+        result = f"""
+INPUT: {self.descriptor_for_LLM}
+// START
+{latest_message.message}
+// END
+"""
+
+        self.io_provider.add_input(
+            self.descriptor_for_LLM, latest_message.message, latest_message.timestamp
+        )
+        self.messages = []
+
+        return result
+
+    def get_latest_chat_id(self) -> Optional[int]:
+        """Get the most recent chat ID for sending responses."""
+        if self.active_chats:
+            return list(self.active_chats.values())[-1]
+        return None

--- a/uv.lock
+++ b/uv.lock
@@ -2478,6 +2478,9 @@ dds = [
 macos = [
     { name = "osascript" },
 ]
+telegram = [
+    { name = "python-telegram-bot" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2525,6 +2528,7 @@ requires-dist = [
     { name = "pyserial" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=21.0" },
     { name = "scipy" },
     { name = "sounddevice" },
     { name = "soundfile" },
@@ -2538,7 +2542,7 @@ requires-dist = [
     { name = "web3" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["dds", "macos"]
+provides-extras = ["dds", "macos", "telegram"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3554,6 +3558,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
+name = "python-telegram-bot"
+version = "22.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/6b/400f88e5c29a270c1c519a3ca8ad0babc650ec63dbfbd1b73babf625ed54/python_telegram_bot-22.5.tar.gz", hash = "sha256:82d4efd891d04132f308f0369f5b5929e0b96957901f58bcef43911c5f6f92f8", size = 1488269, upload-time = "2025-09-27T13:50:27.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c3/340c7520095a8c79455fcf699cbb207225e5b36490d2b9ee557c16a7b21b/python_telegram_bot-22.5-py3-none-any.whl", hash = "sha256:4b7cd365344a7dce54312cc4520d7fa898b44d1a0e5f8c74b5bd9b540d035d16", size = 730976, upload-time = "2025-09-27T13:50:25.93Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Adds Telegram Bot integration, allowing users to control OM1 agents remotely via Telegram messages.

## Problem
Currently, OM1 agents require local hardware (webcam, microphone) or WebSocket connections for input. This limits accessibility for users who want to interact with their agents remotely.

## Solution
This PR adds a complete Telegram integration:

### New Files
| File | Description |
|------|-------------|
| `src/inputs/plugins/telegram_input.py` | Input plugin to receive Telegram messages |
| `src/actions/speak/connector/telegram.py` | Speak connector to send responses to Telegram |
| `config/spot_telegram.json5` | Example configuration for Telegram bot |

### Features
- Receive messages from Telegram users
- Send agent responses back to Telegram
- Optional user whitelist for access control
- `/start` and `/help` commands
- Configurable via environment variables

## Setup Instructions

```bash
# 1. Create a bot via @BotFather on Telegram and get your token

# 2. Add token to .env
echo "TELEGRAM_BOT_TOKEN=your-token-here" >> .env

# 3. Install telegram dependency
uv sync --extra telegram

# 4. Run the agent
uv run src/run.py spot_telegram

# 5. Send /start to your bot on Telegram
```

## Dependencies
- Added `python-telegram-bot>=21.0` as optional dependency `[telegram]`

## Test Plan
- [x] Plugin imports successfully
- [x] Speak connector imports successfully
- [x] Configuration file is valid JSON5
- [ ] Manual test with real Telegram bot (requires bot token)

## Screenshots
N/A - Telegram interface
