### PR TITLE
fix: resolve critical race conditions and resource safety issues

### DIFF
--- a/src/providers/llm_history_manager.py
+++ b/src/providers/llm_history_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, List, Optional, TypeVar, Union
 
@@ -84,6 +85,9 @@ class LLMHistoryManager:
 
         # history buffer
         self.history: List[ChatMessage] = []
+
+        # lock for thread-safe message list modifications
+        self._messages_lock = threading.Lock()
 
         # io provider
         self.io_provider = IOProvider()
@@ -235,29 +239,39 @@ class LLMHistoryManager:
                         return
 
                     summary_message = task.result()
-                    if summary_message.role == "assistant":
-                        del messages[:num_summarized]
-                        messages.insert(0, summary_message)
-                        logging.info("Successfully summarized the state")
-                    elif (
-                        summary_message.role == "system"
-                        and "Error" in summary_message.content
-                    ):
-                        logging.error(
-                            f"Summarization failed: {summary_message.content}"
-                        )
-                        messages.pop(0) if messages else None
-                        messages.pop(0) if messages else None
-                    else:
-                        logging.warning(f"Unexpected summary result: {summary_message}")
+                    with self._messages_lock:
+                        if summary_message.role == "assistant":
+                            del messages[:num_summarized]
+                            messages.insert(0, summary_message)
+                            logging.info("Successfully summarized the state")
+                        elif (
+                            summary_message.role == "system"
+                            and "Error" in summary_message.content
+                        ):
+                            logging.error(
+                                f"Summarization failed: {summary_message.content}"
+                            )
+                            if len(messages) >= 2:
+                                messages.pop(0)
+                                messages.pop(0)
+                            elif messages:
+                                messages.pop(0)
+                        else:
+                            logging.warning(
+                                f"Unexpected summary result: {summary_message}"
+                            )
                 except asyncio.CancelledError:
                     logging.warning("Summary task callback cancelled")
                 except Exception as e:
                     logging.error(
                         f"Error in summary task callback: {type(e).__name__}: {e}"
                     )
-                    messages.pop(0) if messages else None
-                    messages.pop(0) if messages else None
+                    with self._messages_lock:
+                        if len(messages) >= 2:
+                            messages.pop(0)
+                            messages.pop(0)
+                        elif messages:
+                            messages.pop(0)
 
             self._summary_task.add_done_callback(callback)
 
@@ -265,8 +279,12 @@ class LLMHistoryManager:
             logging.warning("Summary task creation cancelled")
         except Exception as e:
             logging.error(f"Error starting summary task: {type(e).__name__}: {e}")
-            messages.pop(0) if messages else None
-            messages.pop(0) if messages else None
+            with self._messages_lock:
+                if len(messages) >= 2:
+                    messages.pop(0)
+                    messages.pop(0)
+                elif messages:
+                    messages.pop(0)
 
     def get_messages(self) -> List[dict]:
         """

--- a/src/runtime/multi_mode/manager.py
+++ b/src/runtime/multi_mode/manager.py
@@ -107,7 +107,7 @@ class ModeManager:
         except Exception as e:
             logging.error(f"Error opening Zenoh client: {e}")
             self.session = None
-            self.pub = None
+            self._zenoh_mode_status_response_pub = None
 
         logging.info(
             f"Mode Manager initialized with current mode: {self.state.current_mode}"
@@ -534,89 +534,89 @@ class ModeManager:
                 return True
 
             self._is_transitioning = True
+            from_mode = self.state.current_mode
 
-        from_mode = self.state.current_mode
+            try:
+                if from_mode == target_mode:
+                    logging.debug(
+                        f"Already in target mode '{target_mode}', skipping transition"
+                    )
+                    return True
 
-        try:
+                transition_key = f"{from_mode}->{target_mode}"
+                self.transition_cooldowns[transition_key] = time.time()
 
-            if from_mode == target_mode:
-                logging.debug(
-                    f"Already in target mode '{target_mode}', skipping transition"
-                )
-                return True
+                from_config = self.config.modes.get(from_mode)
+                to_config = self.config.modes[target_mode]
 
-            transition_key = f"{from_mode}->{target_mode}"
-            self.transition_cooldowns[transition_key] = time.time()
+                transition_context = {
+                    "from_mode": from_mode,
+                    "to_mode": target_mode,
+                    "reason": reason,
+                    "timestamp": time.time(),
+                    "transition_key": transition_key,
+                }
 
-            from_config = self.config.modes.get(from_mode)
-            to_config = self.config.modes[target_mode]
+                # Execute exit hooks for the current mode
+                if from_config:
+                    logging.debug(f"Executing exit hooks for mode: {from_mode}")
+                    exit_success = await from_config.execute_lifecycle_hooks(
+                        LifecycleHookType.ON_EXIT, transition_context.copy()
+                    )
+                    if not exit_success:
+                        logging.warning(f"Some exit hooks failed for mode: {from_mode}")
 
-            transition_context = {
-                "from_mode": from_mode,
-                "to_mode": target_mode,
-                "reason": reason,
-                "timestamp": time.time(),
-                "transition_key": transition_key,
-            }
-
-            # Execute exit hooks for the current mode
-            if from_config:
-                logging.debug(f"Executing exit hooks for mode: {from_mode}")
-                exit_success = await from_config.execute_lifecycle_hooks(
+                # Execute global exit hooks
+                global_exit_success = await self.config.execute_global_lifecycle_hooks(
                     LifecycleHookType.ON_EXIT, transition_context.copy()
                 )
-                if not exit_success:
-                    logging.warning(f"Some exit hooks failed for mode: {from_mode}")
+                if not global_exit_success:
+                    logging.warning("Some global exit hooks failed")
 
-            # Execute global exit hooks
-            global_exit_success = await self.config.execute_global_lifecycle_hooks(
-                LifecycleHookType.ON_EXIT, transition_context.copy()
-            )
-            if not global_exit_success:
-                logging.warning("Some global exit hooks failed")
+                # Update state
+                self.state.previous_mode = from_mode
+                self.state.current_mode = target_mode
+                self.state.mode_start_time = time.time()
+                self.state.last_transition_time = time.time()
+                self.state.transition_history.append(
+                    f"{from_mode}->{target_mode}:{reason}"
+                )
 
-            # Update state
-            self.state.previous_mode = from_mode
-            self.state.current_mode = target_mode
-            self.state.mode_start_time = time.time()
-            self.state.last_transition_time = time.time()
-            self.state.transition_history.append(f"{from_mode}->{target_mode}:{reason}")
+                if len(self.state.transition_history) > 50:
+                    self.state.transition_history = self.state.transition_history[-25:]
 
-            if len(self.state.transition_history) > 50:
-                self.state.transition_history = self.state.transition_history[-25:]
+                logging.info(
+                    f"Mode transition: {from_mode} -> {target_mode} (reason: {reason})"
+                )
 
-            logging.info(
-                f"Mode transition: {from_mode} -> {target_mode} (reason: {reason})"
-            )
+                # Execute entry hooks for the new mode
+                logging.debug(f"Executing entry hooks for mode: {target_mode}")
+                entry_success = await to_config.execute_lifecycle_hooks(
+                    LifecycleHookType.ON_ENTRY, transition_context.copy()
+                )
+                if not entry_success:
+                    logging.warning(f"Some entry hooks failed for mode: {target_mode}")
 
-            # Execute entry hooks for the new mode
-            logging.debug(f"Executing entry hooks for mode: {target_mode}")
-            entry_success = await to_config.execute_lifecycle_hooks(
-                LifecycleHookType.ON_ENTRY, transition_context.copy()
-            )
-            if not entry_success:
-                logging.warning(f"Some entry hooks failed for mode: {target_mode}")
+                # Execute global entry hooks
+                global_entry_success = await self.config.execute_global_lifecycle_hooks(
+                    LifecycleHookType.ON_ENTRY, transition_context.copy()
+                )
+                if not global_entry_success:
+                    logging.warning("Some global entry hooks failed")
 
-            # Execute global entry hooks
-            global_entry_success = await self.config.execute_global_lifecycle_hooks(
-                LifecycleHookType.ON_ENTRY, transition_context.copy()
-            )
-            if not global_entry_success:
-                logging.warning("Some global entry hooks failed")
+                await self._notify_transition_callbacks(from_mode, target_mode)
 
-            await self._notify_transition_callbacks(from_mode, target_mode)
+                self._save_mode_state()
 
-            self._save_mode_state()
+                return True
 
-            return True
-
-        except Exception as e:
-            logging.error(
-                f"Failed to execute transition {from_mode} -> {target_mode}: {e}"
-            )
-            return False
-        finally:
-            self._is_transitioning = False
+            except Exception as e:
+                logging.error(
+                    f"Failed to execute transition {from_mode} -> {target_mode}: {e}"
+                )
+                return False
+            finally:
+                self._is_transitioning = False
 
     def get_available_transitions(self) -> List[str]:
         """
@@ -752,6 +752,9 @@ class ModeManager:
 
         # Request current mode info
         if code == 1:
+            if not self._zenoh_mode_status_response_pub:
+                logging.warning("Zenoh publisher not initialized, cannot respond")
+                return
             mode_status_response = ModeStatusResponse(
                 header=prepare_header(mode_status.header.frame_id),
                 request_id=request_id,
@@ -819,7 +822,10 @@ class ModeManager:
                 message=String(f"Failed to switch to mode {target_mode}"),
             )
 
-        self._zenoh_mode_status_response_pub.put(mode_status_response.serialize())
+        if self._zenoh_mode_status_response_pub:
+            self._zenoh_mode_status_response_pub.put(mode_status_response.serialize())
+        else:
+            logging.warning("Zenoh publisher not initialized, cannot send response")
 
     def _get_state_file_path(self) -> str:
         """


### PR DESCRIPTION
## Summary
- **Bug 1:** Race condition in mode transition - Extended lock scope to cover entire try/except/finally block
- **Bug 2:** Zenoh publisher undefined after init failure - Fixed incorrect variable name and added null checks
- **Bug 3:** LLM history manager thread-safety - Added threading.Lock for message list modifications

## Changes
- `src/runtime/multi_mode/manager.py`: Fixed race condition by extending async lock scope, corrected `self.pub` to `self._zenoh_mode_status_response_pub`, added null checks at lines 755 and 825
- `src/providers/llm_history_manager.py`: Added `threading.Lock` for thread-safe list operations, replaced unsafe `pop(0) if messages else None` with proper length checks

## Test plan
- [x] All existing tests pass (648 passed, 1 skipped due to missing ubtech module)
- [x] No breaking changes - all modifications are backwards compatible
- [x] Follows existing code patterns (threading.Lock used in 14+ other files)