### PR TITLE
feat: add persist and reload conversation history to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ logs/
 # Mode system state files
 config/memory
 config/.runtime.json5
+
+# local runtime history
+.om1/

--- a/src/history_store.py
+++ b/src/history_store.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_history(path: str) -> List[Dict[str, Any]]:
+    """
+    Load conversation history from a JSONL file.
+    Each line is one JSON object.
+    If the file doesn't exist, return an empty list.
+    Corrupted lines are skipped safely.
+    """
+    p = Path(path)
+    if not p.exists():
+        return []
+
+    messages: List[Dict[str, Any]] = []
+    with p.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                messages.append(json.loads(line))
+            except Exception:
+                continue
+    return messages
+
+
+def append_message(path: str, message: Dict[str, Any]) -> None:
+    """
+    Append a single message to a JSONL history file.
+    """
+    p = Path(path)
+    _ensure_parent_dir(p)
+    with p.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(message, ensure_ascii=False) + "\n")
+
+
+def default_history_path() -> str:
+    """
+    Default history file location:
+    .om1/history/conversation_history.jsonl
+    """
+    return str(Path(".om1") / "history" / "conversation_history.jsonl")

--- a/src/providers/teleops_conversation_provider.py
+++ b/src/providers/teleops_conversation_provider.py
@@ -3,11 +3,19 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, Any, Dict, List
 
 import requests
 
 from .singleton import singleton
+
+# --- NEW: disk persistence helpers ---
+# The repo seems to treat "src/" as the python path, so "history_store" is usually importable directly.
+# This fallback keeps it working in different execution modes.
+try:
+    from history_store import load_history, append_message, default_history_path
+except Exception:  # pragma: no cover
+    from ..history_store import load_history, append_message, default_history_path
 
 
 class MessageType(Enum):
@@ -70,6 +78,10 @@ class ConversationMessage:
 class TeleopsConversationProvider:
     """
     Singleton class to manage conversation messages with a Teleops backend.
+
+    NEW:
+    - Persist messages locally to a JSONL file on disk
+    - Reload existing history on startup (if present)
     """
 
     def __init__(
@@ -80,6 +92,10 @@ class TeleopsConversationProvider:
         self.api_key = api_key
         self.base_url = base_url
         self.executor = ThreadPoolExecutor(max_workers=1)
+
+        # --- NEW: persistent conversation history (disk) ---
+        self.history_path = default_history_path()
+        self.disk_history: List[Dict[str, Any]] = load_history(self.history_path)
 
     def store_user_message(self, content: str) -> None:
         """
@@ -113,6 +129,25 @@ class TeleopsConversationProvider:
         )
         self._store_message(message)
 
+    def _to_disk_record(self, message: ConversationMessage) -> Dict[str, Any]:
+        """
+        Convert internal message to a disk-friendly record.
+        """
+        role = "assistant" if message.message_type == MessageType.ROBOT else "user"
+        return {
+            "role": role,
+            "content": message.content,
+            "timestamp": message.timestamp,
+        }
+
+    def _persist_to_disk(self, message: ConversationMessage) -> None:
+        """
+        Persist message to JSONL on disk (append-only).
+        """
+        record = self._to_disk_record(message)
+        append_message(self.history_path, record)
+        self.disk_history.append(record)
+
     def _store_message_worker(self, message: ConversationMessage) -> None:
         """
         Worker method to store a conversation message via HTTP POST.
@@ -122,12 +157,23 @@ class TeleopsConversationProvider:
         message : ConversationMessage
             The conversation message to store.
         """
-        if self.api_key is None or self.api_key == "":
-            logging.debug("API key is missing. Cannot store conversation message.")
-            return
-
         if not message.content or not message.content.strip():
             logging.debug("Empty content, skipping conversation storage")
+            return
+
+        # --- NEW: always persist locally so history survives restarts ---
+        # This ensures "save to disk and reload if exists" works even if:
+        # - API key is missing
+        # - network is down
+        # - backend returns non-200
+        try:
+            self._persist_to_disk(message)
+        except Exception as e:
+            logging.debug(f"Error persisting conversation history to disk: {str(e)}")
+
+        # Existing behavior: attempt remote storage only if API key exists
+        if self.api_key is None or self.api_key == "":
+            logging.debug("API key is missing. Skipping remote conversation storage.")
             return
 
         try:
@@ -161,6 +207,14 @@ class TeleopsConversationProvider:
             The conversation message to store.
         """
         self.executor.submit(self._store_message_worker, message)
+
+    def get_history(self, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """
+        Return locally persisted history (loaded on startup + appended as messages arrive).
+        """
+        if limit is None:
+            return list(self.disk_history)
+        return list(self.disk_history[-limit:])
 
     def is_enabled(self) -> bool:
         """


### PR DESCRIPTION
## Overview
This pull request adds disk persistence for teleops conversation history. Conversation messages are now saved locally to an append-only JSONL file and automatically reloaded on startup if the file exists. This enables conversations to persist across process restarts without altering existing agent or action behavior.

## Type of change
- [x] New feature
- [x] Bounty issue submission

## Changes
- Added a lightweight file-based persistence helper (`src/history_store.py`) for loading and appending conversation history using JSON Lines (JSONL).
- Updated `TeleopsConversationProvider` to load existing conversation history from disk during initialization.
- Persisted all user and robot messages to disk in an append-only format.
- Preserved existing Teleops backend behavior with no changes to remote API interactions.
- Ignored local runtime history directory (`.om1/`) via `.gitignore`.

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Local testing completed

## Impact
This change enables persistent conversation memory across restarts while keeping runtime behavior unchanged. It introduces no new dependencies and limits side effects to local file I/O under `.om1/history/`.

## Additional Information
Conversation history is stored at `.om1/history/conversation_history.jsonl` in JSONL format and is automatically reloaded on startup if present.
