### PR TITLE
docs(actions): clarify base class parameters and implementation methodology

### DIFF
--- a/src/actions/base.py
+++ b/src/actions/base.py
@@ -42,6 +42,20 @@ class MoveCommand:
 class ActionConfig(BaseModel):
     """
     Configuration class for Action implementations.
+    
+    This class serves as the base configuration model for all action implementations
+    within the system. It utilizes Pydantic's BaseModel to provide type validation
+    and serialization capabilities, while allowing additional fields to be dynamically
+    added through the `extra="allow"` configuration directive. This design pattern
+    enables flexible configuration management where action-specific parameters can
+    be extended without modifying the base class structure.
+    
+    Attributes
+    ----------
+    model_config : ConfigDict
+        Pydantic configuration dictionary that permits additional fields beyond
+        those explicitly defined in the model schema, facilitating extensibility
+        for action-specific configuration requirements.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -50,14 +64,26 @@ class ActionConfig(BaseModel):
 @dataclass
 class Interface(T.Generic[IT, OT]):
     """
-    An interface for a action.
+    Generic interface definition for action input and output type specifications.
+    
+    This dataclass provides a type-safe mechanism for defining the input and output
+    type constraints for actions within the system. By utilizing Python's generic
+    type system, it enables compile-time type checking and ensures that actions
+    maintain consistent type contracts throughout their execution lifecycle. The
+    interface serves as a contract specification that defines the expected data
+    structures for both incoming action requests and outgoing action responses.
 
     Parameters
     ----------
     input : IT
-        The input type for the interface.
+        The input type parameter that specifies the expected data structure or
+        type for incoming action requests. This generic type parameter allows
+        for flexible specification of input contracts across different action
+        implementations.
     output : OT
-        The output type for the interface.
+        The output type parameter that defines the structure and type of data
+        that will be produced as a result of action execution. This generic
+        parameter enables type-safe handling of action responses and return values.
     """
 
     input: IT
@@ -66,35 +92,90 @@ class Interface(T.Generic[IT, OT]):
 
 class ActionConnector(ABC, T.Generic[CT, OT]):
     """
-    A connector for an action.
+    Abstract base class for action connectors that facilitate communication between
+    actions and their underlying execution mechanisms.
+    
+    This class provides a standardized interface for implementing connectors that
+    bridge the gap between the action abstraction layer and the concrete execution
+    backends (such as ROS2, Unitree SDK, or other robotic frameworks). The connector
+    pattern enables decoupling of action logic from implementation details, allowing
+    for flexible substitution of execution mechanisms without modifying action
+    definitions. The generic type parameters ensure type safety throughout the
+    connector implementation lifecycle.
+
+    Parameters
+    ----------
+    config : CT
+        Configuration object that contains all necessary parameters and settings
+        required for the connector to establish and maintain connections with
+        the underlying execution backend. The configuration type is constrained
+        to be a subclass of ActionConfig, ensuring consistency across connector
+        implementations.
     """
 
     def __init__(self, config: CT):
         """
-        Initialize the ActionConnector.
+        Initialize the ActionConnector with the provided configuration object.
+        
+        This constructor establishes the foundational state of the connector by
+        storing the configuration parameters that will govern its behavior during
+        connection establishment and action execution. The configuration is
+        stored as an instance variable to enable runtime access to connector
+        settings throughout the connector's lifecycle.
 
         Parameters
         ----------
         config : CT
-            Configuration for the action connector.
+            Configuration object that specifies the operational parameters for
+            this connector instance. The configuration must conform to the
+            ActionConfig base class structure and may contain connector-specific
+            extensions as permitted by the Pydantic model configuration.
         """
         self.config: CT = config
 
     @abstractmethod
     async def connect(self, output_interface: OT) -> None:
         """
-        Connect the input protocol to the action.
+        Establish a connection between the action and its execution backend using
+        the provided output interface specification.
+        
+        This abstract method must be implemented by concrete connector subclasses
+        to define the specific mechanism for establishing communication channels
+        with the underlying execution system. The method receives an output interface
+        that defines the expected data structure and type constraints for action
+        execution results, which the connector must utilize to properly format
+        and transmit action commands to the backend system.
 
         Parameters
         ----------
         output_interface : OT
-            The input protocol containing the action details.
+            The output interface specification that defines the type and structure
+            of data that will be produced as a result of action execution. This
+            interface serves as a contract that the connector must adhere to when
+            formatting and transmitting action commands to the execution backend.
+            The generic type parameter OT ensures type safety throughout the
+            connection establishment process.
         """
         pass
 
     def tick(self) -> None:
         """
-        Tick method for periodic updates.
+        Execute periodic maintenance and update operations for the connector.
+        
+        This method provides a mechanism for connectors to perform periodic
+        housekeeping tasks, such as connection health checks, resource cleanup,
+        or state synchronization with the execution backend. The default
+        implementation introduces a 60-second delay, which can be overridden
+        by subclasses to implement connector-specific periodic update logic.
+        This method is typically invoked by the orchestrator as part of the
+        action execution lifecycle management.
+
+        Notes
+        -----
+        Subclasses should override this method to implement connector-specific
+        periodic update logic. The default implementation serves as a placeholder
+        that prevents immediate return and may be suitable for connectors that
+        do not require periodic maintenance operations.
         """
         time.sleep(60)
 
@@ -102,20 +183,50 @@ class ActionConnector(ABC, T.Generic[CT, OT]):
 @dataclass
 class AgentAction:
     """
-    Base class for agent actions.
+    Comprehensive action definition that encapsulates all metadata and execution
+    components required for an agent to perform a specific action within the system.
+    
+    This dataclass serves as the primary data structure for representing actions
+    that can be executed by autonomous agents. It combines action identification
+    metadata (name and LLM label), type specifications (interface), execution
+    mechanisms (connector), and behavioral configuration (prompt exclusion) into
+    a unified representation. The design enables the action orchestrator to
+    manage and execute actions while maintaining clear separation between action
+    definitions and their concrete implementations.
 
     Parameters
     ----------
     name : str
-        The name of the action.
+        The internal identifier for this action, used for programmatic reference
+        and action lookup within the system. This name should be unique within
+        the action registry and typically follows a snake_case naming convention
+        for consistency with Python coding standards.
     llm_label : str
-        The label used by the LLM for this action.
+        The human-readable label that is presented to the large language model
+        (LLM) when describing this action in natural language contexts. This
+        label is used in prompt generation to enable the LLM to understand and
+        reference the action in conversational interactions, and may differ from
+        the internal name to provide more intuitive descriptions.
     interface : Type[Interface]
-        The interface type for this action.
+        The type specification that defines the input and output type constraints
+        for this action. This parameter accepts a class type (not an instance)
+        that conforms to the Interface generic class structure, establishing
+        compile-time type safety and runtime validation for action inputs and
+        outputs throughout the execution pipeline.
     connector : ActionConnector
-        The connector for this action.
+        The concrete connector instance that provides the implementation mechanism
+        for executing this action. The connector handles the translation between
+        the action abstraction and the underlying execution backend, enabling
+        decoupled action definitions that can be executed across different
+        robotic frameworks and hardware platforms.
     exclude_from_prompt : bool
-        Whether to exclude this action from the prompt.
+        A boolean flag that determines whether this action should be included in
+        the prompt that is presented to the LLM. When set to True, the action
+        will not be listed as an available option in LLM-generated action
+        sequences, effectively making it a system-level action that cannot be
+        directly invoked through conversational interactions. This mechanism
+        enables the implementation of internal actions that support system
+        functionality without exposing them to end users.
     """
 
     name: str


### PR DESCRIPTION
This commit enhances the docstring documentation for the action base classes
in `src/actions/base.py` to provide comprehensive type specifications and
methodological explanations. The improvements include:

- **ActionConfig**: Extended documentation to explain the Pydantic-based
  configuration model architecture and the rationale behind the `extra="allow"`
  design pattern for extensible action-specific parameters.

- **Interface**: Enhanced generic type documentation to clarify the role of
  input and output type parameters in establishing type-safe contracts for
  action execution pipelines.

- **ActionConnector**: Comprehensive documentation of the connector pattern
  implementation, including detailed explanations of the `connect()` method's
  asynchronous connection establishment mechanism and the `tick()` method's
  periodic maintenance operations. Corrected the parameter description for
  `connect()` to accurately reflect the output interface specification.

- **AgentAction**: Detailed documentation of all dataclass parameters,
  explaining the distinction between internal action names and LLM labels,
  the role of interface type specifications, connector instances, and the
  prompt exclusion mechanism for system-level actions.

These documentation improvements facilitate better understanding of the action
system architecture for developers implementing new actions or connectors,
while maintaining consistency with existing project documentation standards.