### PR TITLE
docs: add macOS camera permission note to getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Run
 uv run src/run.py spot
 ```
 
+> **⚠️ Note for macOS Users**
+>
+> If you are running macOS (especially Sequoia or newer), you must verify that your terminal application (e.g., Terminal, iTerm2, or VS Code) has permission to access the camera.
+>
+> If the agent fails to detect video input:
+> 1. Go to **System Settings** > **Privacy & Security** > **Camera**.
+> 2. Ensure the toggle is enabled for your terminal application or Python environment.
+
 After launching OM1, the Spot agent will interact with you and perform (simulated) actions. For more help connecting OM1 to your robot hardware, see [getting started](https://docs.openmind.org/developing/1_get-started).
 
 Note: This is just an example agent configuration.


### PR DESCRIPTION
Fixes #1176.

## Overview
Added a warning note in the "Launching OM1" section of the README. This reminds macOS users (specifically Sequoia+) that they must manually grant camera permissions to their terminal application. This addresses the confusion where the agent runs but detects no video input.

Linked issue: #1176

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
- Updated `README.md` to include a warning block under "Launching OM1".
- Provided specific path instructions (`System Settings -> Privacy & Security -> Camera`) for users to fix the issue.

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [ ] Local testing completed