### PR TITLE
fix: add error handling to DIMO Tesla HTTP requests 

### DIFF
--- a/src/actions/dimo/connector/tesla.py
+++ b/src/actions/dimo/connector/tesla.py
@@ -134,61 +134,79 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
                         f"DIMOTeslaConnector: Error getting DIMO vehicle jwt: {e}"
                     )
                     self.vehicle_jwt = None
-                    return None
+                    return
 
             if self.vehicle_jwt is not None:
                 if output_interface.action == "lock doors":
                     url = f"{self.base_url}/{self.token_id}/commands/doors/lock"
-                    response = requests.post(
-                        url,
-                        headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
-                        timeout=10,
-                    )
-                    if response.status_code == 200:
-                        logging.info("DIMO Tesla: Door locked")
-                    else:
-                        logging.error(
-                            f"Error locking door: {response.status_code} {response.text}"
+                    try:
+                        response = requests.post(
+                            url,
+                            headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
+                            timeout=10,
                         )
+                        if response.status_code == 200:
+                            logging.info("DIMO Tesla: Door locked")
+                        else:
+                            logging.error(
+                                f"Error locking door: {response.status_code} {response.text}"
+                            )
+                    except requests.exceptions.RequestException as e:
+                        logging.error(f"DIMOTeslaConnector: Failed to lock doors: {e}")
+
                 elif output_interface.action == "unlock doors":
                     url = f"{self.base_url}/{self.token_id}/commands/doors/unlock"
-                    response = requests.post(
-                        url,
-                        headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
-                        timeout=10,
-                    )
-                    if response.status_code == 200:
-                        logging.info("DIMO Tesla: Door unlocked")
-                    else:
-                        logging.error(
-                            f"Error unlocking door: {response.status_code} {response.text}"
+                    try:
+                        response = requests.post(
+                            url,
+                            headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
+                            timeout=10,
                         )
+                        if response.status_code == 200:
+                            logging.info("DIMO Tesla: Door unlocked")
+                        else:
+                            logging.error(
+                                f"Error unlocking door: {response.status_code} {response.text}"
+                            )
+                    except requests.exceptions.RequestException as e:
+                        logging.error(
+                            f"DIMOTeslaConnector: Failed to unlock doors: {e}"
+                        )
+
                 elif output_interface.action == "open frunk":
                     url = f"{self.base_url}/{self.token_id}/commands/frunk/open"
-                    response = requests.post(
-                        url,
-                        headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
-                        timeout=10,
-                    )
-                    if response.status_code == 200:
-                        logging.info("DIMO Tesla: Frunk opened")
-                    else:
-                        logging.error(
-                            f"Error opening frunk: {response.status_code} {response.text}"
+                    try:
+                        response = requests.post(
+                            url,
+                            headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
+                            timeout=10,
                         )
+                        if response.status_code == 200:
+                            logging.info("DIMO Tesla: Frunk opened")
+                        else:
+                            logging.error(
+                                f"Error opening frunk: {response.status_code} {response.text}"
+                            )
+                    except requests.exceptions.RequestException as e:
+                        logging.error(f"DIMOTeslaConnector: Failed to open frunk: {e}")
+
                 elif output_interface.action == "open trunk":
                     url = f"{self.base_url}/{self.token_id}/commands/trunk/open"
-                    response = requests.post(
-                        url,
-                        headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
-                        timeout=10,
-                    )
-                    if response.status_code == 200:
-                        logging.info("DIMO Tesla: Trunk opened")
-                    else:
-                        logging.error(
-                            f"Error opening trunk: {response.status_code} {response.text}"
+                    try:
+                        response = requests.post(
+                            url,
+                            headers={"Authorization": f"Bearer {self.vehicle_jwt}"},
+                            timeout=10,
                         )
+                        if response.status_code == 200:
+                            logging.info("DIMO Tesla: Trunk opened")
+                        else:
+                            logging.error(
+                                f"Error opening trunk: {response.status_code} {response.text}"
+                            )
+                    except requests.exceptions.RequestException as e:
+                        logging.error(f"DIMOTeslaConnector: Failed to open trunk: {e}")
+
                 elif output_interface.action == "idle":
                     logging.info("DIMO Tesla: Idle")
                 else:


### PR DESCRIPTION
## Summary
Adds try/except error handling to prevent crashes from network errors.

## Bug
Network errors (ConnectionError, Timeout) from `requests.post()` are not caught, causing the connector to crash.

## Fix
Wrap all 4 HTTP requests in try/except blocks to handle errors gracefully.

## Changes
- 1 file: `src/actions/dimo/connector/tesla.py`