### PR TITLE
fix: wrap long lines in providers/ to comply with E501 (88 chars)

### DIFF
--- a/src/providers/asr_provider.py
+++ b/src/providers/asr_provider.py
@@ -10,11 +10,12 @@ from .singleton import singleton
 @singleton
 class ASRProvider:
     """
-    Audio Speech Recognition Provider that handles audio streaming and websocket communication.
+    Audio Speech Recognition Provider that handles audio streaming
+    and websocket communication.
 
-    This class implements a singleton pattern to manage audio input streaming and websocket
-    communication for speech recognition services. It runs in a separate thread to handle
-    continuous audio processing.
+    This class implements a singleton pattern to manage audio input streaming
+    and websocket communication for speech recognition services.
+    It runs in a separate thread to handle continuous audio processing.
     """
 
     def __init__(
@@ -45,7 +46,8 @@ class ASRProvider:
         chunk : int
             The audio chunk size for the audio stream; used the 200ms default if None
         language_code : str
-            The language code for language in the audio stream; used the en-US default if None
+            The language code for language in the audio stream;
+            used the en-US default if None
         remote_input : bool
             If True, the audio input is processed remotely; defaults to False.
         enable_tts_interrupt : bool
@@ -111,7 +113,8 @@ class ASRProvider:
         """
         Stop the ASR provider.
 
-        Stops the audio stream and websocket clients, and sets the running state to False.
+        Stops the audio stream and websocket clients,
+        and sets the running state to False.
         """
         self.running = False
         self.audio_stream.stop()

--- a/src/providers/asr_rtsp_provider.py
+++ b/src/providers/asr_rtsp_provider.py
@@ -10,11 +10,12 @@ from .singleton import singleton
 @singleton
 class ASRRTSPProvider:
     """
-    Audio Speech Recognition Provider that handles RTSP audio streaming and websocket communication.
+    Audio Speech Recognition Provider that handles RTSP audio streaming
+    and websocket communication.
 
-    This class implements a singleton pattern to manage audio input streaming and websocket
-    communication for speech recognition services. It runs in a separate thread to handle
-    continuous audio processing.
+    This class implements a singleton pattern to manage audio input streaming
+    and websocket communication for speech recognition services.
+    It runs in a separate thread to handle continuous audio processing.
     """
 
     def __init__(
@@ -40,7 +41,8 @@ class ASRRTSPProvider:
         chunk : int
             The audio chunk size for the audio stream; used the 200ms default if None
         language_code : str
-            The language code for language in the audio stream; used the en-US default if None
+            The language code for language in the audio stream;
+            used the en-US default if None
         enable_tts_interrupt : bool
             If True, enables TTS interrupt.
         """
@@ -88,7 +90,8 @@ class ASRRTSPProvider:
         """
         Stop the ASR provider.
 
-        Stops the audio stream and websocket clients, and sets the running state to False.
+        Stops the audio stream and websocket clients,
+        and sets the running state to False.
         """
         if not self.running:
             logging.warning("ASR RTSP provider is not running")

--- a/src/providers/context_provider.py
+++ b/src/providers/context_provider.py
@@ -47,7 +47,8 @@ class ContextProvider:
         Parameters
         ----------
         context : Dict[str, Any]
-            The context information to update. This will be merged with existing context.
+            The context information to update.
+            This will be merged with existing context.
         """
         if not self.publisher:
             logging.warning("ContextProvider not initialized, cannot update context")

--- a/src/providers/elevenlabs_tts_provider.py
+++ b/src/providers/elevenlabs_tts_provider.py
@@ -21,9 +21,11 @@ class ElevenLabsTTSProvider:
     api_key : str
         The API key for the TTS service
     voice_id : str, optional
-        The name of the voice for Eleven Labs TTS service (default is JBFqnCBsd6RMkjVDRZzb)
+        The name of the voice for Eleven Labs TTS service
+        (default is JBFqnCBsd6RMkjVDRZzb)
     model_id : str, optional
-        The name of the model for Eleven Labs TTS service (default is eleven_multilingual
+        The name of the model for Eleven Labs TTS service
+        (default is eleven_multilingual)
     output_format : str, optional
         The output format for the audio stream (default is mp3_44100_128)
     """

--- a/src/providers/fabric_map_provider.py
+++ b/src/providers/fabric_map_provider.py
@@ -206,8 +206,9 @@ class FabricDataSubmitter:
 
     def write_dict_to_file(self, data: dict):
         """
-        Writes a dictionary to a file in JSON lines format. If the file exceeds max_file_size_bytes,
-        creates a new file with a timestamp.
+        Writes a dictionary to a file in JSON lines format.
+        If the file exceeds max_file_size_bytes, creates a new file
+        with a timestamp.
 
         Parameters
         ----------
@@ -274,8 +275,8 @@ class FabricDataSubmitter:
     def share_data(self, data: FabricData):
         """
         Share mapping data.
-        This function submits mapping data collected by a machine to a thread pool executor
-        to run in a separate thread.
+        This function submits mapping data collected by a machine to a
+        thread pool executor to run in a separate thread.
 
         Parameters
         ----------

--- a/src/providers/face_presence_provider.py
+++ b/src/providers/face_presence_provider.py
@@ -220,7 +220,8 @@ class FacePresenceProvider:
         Parameters
         ----------
         text : str
-            A concise, human-readable snapshot (e.g., "present=[alice], unknown=0, ts=...").
+            A concise, human-readable snapshot
+            (e.g., "present=[alice], unknown=0, ts=...").
         """
         with self._cb_lock:
             callbacks = list(self._callbacks)
@@ -275,7 +276,8 @@ class FacePresenceProvider:
                 ):
                     unknown_faces = 0  # suppress brief/rare unknowns
                 else:
-                    unknown_faces = unknown_peak  # report the maximum unknown seen in any single frame
+                    # report the maximum unknown seen in any single frame
+                    unknown_faces = unknown_peak
             else:
                 now = data.get("now", []) or []
                 seen, names_fallback = set(), []
@@ -304,5 +306,5 @@ class FacePresenceProvider:
 
     @property
     def unknown_faces(self) -> int:
-        """Most recent (suppressed) count of unknown faces detected in the lookback window."""
+        """Most recent (suppressed) count of unknown faces in the lookback window."""
         return self._unknown_faces

--- a/src/providers/gps_provider.py
+++ b/src/providers/gps_provider.py
@@ -17,17 +17,18 @@ class GpsProvider:
     """
     GPS Provider for managing GPS, magnetometer, and BLE data from serial connection.
 
-    This class implements a singleton pattern to manage GPS data acquisition from a serial
-    port connection (typically connected to an Arduino-based GPS module). It handles:
+    This class implements a singleton pattern to manage GPS data acquisition
+    from a serial port connection (typically connected to an Arduino-based
+    GPS module). It handles:
         * GPS position data (latitude, longitude, altitude)
         * Satellite information and fix quality
         * Magnetometer heading data
         * BLE (Bluetooth Low Energy) scan data for triangulation
         * Real-time data processing in a background thread
 
-    The provider automatically starts a background thread upon initialization to continuously
-    read and process incoming serial data. GPS data is updated in real-time and can be accessed
-    through the `data` property.
+    The provider automatically starts a background thread upon initialization
+    to continuously read and process incoming serial data. GPS data is updated
+    in real-time and can be accessed through the `data` property.
     """
 
     def __init__(self, serial_port: str = ""):
@@ -157,7 +158,8 @@ class GpsProvider:
 
                     logging.debug(
                         (
-                            f"Current location is {self.lat}, {self.lon} at {alt}m altitude. "
+                            f"Current location is {self.lat}, {self.lon} "
+                            f"at {alt}m altitude. "
                             f"GPS Heading {heading}° with {sat} satellites locked. "
                             f"The unix timestamp is {self.gps_unix_ts}. "
                             f"The fix quality is {self.qua}."

--- a/src/providers/io_provider.py
+++ b/src/providers/io_provider.py
@@ -377,7 +377,8 @@ class IOProvider:
     @contextmanager
     def mode_transition_input(self):
         """
-        Context manager for providing mode transition input that automatically resets after use.
+        Context manager for providing mode transition input.
+        Automatically resets after use.
 
         Yields
         ------

--- a/src/providers/llm_history_manager.py
+++ b/src/providers/llm_history_manager.py
@@ -39,8 +39,19 @@ class LLMHistoryManager:
         self,
         config: LLMConfig,
         client: Union[openai.AsyncClient, openai.OpenAI],
-        system_prompt: str = "You are a helpful assistant that summarizes a succession of events and interactions accurately and concisely. You are watching a robot named **** interact with people and the world. Your goal is to help **** remember what the robot felt, saw, and heard, and how the robot responded to those inputs.",
-        summary_command: str = "\nConsidering the new information, write an updated summary of the situation for ****. Emphasize information that **** needs to know to respond to people and situations in the best possible and most compelling way.",
+        system_prompt: str = (
+            "You are a helpful assistant that summarizes a succession of events "
+            "and interactions accurately and concisely. You are watching a robot "
+            "named **** interact with people and the world. Your goal is to help "
+            "**** remember what the robot felt, saw, and heard, and how the robot "
+            "responded to those inputs."
+        ),
+        summary_command: str = (
+            "\nConsidering the new information, write an updated summary of the "
+            "situation for ****. Emphasize information that **** needs to know to "
+            "respond to people and situations in the best possible and most "
+            "compelling way."
+        ),
     ):
         """
         Initialize the LLMHistoryManager.

--- a/src/providers/odom_provider.py
+++ b/src/providers/odom_provider.py
@@ -19,7 +19,8 @@ try:
     from unitree.unitree_sdk2py.idl.geometry_msgs.msg.dds_ import PoseStamped_
 except ImportError:
     logging.warning(
-        "Unitree SDK or CycloneDDS not found. You do not need this unless you are connecting to a Unitree robot."
+        "Unitree SDK or CycloneDDS not found. You do not need this "
+        "unless you are connecting to a Unitree robot."
     )
 
 from zenoh_msgs import (
@@ -69,7 +70,8 @@ def odom_processor(
         If True, get odom/pose data from Zenoh (typically used by TurtleBot4).
         Otherwise, use CycloneDDS (e.g., for Unitree Go2).
     logging_config : LoggingConfig, optional
-        Optional logging configuration. If provided, it will override the default logging settings.
+        Optional logging configuration. If provided, it will override
+        the default logging settings.
     """
     setup_logging("odom_processor", logging_config=logging_config)
 
@@ -294,8 +296,8 @@ class OdomProvider:
             pose = pose_data.pose
             header = pose_data.header
 
-            # this is the time according to the RockChip. It may be off by several seconds from
-            # UTC
+            # this is the time according to the RockChip.
+            # It may be off by several seconds from UTC
             self.odom_rockchip_ts = header.stamp.sec + header.stamp.nanosec * 1e-9
 
             # The local timestamp
@@ -358,7 +360,8 @@ class OdomProvider:
             self.x = round(pose.position.x, 4)
             self.y = round(pose.position.y, 4)
             logging.debug(
-                f"odom: X:{self.x} Y:{self.y} W:{self.odom_yaw_m180_p180} H:{self.odom_yaw_0_360} T:{self.odom_rockchip_ts}"
+                f"odom: X:{self.x} Y:{self.y} W:{self.odom_yaw_m180_p180} "
+                f"H:{self.odom_yaw_0_360} T:{self.odom_rockchip_ts}"
             )
 
     @property
@@ -375,11 +378,15 @@ class OdomProvider:
             - x: The x coordinate of the robot in the world frame.
             - y: The y coordinate of the robot in the world frame.
             - moving: A boolean indicating if the robot is currently moving.
-            - odom_yaw_0_360: The yaw angle of the robot in degrees, ranging from 0 to 360.
+            - odom_yaw_0_360: The yaw angle of the robot in degrees,
+              ranging from 0 to 360.
             - body_height_cm: The height of the robot's body in centimeters.
-            - body_attitude: The current attitude of the robot (e.g., sitting or standing).
-            - odom_rockchip_ts: The unix timestamp of the last odometry update. Provided by the CycloneDDS publisher.
-            - odom_subscriber_ts: The unix timestamp of the last odometry update according to the subscriber.
+            - body_attitude: The current attitude of the robot
+              (e.g., sitting or standing).
+            - odom_rockchip_ts: The unix timestamp of the last odometry update.
+              Provided by the CycloneDDS publisher.
+            - odom_subscriber_ts: The unix timestamp of the last odometry update
+              according to the subscriber.
         """
         return {
             "odom_x": self.x,

--- a/src/providers/rplidar_provider.py
+++ b/src/providers/rplidar_provider.py
@@ -64,7 +64,8 @@ def rplidar_processor(
     config : Dict
         Configuration dictionary containing parameters for the RPLidar.
     logging_config : Optional[LoggingConfig]
-        Optional logging configuration. If provided, it will override the default logging settings.
+        Optional logging configuration. If provided, it will override
+        the default logging settings.
     """
     setup_logging("rplidar_processor", logging_config=logging_config)
 
@@ -237,7 +238,8 @@ class RPLidarProvider:
 
         # Initialize paths for path planning
         # Define 9 straight line paths separated by 15 degrees
-        # Center path is 0° (straight forward), then ±15°, ±30°, ±45°, ±60°, 180° (backwards)
+        # Center path is 0° (straight forward), then ±15°, ±30°, ±45°,
+        # ±60°, 180° (backwards)
         self.path_angles = [-60, -45, -30, -15, 0, 15, 30, 45, 60, 180]
         self.paths = self._initialize_paths()
 
@@ -265,7 +267,8 @@ class RPLidarProvider:
 
                 if self.machine_type == "tb4":
                     logging.info(
-                        f"{self.machine_type} RPLIDAR listener starting with URID: {self.URID}"
+                        f"{self.machine_type} RPLIDAR listener starting "
+                        f"with URID: {self.URID}"
                     )
                     self.zen.declare_subscriber(
                         f"{self.URID}/pi/scan", self.listen_scan
@@ -277,7 +280,8 @@ class RPLidarProvider:
 
                 if self.machine_type != "tb4" and self.machine_type != "go2":
                     raise ValueError(
-                        f"Unsupported machine type: {self.machine_type}. Supported types are 'tb4' and 'go2'."
+                        f"Unsupported machine type: {self.machine_type}. "
+                        "Supported types are 'tb4' and 'go2'."
                     )
 
             except Exception as e:
@@ -298,8 +302,9 @@ class RPLidarProvider:
 
     def write_str_to_file(self, json_line: str):
         """
-        Writes a dictionary to a file in JSON lines format. If the file exceeds max_file_size_bytes,
-        creates a new file with a timestamp.
+        Writes a dictionary to a file in JSON lines format.
+        If the file exceeds max_file_size_bytes, creates a new file
+        with a timestamp.
 
         Parameters
         ----------
@@ -339,7 +344,8 @@ class RPLidarProvider:
     def start(self):
         """
         Start the RPLidar provider.
-        This method initializes the RPLidar processing thread and the serial data processing thread.
+        This method initializes the RPLidar processing thread
+        and the serial data processing thread.
         """
         self.running = True
 
@@ -387,7 +393,10 @@ class RPLidarProvider:
         if scan is None:
             logging.info("Waiting for Zenoh Laserscan data...")
             self._raw_scan = None
-            self._lidar_string = "You might be surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
+            self._lidar_string = (
+                "You might be surrounded by objects and cannot safely move "
+                "in any direction. DO NOT MOVE."
+            )
             self._valid_paths = []
         else:
             # logging.debug(f"_preprocess_zenoh: {scan}")
@@ -507,9 +516,9 @@ class RPLidarProvider:
                 logging.error(f"Error saving rplidar to file: {str(e)}")
 
         # sort data into strictly increasing angles to deal with sensor issues
-        # the sensor sometimes reports part of the previous scan and part of the next scan
-        # so you end up with multiple slightly different values for some angles at the
-        # junction
+        # the sensor sometimes reports part of the previous scan and part of
+        # the next scan so you end up with multiple slightly different values
+        # for some angles at the junction
 
         """
         Determine set of possible paths
@@ -592,7 +601,8 @@ class RPLidarProvider:
         self._valid_paths = ppl
 
         logging.debug(
-            f"RPLidar Provider string: {self._lidar_string}\nValid paths: {self._valid_paths}"
+            f"RPLidar Provider string: {self._lidar_string}\n"
+            f"Valid paths: {self._valid_paths}"
         )
 
     def _serial_processor(self):
@@ -764,8 +774,10 @@ class RPLidarProvider:
     ) -> float:
         """
         Calculate the distance from a point to a line segment.
-        This method computes the shortest distance from a point (px, py) to a line segment defined by two endpoints (x1, y1) and (x2, y2).
-        If the line segment has zero length, it returns the distance from the point to one of the endpoints.
+        This method computes the shortest distance from a point (px, py) to
+        a line segment defined by two endpoints (x1, y1) and (x2, y2).
+        If the line segment has zero length, it returns the distance from
+        the point to one of the endpoints.
 
         Parameters
         ----------
@@ -786,7 +798,8 @@ class RPLidarProvider:
         -------
         float
             The shortest distance from the point to the line segment.
-            If the line segment has zero length, it returns the distance to the closest endpoint.
+            If the line segment has zero length, it returns the distance
+            to the closest endpoint.
         """
         dx = x2 - x1
         dy = y2 - y1
@@ -795,7 +808,8 @@ class RPLidarProvider:
         if dx == 0 and dy == 0:
             return math.sqrt((px - x1) ** 2 + (py - y1) ** 2)
 
-        # Calculate the parameter t that represents the projection of the point onto the line
+        # Calculate the parameter t that represents the projection of the point
+        # onto the line
         t = ((px - x1) * dx + (py - y1) * dy) / (dx * dx + dy * dy)
 
         # Clamp t to [0, 1] to stay within the line segment
@@ -823,7 +837,10 @@ class RPLidarProvider:
             A string describing the safe movement directions based on the valid paths.
         """
         if not valid_paths:
-            return "You are surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
+            return (
+                "You are surrounded by objects and cannot safely move "
+                "in any direction. DO NOT MOVE."
+            )
 
         parts = ["The safe movement directions are: {"]
 

--- a/src/providers/rtk_provider.py
+++ b/src/providers/rtk_provider.py
@@ -123,8 +123,9 @@ class RtkProvider:
 
             # NMEA-GN-GGA
             # Description:
-            # Standard NMEA: Global positioning system fix data. This message contains time, date,
-            # position (in LLH coordinates), fix quality, number of satellites, and horizontal dilution of
+            # Standard NMEA: Global positioning system fix data.
+            # This message contains time, date, position (in LLH coordinates),
+            # fix quality, number of satellites, and horizontal dilution of
             # precision (HDOP) data provided by the selected source.
 
             if msg and msg.msgID == "GGA":

--- a/src/providers/simple_paths_provider.py
+++ b/src/providers/simple_paths_provider.py
@@ -197,7 +197,10 @@ class SimplePathsProvider:
             A string describing the safe movement directions based on the valid paths.
         """
         if not valid_paths:
-            return "You are surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
+            return (
+                "You are surrounded by objects and cannot safely move "
+                "in any direction. DO NOT MOVE."
+            )
 
         parts = ["The safe movement directions are: {"]
 

--- a/src/providers/sleep_ticker_provider.py
+++ b/src/providers/sleep_ticker_provider.py
@@ -8,7 +8,8 @@ from .singleton import singleton
 @singleton
 class SleepTickerProvider:
     """
-    A singleton provider for managing asynchronous sleep operations with cancellation support.
+    A singleton provider for managing asynchronous sleep operations
+    with cancellation support.
 
     This class provides a thread-safe way to manage sleep operations that can be
     skipped/cancelled. It uses a lock mechanism to ensure thread safety when

--- a/src/providers/teleops_conversation_provider.py
+++ b/src/providers/teleops_conversation_provider.py
@@ -151,15 +151,18 @@ class TeleopsConversationProvider:
 
             if request.status_code == 200:
                 logging.debug(
-                    f"Successfully stored {message.message_type.value} message to conversation"
+                    f"Successfully stored {message.message_type.value} "
+                    "message to conversation"
                 )
             else:
                 logging.debug(
-                    f"Failed to store {message.message_type.value} message: {request.status_code} - {request.text}"
+                    f"Failed to store {message.message_type.value} message: "
+                    f"{request.status_code} - {request.text}"
                 )
         except Exception as e:
             logging.debug(
-                f"Error storing {message.message_type.value} conversation message: {str(e)}"
+                f"Error storing {message.message_type.value} "
+                f"conversation message: {str(e)}"
             )
 
     def _store_message(self, message: ConversationMessage) -> None:

--- a/src/providers/turtlebot4_camera_vlm_provider.py
+++ b/src/providers/turtlebot4_camera_vlm_provider.py
@@ -73,7 +73,8 @@ class TurtleBot4CameraVideoStream(VideoStream):
             self.session = open_zenoh_session()
             topic = f"{URID}/pi/oakd/rgb/preview/image_raw"
             logging.info(
-                f"TurtleBot4 Camera listener starting with URID: {URID} and topic: {topic}"
+                f"TurtleBot4 Camera listener starting with URID: {URID} "
+                f"and topic: {topic}"
             )
             self.camera = self.session.declare_subscriber(topic, self.camera_listener)
             logging.info("Zenoh TurtleBot4 Camera subscriber created")

--- a/src/providers/vlm_gemini_provider.py
+++ b/src/providers/vlm_gemini_provider.py
@@ -72,7 +72,10 @@ class VLMGeminiProvider:
                         "content": [
                             {
                                 "type": "text",
-                                "text": "What is the most interesting aspect in this series of images?",
+                                "text": (
+                                    "What is the most interesting aspect "
+                                    "in this series of images?"
+                                ),
                             },
                             {
                                 "type": "image_url",

--- a/src/providers/vlm_openai_provider.py
+++ b/src/providers/vlm_openai_provider.py
@@ -72,7 +72,10 @@ class VLMOpenAIProvider:
                         "content": [
                             {
                                 "type": "text",
-                                "text": "What is the most interesting aspect in this series of images?",
+                                "text": (
+                                    "What is the most interesting aspect "
+                                    "in this series of images?"
+                                ),
                             },
                             {
                                 "type": "image_url",

--- a/src/providers/vlm_openai_rtsp_provider.py
+++ b/src/providers/vlm_openai_rtsp_provider.py
@@ -16,8 +16,8 @@ class VLMOpenAIRTSPProvider:
     """
     VLM Provider that handles audio streaming and websocket communication.
 
-    This class implements a singleton pattern to manage video stream from RTSP and websocket
-    communication for vlm services. It runs in a separate thread to handle
+    This class implements a singleton pattern to manage video stream from RTSP
+    and websocket communication for vlm services. It runs in a separate thread to handle
     continuous vlm processing.
     """
 

--- a/src/providers/vlm_vila_provider.py
+++ b/src/providers/vlm_vila_provider.py
@@ -12,8 +12,8 @@ class VLMVilaProvider:
     """
     VLM Provider that handles audio streaming and websocket communication.
 
-    This class implements a singleton pattern to manage audio input streaming and websocket
-    communication for vlm services. It runs in a separate thread to handle
+    This class implements a singleton pattern to manage audio input streaming
+    and websocket communication for vlm services. It runs in a separate thread to handle
     continuous vlm processing.
     """
 

--- a/src/providers/vlm_vila_rtsp_provider.py
+++ b/src/providers/vlm_vila_rtsp_provider.py
@@ -12,8 +12,8 @@ class VLMVilaRTSPProvider:
     """
     VLM Provider that handles audio streaming and websocket communication.
 
-    This class implements a singleton pattern to manage video stream from RTSP and websocket
-    communication for vlm services. It runs in a separate thread to handle
+    This class implements a singleton pattern to manage video stream from RTSP
+    and websocket communication for vlm services. It runs in a separate thread to handle
     continuous vlm processing.
     """
 


### PR DESCRIPTION
## Summary

This PR fixes **E501** (line too long) violations in the `src/providers/` directory by wrapping long lines to comply with the 88-character line length limit.

## Problem

Lines exceeding 88 characters reduce code readability and violate the project's style guidelines enforced by ruff. Long lines are harder to read, especially in:
- Side-by-side diffs during code review
- Split-screen editing
- Terminal environments

**Before (problematic):**
```python
self._lidar_string = "You might be surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
```

**After (fixed):**
```python
self._lidar_string = (
    "You might be surrounded by objects and cannot safely move "
    "in any direction. DO NOT MOVE."
)
```

## Changes

### Files Modified (21 files)

| File | Changes |
|------|---------|
| `asr_provider.py` | Wrapped docstrings for class and method descriptions |
| `asr_rtsp_provider.py` | Wrapped docstrings for class and method descriptions |
| `context_provider.py` | Wrapped parameter description in docstring |
| `elevenlabs_tts_provider.py` | Wrapped parameter descriptions in docstring |
| `fabric_map_provider.py` | Wrapped docstrings for methods |
| `face_presence_provider.py` | Wrapped docstrings and inline comments |
| `gps_provider.py` | Wrapped class docstring and f-string in logging |
| `io_provider.py` | Wrapped docstring for context manager |
| `llm_history_manager.py` | Split long default string parameters |
| `odom_provider.py` | Wrapped docstrings, comments, and log messages |
| `rplidar_provider.py` | Wrapped docstrings, comments, error messages, and log strings |
| `rtk_provider.py` | Wrapped multi-line comments |
| `simple_paths_provider.py` | Wrapped long return string |
| `sleep_ticker_provider.py` | Wrapped class docstring |
| `teleops_conversation_provider.py` | Wrapped f-strings in logging statements |
| `turtlebot4_camera_vlm_provider.py` | Wrapped f-string in logging |
| `vlm_gemini_provider.py` | Wrapped long text string in dict |
| `vlm_openai_provider.py` | Wrapped long text string in dict |
| `vlm_openai_rtsp_provider.py` | Wrapped class docstring |
| `vlm_vila_provider.py` | Wrapped class docstring |
| `vlm_vila_rtsp_provider.py` | Wrapped class docstring |

## Notes

- Files matching `unitree_*/ubtech_*` patterns are excluded (vendor code)
- No functional changes - only formatting for style compliance
- Python string concatenation is used for multi-line strings (automatically joined at compile time)

## Test Plan

- [x] `uv run ruff check src/providers/` - All E501 violations resolved
- [x] `uv run pyright` - No new errors (only pre-existing import warnings for unitree SDK)
- [x] `uv run black --check src/providers/` - Formatting verified
- [x] `uv run isort --check src/providers/` - Import sorting verified
- [x] `uv run pytest tests/providers/` - 92 passed, 4 skipped

## References

- [Ruff E501 Rule](https://docs.astral.sh/ruff/rules/line-too-long/)
- [PEP 8 - Maximum Line Length](https://peps.python.org/pep-0008/#maximum-line-length)