### PR TITLE
feat: add Mistral LLM plugin for Mistral AI models

### DIFF
--- a/config/mistral.json5
+++ b/config/mistral.json5
@@ -1,0 +1,57 @@
+{
+  version: "v1.0.1",
+  hertz: 1,
+  name: "mistral",
+  api_key: "openmind_free",
+  URID: "default",
+  system_prompt_base: "You are a smart, curious, and friendly dog. Your name is Spot. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  system_prompt_examples: "Here are some examples of interactions you might encounter:\n\n1. If a person says 'Give me your paw!', you might:\n    Move: 'shake paw'\n    Speak: {{'sentence': 'Hello, let\\'s shake paws!'}}\n    Face: 'joy'\n\n2. If a person says 'Sit!' you might:\n    Move: 'sit'\n    Speak: {{'sentence': 'Ok, but I like running more'}}\n    Face: 'smile'\n\n3. If there\\'s no sound, go explore. You might:\n    Move: 'run'\n    Speak: {{'sentence': 'I\\'m going to go explore the room and meet more people.'}}\n    Face: 'think'",
+  agent_inputs: [
+    {
+      type: "DummyVLMLocal",
+    },
+    {
+      type: "FaceEmotionCapture",
+    },
+  ],
+  simulators: [
+    {
+      type: "WebSim",
+      config: {
+        host: "0.0.0.0",
+        port: 8000,
+        tick_rate: 100,
+        auto_reconnect: true,
+        debug_mode: false,
+      },
+    },
+  ],
+  cortex_llm: {
+    type: "MistralLLM",
+    config: {
+      agent_name: "Spot",
+      history_length: 10,
+    },
+  },
+  agent_actions: [
+    {
+      name: "move",
+      llm_label: "move",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "speak",
+      llm_label: "speak",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+  ],
+}

--- a/src/llm/plugins/mistral_llm.py
+++ b/src/llm/plugins/mistral_llm.py
@@ -1,0 +1,139 @@
+"""Mistral LLM plugin for Mistral AI models with function calling support."""
+
+import logging
+import time
+import typing as T
+
+import openai
+from pydantic import BaseModel
+
+from llm import LLM, LLMConfig
+from llm.function_schemas import convert_function_calls_to_actions
+from llm.output_model import CortexOutputModel
+from providers.avatar_llm_state_provider import AvatarLLMState
+from providers.llm_history_manager import LLMHistoryManager
+
+R = T.TypeVar("R", bound=BaseModel)
+
+
+class MistralLLM(LLM[R]):
+    """
+    Mistral AI Language Model implementation using OpenAI-compatible API.
+
+    Mistral AI provides efficient, high-performance models with excellent
+    price-to-performance ratio. Supported models include:
+    - mistral-large-latest: Frontier model with 675B parameters (recommended)
+    - mistral-medium-latest: GPT-4 class performance, cost-effective
+    - mistral-small-latest: Fast and efficient for simple tasks
+    - magistral-medium-latest: Enhanced reasoning capabilities
+
+    This class implements the LLM interface for Mistral models, handling
+    configuration, authentication, and async API communication.
+
+    Parameters
+    ----------
+    config : LLMConfig
+        Configuration object containing API settings.
+    available_actions : list[AgentAction], optional
+        List of available actions for function call generation. If provided,
+        the LLM will use function calls instead of structured JSON output.
+    """
+
+    def __init__(
+        self,
+        config: LLMConfig,
+        available_actions: T.Optional[T.List] = None,
+    ):
+        """
+        Initialize the Mistral LLM instance.
+
+        Parameters
+        ----------
+        config : LLMConfig
+            Configuration settings for the LLM.
+        available_actions : list[AgentAction], optional
+            List of available actions for function calling.
+        """
+        super().__init__(config, available_actions)
+
+        if not config.api_key:
+            raise ValueError("config file missing api_key")
+        if not config.model:
+            self._config.model = "mistral-large-latest"
+
+        self._client = openai.AsyncOpenAI(
+            base_url=config.base_url or "https://api.openmind.org/api/core/mistral",
+            api_key=config.api_key,
+        )
+
+        self.history_manager = LLMHistoryManager(self._config, self._client)
+
+    @AvatarLLMState.trigger_thinking()
+    @LLMHistoryManager.update_history()
+    async def ask(
+        self, prompt: str, messages: T.List[T.Dict[str, str]] = []
+    ) -> T.Optional[R]:
+        """
+        Send a prompt to the Mistral API and get a structured response.
+
+        Parameters
+        ----------
+        prompt : str
+            The input prompt to send to the model.
+        messages : List[Dict[str, str]]
+            List of message dictionaries containing conversation history.
+
+        Returns
+        -------
+        R or None
+            Parsed response matching the output_model structure, or None if
+            parsing fails or an error occurs.
+        """
+        try:
+            logging.debug(f"Mistral LLM input: {prompt}")
+            logging.debug(f"Mistral LLM messages: {messages}")
+
+            self.io_provider.llm_start_time = time.time()
+            self.io_provider.set_llm_prompt(prompt)
+
+            formatted_messages = [
+                {"role": msg.get("role", "user"), "content": msg.get("content", "")}
+                for msg in messages
+            ]
+            formatted_messages.append({"role": "user", "content": prompt})
+
+            response = await self._client.chat.completions.create(
+                model=self._config.model or "mistral-large-latest",
+                messages=T.cast(T.Any, formatted_messages),
+                tools=T.cast(T.Any, self.function_schemas),
+                tool_choice="auto",
+                timeout=self._config.timeout,
+            )
+
+            message = response.choices[0].message
+            self.io_provider.llm_end_time = time.time()
+
+            if message.tool_calls:
+                logging.info(f"Received {len(message.tool_calls)} function calls")
+                logging.info(f"Function calls: {message.tool_calls}")
+
+                function_call_data = [
+                    {
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        }
+                    }
+                    for tc in message.tool_calls
+                ]
+
+                actions = convert_function_calls_to_actions(function_call_data)
+
+                result = CortexOutputModel(actions=actions)
+                logging.info(f"Mistral LLM function call output: {result}")
+                return T.cast(R, result)
+
+            return None
+        except Exception as e:
+            logging.error(f"Mistral API error: {e}")
+            return None

--- a/tests/llm/plugins/test_mistral_llm.py
+++ b/tests/llm/plugins/test_mistral_llm.py
@@ -1,0 +1,224 @@
+"""Tests for Mistral LLM plugin."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from llm import LLMConfig
+from llm.output_model import Action, CortexOutputModel
+from llm.plugins.mistral_llm import MistralLLM
+
+
+@pytest.fixture(autouse=True)
+def mock_avatar_components():
+    """Mock all avatar and IO components to prevent Zenoh session creation."""
+
+    def mock_decorator(func=None):
+        def decorator(f):
+            return f
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+    with (
+        patch(
+            "llm.plugins.mistral_llm.AvatarLLMState.trigger_thinking",
+            mock_decorator,
+        ),
+        patch(
+            "llm.plugins.mistral_llm.LLMHistoryManager.update_history",
+            mock_decorator,
+        ),
+        patch("llm.plugins.mistral_llm.LLMHistoryManager"),
+        patch("llm.plugins.mistral_llm.AvatarLLMState") as mock_avatar_state,
+        patch("providers.avatar_provider.AvatarProvider") as mock_avatar_provider,
+        patch(
+            "providers.avatar_llm_state_provider.AvatarProvider"
+        ) as mock_avatar_llm_state_provider,
+    ):
+        mock_avatar_state._instance = None
+        mock_avatar_state._lock = None
+
+        mock_provider_instance = MagicMock()
+        mock_provider_instance.running = False
+        mock_provider_instance.session = None
+        mock_provider_instance.stop = MagicMock()
+        mock_avatar_provider.return_value = mock_provider_instance
+        mock_avatar_llm_state_provider.return_value = mock_provider_instance
+
+        yield
+
+
+class TestMistralLLMInit:
+    """Tests for MistralLLM initialization."""
+
+    def test_init_without_api_key_raises_error(self):
+        """Test that initialization without api_key raises ValueError."""
+        config = LLMConfig(api_key=None)
+
+        with pytest.raises(ValueError, match="config file missing api_key"):
+            with patch("llm.plugins.mistral_llm.openai.AsyncOpenAI"):
+                MistralLLM(config)
+
+    def test_init_with_api_key_succeeds(self):
+        """Test that initialization with api_key succeeds."""
+        config = LLMConfig(api_key="test-api-key")
+
+        with patch("llm.plugins.mistral_llm.openai.AsyncOpenAI") as mock_client:
+            llm = MistralLLM(config)
+
+            mock_client.assert_called_once_with(
+                base_url="https://api.openmind.org/api/core/mistral",
+                api_key="test-api-key",
+            )
+            assert llm._config.model == "mistral-large-latest"
+
+    def test_init_with_custom_model(self):
+        """Test that custom model is preserved."""
+        config = LLMConfig(api_key="test-api-key", model="mistral-small-latest")
+
+        with patch("llm.plugins.mistral_llm.openai.AsyncOpenAI"):
+            llm = MistralLLM(config)
+
+            assert llm._config.model == "mistral-small-latest"
+
+    def test_init_with_custom_base_url(self):
+        """Test that custom base_url is used."""
+        custom_url = "https://api.mistral.ai/v1"
+        config = LLMConfig(api_key="test-api-key", base_url=custom_url)
+
+        with patch("llm.plugins.mistral_llm.openai.AsyncOpenAI") as mock_client:
+            MistralLLM(config)
+
+            mock_client.assert_called_once_with(
+                base_url=custom_url,
+                api_key="test-api-key",
+            )
+
+
+class TestMistralLLMAsk:
+    """Tests for MistralLLM.ask method."""
+
+    @pytest.fixture
+    def mistral_llm(self):
+        """Create a MistralLLM instance for testing."""
+        config = LLMConfig(api_key="test-api-key")
+
+        with patch("llm.plugins.mistral_llm.openai.AsyncOpenAI"):
+            llm = MistralLLM(config)
+
+        llm.io_provider = MagicMock()
+        llm.io_provider.llm_start_time = None
+        llm.io_provider.llm_end_time = None
+        llm.function_schemas = []
+
+        return llm
+
+    @pytest.mark.asyncio
+    async def test_ask_with_function_calls(self, mistral_llm):
+        """Test ask method when model returns function calls."""
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "speak"
+        mock_tool_call.function.arguments = '{"action": "Hello world"}'
+
+        mock_message = MagicMock()
+        mock_message.tool_calls = [mock_tool_call]
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mistral_llm._client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        with patch(
+            "llm.plugins.mistral_llm.convert_function_calls_to_actions"
+        ) as mock_convert:
+            mock_action = Action(type="speak", value="Hello world")
+            mock_convert.return_value = [mock_action]
+
+            result = await mistral_llm.ask("Test prompt")
+
+            assert result is not None
+            assert isinstance(result, CortexOutputModel)
+            assert len(result.actions) == 1
+            mock_convert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ask_without_function_calls(self, mistral_llm):
+        """Test ask method when model returns no function calls."""
+        mock_message = MagicMock()
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mistral_llm._client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        result = await mistral_llm.ask("Test prompt")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ask_formats_messages_correctly(self, mistral_llm):
+        """Test that ask method formats messages and calls API correctly."""
+        mock_message = MagicMock()
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mistral_llm._client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        await mistral_llm.ask("Test prompt")
+
+        mistral_llm._client.chat.completions.create.assert_called_once()
+        call_args = mistral_llm._client.chat.completions.create.call_args
+        assert call_args.kwargs["model"] == "mistral-large-latest"
+        assert "messages" in call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_ask_handles_api_error(self, mistral_llm):
+        """Test that API errors are handled gracefully."""
+        mistral_llm._client.chat.completions.create = AsyncMock(
+            side_effect=Exception("API Error")
+        )
+
+        result = await mistral_llm.ask("Test prompt")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ask_sets_io_provider_times(self, mistral_llm):
+        """Test that IO provider times are set correctly."""
+        mock_message = MagicMock()
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        mistral_llm._client.chat.completions.create = AsyncMock(
+            return_value=mock_response
+        )
+
+        await mistral_llm.ask("Test prompt")
+
+        assert mistral_llm.io_provider.llm_start_time is not None
+        assert mistral_llm.io_provider.llm_end_time is not None


### PR DESCRIPTION
## Summary

- Add Mistral LLM plugin with OpenAI-compatible API support
- Mistral AI provides efficient, high-performance models with excellent price-to-performance ratio

## Supported Models

| Model | ID | Use Case |
|-------|-----|----------|
| Mistral Large 3 | `mistral-large-latest` | Frontier model, 675B params (default) |
| Mistral Medium 3 | `mistral-medium-latest` | GPT-4 class, cost-effective |
| Mistral Small 3.1 | `mistral-small-latest` | Fast, efficient |
| Magistral Medium | `magistral-medium-latest` | Enhanced reasoning |

## Changes

- `src/llm/plugins/mistral_llm.py` - Mistral LLM implementation following existing patterns
- `config/mistral.json5` - Example configuration using OpenMind proxy
- `tests/llm/plugins/test_mistral_llm.py` - Unit tests (9 tests, all passing)

## Pattern Compliance

- Follows same pattern as DeepSeek, OpenAI, Gemini LLM plugins
- Uses OpenMind proxy endpoint: `https://api.openmind.org/api/core/mistral`
- Default model: `mistral-large-latest`
- Properly mocks AvatarProvider in tests to prevent Zenoh session leaks

## Direct API Usage (without OpenMind proxy)

To test with your own Mistral API key before OpenMind backend support:

```json5
// config/mistral_direct.json5
{
  // ... other config ...
  cortex_llm: {
    type: "MistralLLM",
    config: {
      base_url: "https://api.mistral.ai/v1",
      api_key: "your-mistral-api-key",  // Your Mistral API key
      agent_name: "Mistral",
      history_length: 10,
    },
  },
}
```

Or set in `.env` and use `OM_API_KEY`:
```bash
# .env
OM_API_KEY=your-mistral-api-key
```

Get your API key at: https://console.mistral.ai

## Test plan

- [x] Unit tests pass (9/9)
- [x] Lint checks pass (ruff)
- [x] Type checks pass (pyright)
- [ ] Requires OpenMind backend to add `/api/core/mistral` endpoint