### PR TITLE
docs: add Rust installation guide for Apple Silicon users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ For MacOS
 brew install portaudio ffmpeg
 ```
 
+For MacOS (Apple Silicon) - If you encounter build errors with `py-sr25519-bindings` or `maturin`:
+```bash
+# Install Rust compiler
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+
 For Linux
 ```bash
 sudo apt-get update


### PR DESCRIPTION
  ## Description

  Add Rust installation instructions for Apple Silicon (M1/M2/M3/M4) Mac users who encounter build errors with `py-sr25519-bindings` or `maturin`.

  Closes #1175

  ## Changes

  - Added troubleshooting section in README.md under "Install Dependencies" for Apple Silicon users
  - Provides Rust compiler installation commands to resolve build errors

  ## Why

  Some Apple Silicon users may encounter build errors when installing dependencies that require Rust compilation (e.g., `py-sr25519-bindings`). While pre-built wheels exist for most Python versions, this guide helps users who face compilation issues.

  ## Testing

  - [x] Documentation change only, no code changes