### PR TITLE
 feat: skip LLM calls when no meaningful inputs are available

### DIFF
--- a/src/fuser/__init__.py
+++ b/src/fuser/__init__.py
@@ -40,7 +40,9 @@ class Fuser:
         self.config = config
         self.io_provider = IOProvider()
 
-    def fuse(self, inputs: list[Sensor], finished_promises: list[T.Any]) -> str:
+    def fuse(
+        self, inputs: list[Sensor], finished_promises: list[T.Any]
+    ) -> T.Optional[str]:
         """
         Combine all inputs into a single formatted prompt string.
 
@@ -56,8 +58,9 @@ class Fuser:
 
         Returns
         -------
-        str
-            Fused prompt string combining all inputs and context.
+        str or None
+            Fused prompt string combining all inputs and context,
+            or None if there are no meaningful inputs to process.
         """
         # Record the timestamp of the input
         self.io_provider.fuser_start_time = time.time()
@@ -69,6 +72,16 @@ class Fuser:
         system_prompt = "\nBASIC CONTEXT:\n" + self.config.system_prompt_base + "\n"
 
         inputs_fused = " ".join([s for s in input_strings if s is not None])
+
+        # Skip LLM call if there are no meaningful inputs
+        # This prevents unnecessary API calls and credit consumption when:
+        # - No camera/microphone is connected
+        # - No sensor data is available
+        # - All input sources return None/empty
+        # See: https://github.com/OpenmindAGI/OM1/issues/1372
+        if not inputs_fused.strip():
+            logging.debug("No meaningful inputs available, skipping LLM call")
+            return None
 
         # if we provide laws from blockchain, these override the locally stored rules
         # the rules are not provided in the system prompt, but as a separate INPUT,

--- a/tests/fuser/test_init.py
+++ b/tests/fuser/test_init.py
@@ -55,10 +55,11 @@ def test_fuser_timestamps(mock_time):
     mock_time.return_value = 1000
     config = create_mock_config()
     io_provider = IOProvider()
+    inputs: list[Sensor[Any, Any]] = [MockSensor()]  # Need valid input to test timestamps
 
     with patch("fuser.IOProvider", return_value=io_provider):
         fuser = Fuser(config)
-        fuser.fuse([], [])
+        fuser.fuse(inputs, [])
         assert io_provider.fuser_start_time == 1000
         assert io_provider.fuser_end_time == 1000
 
@@ -94,3 +95,92 @@ def test_fuser_with_inputs_and_actions(mock_describe):
             io_provider.fuser_available_actions
             == "AVAILABLE ACTIONS:\naction description\n\naction description\n\n\n\nWhat will you do? Actions:"
         )
+
+
+@dataclass
+class MockEmptySensor(Sensor[SensorConfig, Any]):
+    """Mock sensor that returns None (no input available)."""
+
+    def __init__(self):
+        super().__init__(SensorConfig())
+
+    def formatted_latest_buffer(self):
+        return None
+
+
+@dataclass
+class MockEmptyStringSensor(Sensor[SensorConfig, Any]):
+    """Mock sensor that returns empty string."""
+
+    def __init__(self):
+        super().__init__(SensorConfig())
+
+    def formatted_latest_buffer(self):
+        return ""
+
+
+def test_fuser_returns_none_when_no_inputs():
+    """Test that fuser returns None when there are no input sensors.
+
+    This prevents unnecessary LLM API calls when no inputs are available.
+    See: https://github.com/OpenmindAGI/OM1/issues/1372
+    """
+    config = create_mock_config()
+    io_provider = IOProvider()
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse([], [])
+
+        assert result is None
+
+
+def test_fuser_returns_none_when_all_inputs_are_none():
+    """Test that fuser returns None when all sensors return None.
+
+    This prevents unnecessary LLM API calls when sensors have no data.
+    See: https://github.com/OpenmindAGI/OM1/issues/1372
+    """
+    config = create_mock_config()
+    inputs: list[Sensor[Any, Any]] = [MockEmptySensor(), MockEmptySensor()]
+    io_provider = IOProvider()
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(inputs, [])
+
+        assert result is None
+
+
+def test_fuser_returns_none_when_all_inputs_are_empty_strings():
+    """Test that fuser returns None when all sensors return empty strings.
+
+    This prevents unnecessary LLM API calls when sensors return empty data.
+    See: https://github.com/OpenmindAGI/OM1/issues/1372
+    """
+    config = create_mock_config()
+    inputs: list[Sensor[Any, Any]] = [MockEmptyStringSensor()]
+    io_provider = IOProvider()
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(inputs, [])
+
+        assert result is None
+
+
+def test_fuser_returns_prompt_when_at_least_one_input_has_data():
+    """Test that fuser returns prompt when at least one sensor has data.
+
+    Mixed inputs (some None, some with data) should still produce a prompt.
+    """
+    config = create_mock_config()
+    inputs: list[Sensor[Any, Any]] = [MockEmptySensor(), MockSensor()]
+    io_provider = IOProvider()
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(inputs, [])
+
+        assert result is not None
+        assert "test input" in result


### PR DESCRIPTION
Description:

  Summary

  This PR prevents unnecessary LLM API calls and credit consumption when no meaningful inputs are available.

  Fixes #1372

  Problem

  When a robot has no valid input sources (e.g., camera or microphone not connected), the system still continuously calls the LLM API at the frequency configured by hertz, resulting in:

  - Rapid credit consumption - Test users' API credits are quickly depleted
  - Meaningless API calls - The robot is "idling" with no actual input but keeps calling the LLM
  - Resource waste - Network bandwidth and computing resources are wasted

  With default hertz: 1 configuration, a robot without any input sources will consume approximately 3,600 API calls per hour.

  Solution

  Modified src/fuser/__init__.py to return None when inputs_fused is empty. The existing cortex._tick() method already handles None return values to skip the LLM call.

  # Skip LLM call if there are no meaningful inputs
  if not inputs_fused.strip():
      logging.debug("No meaningful inputs available, skipping LLM call")
      return None

  Changes

  - src/fuser/__init__.py - Added check to return None when no meaningful inputs
  - tests/fuser/test_init.py - Added 4 new unit tests for empty input scenarios

  Testing

  All tests pass:
  tests/fuser/test_init.py::test_fuser_returns_none_when_no_inputs PASSED
  tests/fuser/test_init.py::test_fuser_returns_none_when_all_inputs_are_none PASSED
  tests/fuser/test_init.py::test_fuser_returns_none_when_all_inputs_are_empty_strings PASSED
  tests/fuser/test_init.py::test_fuser_returns_prompt_when_at_least_one_input_has_data PASSED

  Impact

  - ✅ Reduces unnecessary API calls
  - ✅ Saves user credits
  - ✅ Backward compatible - does not affect existing functionality