### PR TITLE
improve(cli): make JSON parse error handling more robust

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -198,8 +198,13 @@ def validate_config(
             print("-" * 50)
 
         # Load and parse JSON5
-        with open(config_path, "r") as f:
-            raw_config = json5.load(f)
+        try:
+            with open(config_path, "r") as f:
+                raw_config = json5.load(f)
+        except ValueError as e:
+            print("Error: Invalid JSON5 syntax")
+            print(f"   {e}")
+            raise typer.Exit(1)
 
         if verbose:
             print("JSON5 syntax valid")
@@ -259,10 +264,7 @@ def validate_config(
         raise typer.Exit(1)
 
     except ValueError as e:
-        if "line" in str(e).lower() or "parse" in str(e).lower():
-            print("Error: Invalid JSON5 syntax")
-            print(f"   {e}")
-        elif "Component validation" in str(e):
+        if "Component validation" in str(e):
             pass  # Already printed by _validate_components
         else:
             print("Error: Unexpected validation error")


### PR DESCRIPTION
## Overview
This PR improves the robustness of JSON error handling in the CLI's validate_config command. Previously, the code relied on inspecting the string representation of ValueError exceptions (looking for substrings like "line" or "parse") to identify JSON parsing errors. This approach was fragile and susceptible to breaking if the underlying json5 library changed its error messages.

## Changes
- Refactored validate_config in src/cli.py to isolate the json5.load call within its own try/except block.
- Explicitly catches ValueError during file loading to report "Invalid JSON5 syntax".
- Removed the legacy logic that attempted to classify errors by string matching later in the function.

## Impact
- Robustness: The CLI will now correctly identify and report JSON syntax errors regardless of the specific wording of the exception message.
- Maintainability: Removes implicit dependencies on the internal error message format of the json5 library.
- User Experience: Ensures users receive clear, actionable feedback when their configuration files contain syntax errors, rather than falling back to a generic "Unexpected validation error".

## Testing
- Run uv run src/cli.py validate-config <invalid_config> and verify it reports "Error: Invalid JSON5 syntax" with the specific error details.
- Run uv run src/cli.py validate-config <valid_config> and verify it proceeds to schema validation.
- Ensure ruff and pyright checks pass.

## Additional Information
This change addresses the "Fragile JSON Error Handling" issue identified during the strict CI compliance review.