### PR TITLE
fix: Add missing dds_ placeholder in unitree_g1_basic.py

### DIFF
--- a/src/inputs/plugins/unitree_g1_basic.py
+++ b/src/inputs/plugins/unitree_g1_basic.py
@@ -18,20 +18,20 @@ except ImportError:
     )
 
     class BmsState_:
-        """
-        Placeholder for BmsState_ when Unitree SDK is not installed.
-        """
+        """Placeholder for BmsState_ when Unitree SDK is not installed."""
 
-        def __init__(self):
-            pass
+        pass
 
     class LowState_:
-        """
-        Placeholder for LowState_ when Unitree SDK is not installed.
-        """
+        """Placeholder for LowState_ when Unitree SDK is not installed."""
 
-        def __init__(self):
-            pass
+        pass
+
+    class dds_:
+        """Placeholder for dds_ module when Unitree SDK is not installed."""
+
+        BmsState_ = BmsState_
+        LowState_ = LowState_
 
 
 # Data structure documentation:


### PR DESCRIPTION
## Summary

- Added missing `dds_` placeholder class in the `ImportError` handler
- This fixes `NameError: name 'dds_' is not defined` when Unitree SDK is not installed
- Enables proper test collection without the SDK installed

## Problem

When running tests without the Unitree SDK installed, test collection fails with:

```
NameError: name 'dds_' is not defined
```

The `ImportError` handler defined placeholders for `BmsState_` and `LowState_`, but not for `dds_`, which is used in type hints at line 139.

## Solution

Added a `dds_` placeholder class with `BmsState_` and `LowState_` attributes to match the expected module structure.

## Test Plan

- [x] `pre-commit run --all-files` passes
- [x] Test collection works without Unitree SDK (965 tests collected vs 657 before)
- [x] No new test failures introduced