### PR TITLE
Docs: update recommended model to gpt-4.1-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## Getting Started
 
 To get started with OM1, let's run the Spot agent. Spot uses your webcam to capture and label objects. These text captions are then sent to the LLM, which returns `movement`, `speech` and `face` action commands. These commands are displayed on WebSim along with basic timing and other debugging information.
-
+Note for beginners: If you receive a 404 Not Found error when using gpt-4, try changing the model to gpt-4.1-mini in your configuration file. This is the latest supported version.
 ### Package Management and VENV
 
 You will need the [`uv` package manager](https://docs.astral.sh/uv/getting-started/installation/).


### PR DESCRIPTION
Note for beginners: If you receive a 404 Not Found error when using gpt-4, try changing the model to gpt-4.1-mini in your configuration file. This is the latest supported version.

## Overview
Added a troubleshooting tip for beginners to address the 404 Not Found error when using the default gpt-4 model.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes

Added a note to README.md recommending the use of gpt-4.1-mini as a fix for the 404 error encountered during initial setup.
## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact

Helps new developers successfully complete the OM1 setup without getting stuck on model configuration errors.
## Additional Information

Could you please review this again? I've updated the description.