### PR TITLE
fix(zenoh_msgs): add type annotations to idl __init__ module

### DIFF
--- a/src/zenoh_msgs/idl/__init__.py
+++ b/src/zenoh_msgs/idl/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .geographic_msgs import GeoPoint, GeoPointStamped
 from .geometry_msgs import (
     Accel,
@@ -51,7 +53,7 @@ from .status_msgs import (
 )
 from .std_msgs import ColorRGBA, Duration, Header, String, Time, prepare_header
 
-__all__ = [
+__all__: list[str] = [
     # std_msgs
     "Time",
     "Duration",


### PR DESCRIPTION
Added type annotations to the `zenoh_msgs.idl.__init__` module to improve type safety and IDE support.

Changes:
- Added `from __future__ import annotations` import to enable forward references
- Added type annotation `list[str]` to the `__all__` export list

This change enhances static type checking capabilities and provides better IDE autocomplete support for the module's public API.