### PR TITLE
fix(provider): guard v4l2 device detection to linux platforms

### DIFF
--- a/src/providers/unitree_realsense_dev_vlm_provider.py
+++ b/src/providers/unitree_realsense_dev_vlm_provider.py
@@ -2,6 +2,7 @@ import base64
 import glob
 import logging
 import subprocess
+import sys
 import time
 from typing import Callable, List, Optional, Tuple
 
@@ -144,7 +145,7 @@ class UnitreeRealSenseDevVideoStream(VideoStream):
 
         Parameters
         ----------
-        cam : str
+        cam : str or int
             The device path (e.g., '/dev/video0')
 
         Returns
@@ -188,11 +189,19 @@ class UnitreeRealSenseDevVideoStream(VideoStream):
 
         Returns
         -------
-        str or None
+        str or int or None
             The first viable RGB device, or None if none is found.
         """
         if skip_devices is None:
             skip_devices = set()
+
+        if not sys.platform.startswith("linux"):
+            # On non-Linux systems, v4l2-ctl is not available.
+            # Fallback to default camera index 0 if not already skipped.
+            if 0 not in skip_devices:
+                logger.info("Non-Linux platform detected. Defaulting to camera index 0.")
+                return 0
+            return None
 
         try:
             video_devices = sorted(glob.glob("/dev/video*"))


### PR DESCRIPTION
## Overview
This PR addresses a cross-platform compatibility issue in the UnitreeRealSenseDevVideoStream class. Previously, the device discovery logic unconditionally relied on v4l2-ctl, a Linux-specific tool, causing the provider to crash on macOS and Windows environments despite documentation claiming support. This change introduces a platform check to ensure safe execution on non-Linux systems.

## Changes
Modified src/providers/unitree_realsense_dev_vlm_provider.py:
Added a check for sys.platform inside _find_rgb_device.
On non-Linux systems, the method now skips the v4l2-ctl subprocess call and defaults to camera index 0 (if available).
Added logging to inform the user when the non-Linux fallback is triggered.

## Impact
- Stability: Prevents FileNotFoundError and subprocess crashes on macOS and Windows when initializing the VLM provider.
- Usability: Enables developers to run and test the Unitree VLM provider locally on macOS without needing a Linux environment or Docker container for basic camera access.
- Risk: Low. The logic for Linux systems remains effectively unchanged, while non-Linux systems gain a functional fallback.

## Testing:
- Verified that the provider initializes successfully on macOS without raising an exception.
- Confirmed that the default camera (index 0) is selected on macOS.
- Confirmed that Linux behavior remains consistent with previous functionality.

## Additional Information
This fix aligns the code with the class docstring, which states support for "both macOS and Linux devices."