### PR TITLE
Standardize movement handler commands and improve log clarity

### DIFF
--- a/src/actions/move_go2_autonomy/connector/unitree_sdk.py
+++ b/src/actions/move_go2_autonomy/connector/unitree_sdk.py
@@ -123,8 +123,8 @@ class MoveUnitreeSDKConnector(ActionConnector[MoveUnitreeSDKConfig, MoveInput]):
         movement_map = {
             "turn left": self._process_turn_left,
             "turn right": self._process_turn_right,
-            "move forwards": self._process_move_forward,
-            "move back": self._process_move_back,
+            "move forward": self._process_move_forward,
+            "move backward": self._process_move_back,
             "stand still": lambda: logging.info("AI movement command: stand still"),
         }
 
@@ -315,7 +315,7 @@ class MoveUnitreeSDKConnector(ActionConnector[MoveUnitreeSDKConfig, MoveInput]):
                         self._move_robot(fb * speed, 0.0, 0.0)
                     elif distance_traveled > abs(goal_dx):
                         logging.debug(
-                            f"Phase 2 - OVERSHOOT: move other way. Remaining: {gap}m"
+                            f"Phase 2 - OVERSHOOT: move the other way. Remaining: {gap}m"
                         )
                         self._move_robot(-1 * fb * 0.2, 0.0, 0.0)
                 else:


### PR DESCRIPTION
**PR Description**
**The Bug**
- Command Mismatch : The `movement_map` used non-standard keys (`move forwards, move back`). Since LLMs and user interfaces typically send singular commands like `move forward`, the robot would fail to find the correct handler and remain stationary.
- Inconsistency: Using "forward" (pluralized) and "back" (abbreviated) creates a mismatched pair. In technical control systems, "forward" and "backward" are the standard expected pairing.
- Log Clarity: The Phase 2 debug message `move other way` lacked proper grammar, making automated log parsing or human review less intuitive during overshoot corrections.