### PR TITLE
docs: fix GitHub organization name case inconsistency in links

### DIFF
--- a/docs/developing/4_inputs.mdx
+++ b/docs/developing/4_inputs.mdx
@@ -18,11 +18,11 @@ description: "Input Plugin Overview"
 
 Here are a few examples for you to reuse and build on:
 
-- [Google ASR](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/google_asr.py)
-- [Riva ASR](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/riva_asr.py)
-- [RPLidar](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/rplidar.py)
-- [VLM_COCO_Local](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_coco_local.py)
-- [VLM_Vila](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_vila.py)
-- [Arduino GPS](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/gps.py)
+- [Google ASR](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/google_asr.py)
+- [Riva ASR](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/riva_asr.py)
+- [RPLidar](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/rplidar.py)
+- [VLM_COCO_Local](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/vlm_coco_local.py)
+- [VLM_Vila](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/vlm_vila.py)
+- [Arduino GPS](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/gps.py)
 
 Learn how to build a new input plugin [here](../developer_cookbook/input.mdx)

--- a/docs/examples/overview.mdx
+++ b/docs/examples/overview.mdx
@@ -5,12 +5,12 @@ description: "OM1 Tutorials"
 
 ## Tutorials
 
-This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/openmind/OM1/tree/main/config). Some good starting examples include:
+This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/OpenMind/OM1/tree/main/config). Some good starting examples include:
 
-- [conversation.json5](https://github.com/openmind/OM1/tree/main/config/conversation.json5)
-- [spot.json5](https://github.com/openmind/OM1/tree/main/config/spot.json5)
-- [cubly.json5](https://github.com/openmind/OM1/tree/main/config/cubly.json5)
-- [turtlebot4.json5](https://github.com/openmind/OM1/tree/main/config/turtlebot4.json5)
-- [unitree_g1_humanoid.json5](https://github.com/openmind/OM1/tree/main/config/unitree_g1_humanoid.json5)
-- [unitree_go2_basic.json5](https://github.com/openmind/OM1/tree/main/config/unitree_go2_basic.json5)
-- [multiagent.json5](https://github.com/openmind/OM1/tree/main/config/multiagent.json5)
+- [conversation.json5](https://github.com/OpenMind/OM1/tree/main/config/conversation.json5)
+- [spot.json5](https://github.com/OpenMind/OM1/tree/main/config/spot.json5)
+- [cubly.json5](https://github.com/OpenMind/OM1/tree/main/config/cubly.json5)
+- [turtlebot4.json5](https://github.com/OpenMind/OM1/tree/main/config/turtlebot4.json5)
+- [unitree_g1_humanoid.json5](https://github.com/OpenMind/OM1/tree/main/config/unitree_g1_humanoid.json5)
+- [unitree_go2_basic.json5](https://github.com/OpenMind/OM1/tree/main/config/unitree_go2_basic.json5)
+- [multiagent.json5](https://github.com/OpenMind/OM1/tree/main/config/multiagent.json5)

--- a/docs/robotics/nvidia_thor.mdx
+++ b/docs/robotics/nvidia_thor.mdx
@@ -126,4 +126,4 @@ For robot deployments, we recommend modules such as the [Auvidea Jetson T5000 mo
 
 ## Done
 
-You are now running OM1 on your Nvidia Thor. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/openmind/OM1) for advanced settings and next steps.
+You are now running OM1 on your Nvidia Thor. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/OpenMind/OM1) for advanced settings and next steps.

--- a/docs/robotics/raspberrypi.mdx
+++ b/docs/robotics/raspberrypi.mdx
@@ -16,4 +16,4 @@ Then, install OM1 on the Raspberry Pi from its command line, following the [stan
 
 ## Done
 
-You’re now running OM1 on your Raspberry Pi. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/openmind/OM1) for advanced settings and next steps.
+You’re now running OM1 on your Raspberry Pi. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/OpenMind/OM1) for advanced settings and next steps.

--- a/mintlify/developing/4_inputs.mdx
+++ b/mintlify/developing/4_inputs.mdx
@@ -18,11 +18,11 @@ description: "Input Plugin Overview"
 
 Here are a few examples for you to reuse and build on:
 
-- [Google ASR](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/google_asr.py)
-- [Riva ASR](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/riva_asr.py)
-- [RPLidar](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/rplidar.py)
-- [VLM_COCO_Local](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_coco_local.py)
-- [VLM_Vila](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_vila.py)
-- [Arduino GPS](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/gps.py)
+- [Google ASR](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/google_asr.py)
+- [Riva ASR](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/riva_asr.py)
+- [RPLidar](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/rplidar.py)
+- [VLM_COCO_Local](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/vlm_coco_local.py)
+- [VLM_Vila](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/vlm_vila.py)
+- [Arduino GPS](https://github.com/OpenMind/OM1/blob/main/src/inputs/plugins/gps.py)
 
 Learn how to build a new input plugin [here](../developer_cookbook/input)

--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -214,7 +214,7 @@
     "footer": {
         "socials": {
             "x": "https://x.com/openmind_agi",
-            "github": "https://github.com/openmind"
+            "github": "https://github.com/OpenMind"
         }
     }
 }

--- a/mintlify/examples/0_overview.mdx
+++ b/mintlify/examples/0_overview.mdx
@@ -5,7 +5,7 @@ description: "OM1 Tutorials"
 
 ## Tutorials
 
-This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/openmind/OM1/tree/main/config). Some good starting examples include:
+This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/OpenMind/OM1/tree/main/config). Some good starting examples include:
 
 
 - conversation.json5

--- a/mintlify/examples/overview.mdx
+++ b/mintlify/examples/overview.mdx
@@ -5,12 +5,12 @@ description: "OM1 Tutorials"
 
 ## Tutorials
 
-This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/openmind/OM1/tree/main/config). Some good starting examples include:
+This section provides an overview of OM1 tutorials. The implementation configurations of the tutorials are available in the [OM1 repository](https://github.com/OpenMind/OM1/tree/main/config). Some good starting examples include:
 
-- [conversation.json5](https://github.com/openmind/OM1/tree/main/config/conversation.json5)
-- [spot.json5](https://github.com/openmind/OM1/tree/main/config/spot.json5)
-- [cubly.json5](https://github.com/openmind/OM1/tree/main/config/cubly.json5)
-- [turtlebot4.json5](https://github.com/openmind/OM1/tree/main/config/turtlebot4.json5)
-- [unitree_g1_humanoid.json5](https://github.com/openmind/OM1/tree/main/config/unitree_g1_humanoid.json5)
-- [unitree_go2_basic.json5](https://github.com/openmind/OM1/tree/main/config/unitree_go2_basic.json5)
-- [multiagent.json5](https://github.com/openmind/OM1/tree/main/config/multiagent.json5)
+- [conversation.json5](https://github.com/OpenMind/OM1/tree/main/config/conversation.json5)
+- [spot.json5](https://github.com/OpenMind/OM1/tree/main/config/spot.json5)
+- [cubly.json5](https://github.com/OpenMind/OM1/tree/main/config/cubly.json5)
+- [turtlebot4.json5](https://github.com/OpenMind/OM1/tree/main/config/turtlebot4.json5)
+- [unitree_g1_humanoid.json5](https://github.com/OpenMind/OM1/tree/main/config/unitree_g1_humanoid.json5)
+- [unitree_go2_basic.json5](https://github.com/OpenMind/OM1/tree/main/config/unitree_go2_basic.json5)
+- [multiagent.json5](https://github.com/OpenMind/OM1/tree/main/config/multiagent.json5)

--- a/mintlify/robotics/nvidia_thor.mdx
+++ b/mintlify/robotics/nvidia_thor.mdx
@@ -126,4 +126,4 @@ For robot deployments, we recommend modules such as the [Auvidea Jetson T5000 mo
 
 ## Done
 
-You are now running OM1 on your Nvidia Thor. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/openmind/OM1) for advanced settings and next steps.
+You are now running OM1 on your Nvidia Thor. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/OpenMind/OM1) for advanced settings and next steps.

--- a/mintlify/robotics/raspberrypi.mdx
+++ b/mintlify/robotics/raspberrypi.mdx
@@ -16,4 +16,4 @@ Then, install OM1 on the Raspberry Pi from its command line, following the [stan
 
 ## Done
 
-You’re now running OM1 on your Raspberry Pi. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/openmind/OM1) for advanced settings and next steps.
+You’re now running OM1 on your Raspberry Pi. Explore its capabilities and refer to the [OM1 GitHub repository](https://github.com/OpenMind/OM1) for advanced settings and next steps.


### PR DESCRIPTION
## Summary

Fix case inconsistency in GitHub links throughout the documentation by standardizing the organization name from `openmind` to the correct `OpenMind` (with capital O and M).

## Changes

This PR fixes GitHub links in the following files:

### docs/ directory
- `docs/examples/overview.mdx` - Fix all configuration file links
- `docs/developing/4_inputs.mdx` - Fix input plugin example links
- `docs/robotics/raspberrypi.mdx` - Fix repository reference link
- `docs/robotics/nvidia_thor.mdx` - Fix repository reference link

### mintlify/ directory (documentation mirror)
- `mintlify/examples/overview.mdx`
- `mintlify/examples/0_overview.mdx`
- `mintlify/developing/4_inputs.mdx`
- `mintlify/robotics/raspberrypi.mdx`
- `mintlify/robotics/nvidia_thor.mdx`
- `mintlify/docs.json` - Fix footer GitHub social link

## Improvements

- ✅ Improves documentation consistency and professionalism
- ✅ Ensures all GitHub links use the correct organization name casing
- ✅ All links remain functional (GitHub URLs are case-insensitive)

## Testing

Verified with grep that no `github.com/openmind/OM1` links remain in the codebase.