### PR TITLE
docs: add macOS camera permission requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ For MacOS
 brew install portaudio ffmpeg
 ```
 
+
+```md
+### macOS Camera Permission (Required)
+
+On macOS, OM1 requires camera access for vision-based features.
+
+1. Open **System Settings → Privacy & Security → Camera**
+2. Enable camera access for your terminal application (Terminal / iTerm)
+3. Restart OM1 after granting permission
+
+If camera access is denied, vision modules may fail to initialize.
+
 For Linux
 ```bash
 sudo apt-get update


### PR DESCRIPTION
## Overview
Added instructions for macOS camera permission under the MacOS dependencies section in README.md.  
This ensures OM1’s vision-based features work properly on macOS.

(Linked issue: #1177)

## Type of change
- [x] Documentation improvement

## Changes
- Added "macOS Camera Permission (Required)" section to README.md  
- Step-by-step instructions for enabling camera access in macOS  

## Checklist
- [x] Documentation updated
- [x] Self-review completed

## Impact
Low — only updates documentation. No code changes.  
Helps users avoid vision module initialization issues on macOS.

## Additional Information
Fixes issue #1177.

