### PR TITLE
Update LICENSE copyright years to include 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2024, 2025 OPENMIND.ORG
+Copyright (c) 2024, 2025, 2026 OPENMIND.ORG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Added 2026 to the copyright years in the LICENSE file to reflect continued coverage.
