### PR TITLE
docs: fix minor docstring typo in move_to_peer ROS2 connector

### DIFF
--- a/src/actions/move_to_peer/connector/ros2.py
+++ b/src/actions/move_to_peer/connector/ros2.py
@@ -49,7 +49,7 @@ class MoveToPeerRos2Connector(ActionConnector[ActionConfig, MoveToPeerInput]):
 
     async def connect(self, output_interface: MoveToPeerInput) -> None:
         """
-        Execute the *navigate‑to‑peer* behaviour once.
+        Execute the *navigate‑to‑peer* behavior once.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes a minor spelling inconsistency in a docstring
(behaviour → behavior) to align with OM1's American
English convention. No functional changes.
