### PR TITLE
docs: add module docstrings to LLM plugins

### DIFF
--- a/src/llm/plugins/__init__.py
+++ b/src/llm/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""LLM plugins for various AI model providers."""

--- a/src/llm/plugins/deepseek_llm.py
+++ b/src/llm/plugins/deepseek_llm.py
@@ -1,3 +1,5 @@
+"""DeepSeek LLM plugin for DeepSeek conversation models."""
+
 import logging
 import time
 import typing as T

--- a/src/llm/plugins/dual_llm.py
+++ b/src/llm/plugins/dual_llm.py
@@ -1,3 +1,5 @@
+"""Dual LLM plugin for parallel primary/secondary model inference."""
+
 import asyncio
 import json
 import logging

--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -1,3 +1,5 @@
+"""Google Gemini LLM plugin using OpenAI-compatible API."""
+
 import logging
 import time
 import typing as T

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -1,3 +1,5 @@
+"""Multi LLM plugin (deprecated). Use NearAI or OpenAI LLM plugins instead."""
+
 # Deprecated: Use NearAI or Open AI LLM plugins instead.
 
 # import logging

--- a/src/llm/plugins/multi_llm_healthy.py
+++ b/src/llm/plugins/multi_llm_healthy.py
@@ -1,3 +1,5 @@
+"""Multi LLM Healthy plugin (deprecated). Use NearAI or OpenAI LLM plugins instead."""
+
 # Deprecated: Use NearAI or Open AI LLM plugins instead.
 
 # import logging

--- a/src/llm/plugins/near_ai_llm.py
+++ b/src/llm/plugins/near_ai_llm.py
@@ -1,3 +1,5 @@
+"""NEAR AI LLM plugin for NEAR Protocol AI inference."""
+
 import logging
 import time
 import typing as T

--- a/src/llm/plugins/ollama_llm.py
+++ b/src/llm/plugins/ollama_llm.py
@@ -1,3 +1,5 @@
+"""Ollama LLM plugin for local model inference."""
+
 import json
 import logging
 import time

--- a/src/llm/plugins/openai_llm.py
+++ b/src/llm/plugins/openai_llm.py
@@ -1,3 +1,5 @@
+"""OpenAI LLM plugin for GPT models with function calling support."""
+
 import logging
 import time
 import typing as T

--- a/src/llm/plugins/openai_spatial_memory.py
+++ b/src/llm/plugins/openai_spatial_memory.py
@@ -1,3 +1,5 @@
+"""OpenAI Spatial Memory LLM plugin (deprecated). Location-aware inference support."""
+
 # import json
 # import logging
 # import time

--- a/src/llm/plugins/openrouter.py
+++ b/src/llm/plugins/openrouter.py
@@ -1,3 +1,5 @@
+"""OpenRouter LLM plugin for unified access to multiple LLM providers."""
+
 import logging
 import time
 import typing as T

--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -1,3 +1,5 @@
+"""Qwen LLM plugin for Alibaba Cloud Qwen models."""
+
 import json
 import logging
 import re

--- a/src/llm/plugins/rag_multi_llm.py
+++ b/src/llm/plugins/rag_multi_llm.py
@@ -1,3 +1,5 @@
+"""RAG Multi LLM plugin (deprecated). Retrieval-augmented generation support."""
+
 # import logging
 # import time
 # import typing as T

--- a/src/llm/plugins/xai_llm.py
+++ b/src/llm/plugins/xai_llm.py
@@ -1,3 +1,5 @@
+"""xAI LLM plugin for Grok models using OpenAI-compatible API."""
+
 import logging
 import time
 import typing as T


### PR DESCRIPTION
## Summary
Add descriptive module-level docstrings to all 14 LLM plugin files for better code documentation and IDE support.

## Changes
| File | Docstring |
|------|-----------|
| `__init__.py` | LLM plugins for various AI model providers |
| `openai_llm.py` | OpenAI LLM plugin for GPT models with function calling support |
| `gemini_llm.py` | Google Gemini LLM plugin using OpenAI-compatible API |
| `deepseek_llm.py` | DeepSeek LLM plugin for DeepSeek conversation models |
| `xai_llm.py` | xAI LLM plugin for Grok models using OpenAI-compatible API |
| `ollama_llm.py` | Ollama LLM plugin for local model inference |
| `qwen_llm.py` | Qwen LLM plugin for Alibaba Cloud Qwen models |
| `openrouter.py` | OpenRouter LLM plugin for unified access to multiple LLM providers |
| `near_ai_llm.py` | NEAR AI LLM plugin for NEAR Protocol AI inference |
| `dual_llm.py` | Dual LLM plugin for parallel primary/secondary model inference |
| `multi_llm.py` | Multi LLM plugin (deprecated) |
| `multi_llm_healthy.py` | Multi LLM Healthy plugin (deprecated) |
| `rag_multi_llm.py` | RAG Multi LLM plugin (deprecated) |
| `openai_spatial_memory.py` | OpenAI Spatial Memory LLM plugin (deprecated) |

## Test Plan
- [x] Pre-commit hooks pass (ruff, black, isort, typos)
- [x] No functional changes, documentation only