### PR TITLE
Fix: Thread safe singleton lock initialization in AvatarLLMState

### DIFF
--- a/src/providers/avatar_llm_state_provider.py
+++ b/src/providers/avatar_llm_state_provider.py
@@ -15,12 +15,10 @@ class AvatarLLMState:
     """
 
     _instance = None
-    _lock = None
+    _lock = threading.Lock()
 
     def __new__(cls):
         if cls._instance is None:
-            if cls._lock is None:
-                cls._lock = threading.Lock()
 
             with cls._lock:
                 if cls._instance is None:


### PR DESCRIPTION
## Summary

Fixes a threading race condition in the `AvatarLLMState` singleton pattern that could allow multiple instances to be created in concurrent environments.

## Problem

The lazy initialization of `_lock` creates a race condition when multiple threads simultaneously access the singleton for the first time:

**Current code (has bug):**
```python
class AvatarLLMState:
    _instance = None
    _lock = None  # Lazy initialization
    
    def __new__(cls):
        if cls._instance is None:
            if cls._lock is None:  # ⚠️ Race condition here
                cls._lock = threading.Lock()
            with cls._lock:
                if cls._instance is None:
                    cls._instance = super().__new__(cls)
```

**Race condition timeline:**
```
Thread A (t=0): Check cls._lock is None → TRUE
Thread B (t=1): Check cls._lock is None → TRUE (still None!)
Thread A (t=2): cls._lock = threading.Lock()  # Creates Lock #1
Thread B (t=3): cls._lock = threading.Lock()  # Creates Lock #2, overwrites #1
Thread A (t=4): with Lock #1: ...
Thread B (t=5): with Lock #2: ...
Result: Different locks used → singleton protection fails
```

This is a classic **TOCTOU (Time-Of-Check-Time-Of-Use)** bug in concurrent programming.

## Solution

Move `_lock` initialization to class level for thread-safe eager initialization:
```python
class AvatarLLMState:
    _instance = None
    _lock = threading.Lock()  # ✅ Thread-safe initialization
    
    def __new__(cls):
        if cls._instance is None:
            # Removed lazy initialization check
            with cls._lock:
                if cls._instance is None:
                    cls._instance = super().__new__(cls)
```

**Why this is safe:**
- Python's GIL guarantees class level attribute initialization is atomic
- `_lock` is created exactly once during module import
- No check then create pattern = no race condition
- Follows Python threading best practices

## Changes Made

**File:** `src/providers/avatar_llm_state_provider.py`

**Line ~18:** Changed lock initialization
```diff
  class AvatarLLMState:
      _instance = None
-     _lock = None
+     _lock = threading.Lock()
```

**Line ~25-26:** Removed `cls._lock`
```diff
  def __new__(cls):
      if cls._instance is None:
-         if cls._lock is None:
-             cls._lock = threading.Lock()
-
          with cls._lock:
              if cls._instance is None:
```

**Total changes:** 3 lines (1 modified, 2 deleted)

## Impact

**Why this matters in OM1:**
- Multiple sensors/inputs (camera, voice, LIDAR) trigger avatar state changes concurrently
- Race condition could create duplicate `AvatarLLMState` instances
- Consequences:
  - Inconsistent avatar animation states (e.g., "Think" vs "Happy" conflicts)
  - Unpredictable behavior in multi-threaded robotics environment

**Risk level:** Low
- No API changes
- No behavior changes for existing code
- Purely internal fix following Python best practices

## Testing

- ✅ Existing unit tests should pass without modification
- ✅ Singleton pattern now thread-safe in all scenarios
- ✅ No external API changes

## References

- [Python threading documentation](https://docs.python.org/3/library/threading.html#lock-objects)
- [Singleton pattern with threading](https://refactoring.guru/design-patterns/singleton/python/example)