### PR TITLE
fix(cli): surface SyntaxError during component validation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -610,6 +610,9 @@ def _check_class_in_dir(directory: str, class_name: str) -> bool:
                     for node in tree.body:
                         if isinstance(node, ast.ClassDef) and node.name == class_name:
                             return True
+            except SyntaxError as e:
+                print(f"\nWarning: Syntax error parsing {filepath}: {e}")
+                continue
             except Exception:
                 continue
     return False

--- a/tests/runtime/test_cli_validation.py
+++ b/tests/runtime/test_cli_validation.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+from cli import _check_class_in_dir
+
+
+def test_check_class_in_dir_handles_syntax_error(capsys):
+    """
+    Verify that _check_class_in_dir catches SyntaxError in plugin files
+    and logs a warning instead of silently failing or crashing.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # 1. Create a dummy python file with a syntax error (missing colon)
+        bad_file = os.path.join(tmp_dir, "bad_plugin.py")
+        with open(bad_file, "w", encoding="utf-8") as f:
+            f.write("class BrokenPlugin\n    pass")
+
+        # 2. Create a valid plugin file
+        good_file = os.path.join(tmp_dir, "good_plugin.py")
+        with open(good_file, "w", encoding="utf-8") as f:
+            f.write("class ValidPlugin:\n    pass")
+
+        # 3. Check for the valid plugin. The parser should encounter the bad file,
+        #    log a warning, and continue to find the valid plugin.
+        exists = _check_class_in_dir(tmp_dir, "ValidPlugin")
+
+        assert exists is True, "Should find ValidPlugin despite syntax error in sibling file"
+
+        # 4. Verify the warning was printed to stdout
+        captured = capsys.readouterr()
+        assert "Warning: Syntax error parsing" in captured.out
+        assert "bad_plugin.py" in captured.out


### PR DESCRIPTION
## Overview 
This PR improves the validate_config command by explicitly catching and logging SyntaxError when parsing component files. Previously, the AST parser wrapped all exceptions in a broad try...except Exception block, causing syntax errors in plugin files to be silently swallowed. This led to confusing "component not found" errors instead of identifying the actual syntax issue.

## Changes
Modified src/cli.py:
- Added a specific except SyntaxError block in _check_class_in_dir.
The new block prints a warning with the filepath and error details to stdout.
- Added tests/runtime/test_cli_validation.py:
Created a new test file to verify that SyntaxError in a plugin file triggers a warning.
Verifies that valid components in the same directory are still correctly identified despite sibling errors.

## Impac:
- Diagnostics: Users will now see a clear warning if their custom plugin files contain syntax errors, rather than a misleading "not found" error.
- UX: Slightly alters CLI output when an error is found, but ensures critical information is not hidden.
- Risk: Low. The validation logic continues after logging the error, preserving existing behavior for other files.

## Testing:
- Added tests/runtime/test_cli_validation.py.
- Verified that SyntaxError in a dummy .py file triggers the warning during execution.
- Verified that valid files are still correctly identified.

## Aditional Information
This change helps new contributors/users debugging their custom plugins by surfacing python syntax errors immediately during the config validation step.