### PR TITLE
feat: add missing teleops.json5 config

### DIFF
--- a/config/teleops.json5
+++ b/config/teleops.json5
@@ -1,0 +1,22 @@
+{
+  "name": "teleops",
+  "version": "v1.0.1",
+  "description": "Teleoperation mode with status reporting",
+  "cortex_llm": {
+    "plugin": {
+      "name": "OpenAILLM",
+      "type": "OpenAILLM",
+      "model": "gpt-4o",
+      "api_key": "${OM_API_KEY}"
+    }
+  },
+  "inputs": [],
+  "outputs": [],
+  "backgrounds": [
+    {
+      "name": "StatusReporter",
+      "type": "AgentTeleopsStatusBackground",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Added the missing `config/teleops.json5` file to fix the "Configuration file not found" error.

Changes:
- Added `AgentTeleopsStatusBackground` class name reference to match source code.
- Added explicit `type` field to `cortex_llm` to prevent loader errors.
- Set default model to `gpt-4o`.