### PR TITLE
fix(runtime): wrap long lines to comply with E501 line length

### DIFF
--- a/src/runtime/logging.py
+++ b/src/runtime/logging.py
@@ -10,7 +10,8 @@ class LoggingConfig:
     """
     Logging configuration for the application.
 
-    This class holds the configuration for logging, including the log level and whether to log to a file.
+    This class holds the configuration for logging, including the log level
+    and whether to log to a file.
 
     Parameters
     ----------

--- a/src/runtime/multi_mode/config.py
+++ b/src/runtime/multi_mode/config.py
@@ -58,13 +58,16 @@ class TransitionRule:
     trigger_keywords : List[str], optional
         Keywords or phrases that can trigger the transition (for input-triggered).
     priority : int, optional
-        Priority of the rule when multiple rules could apply. Higher numbers = higher priority. Defaults to 1.
+        Priority of the rule when multiple rules could apply.
+        Higher numbers = higher priority. Defaults to 1.
     cooldown_seconds : float, optional
         Minimum time in seconds before this rule can trigger again. Defaults to 0.0.
     timeout_seconds : Optional[float], optional
-        For time-based transitions, the time in seconds after which to switch modes. Defaults to None.
+        For time-based transitions, the time in seconds after which
+        to switch modes. Defaults to None.
     context_conditions : Dict, optional
-        Conditions based on context that must be met for the transition. Defaults to empty dict.
+        Conditions based on context that must be met for the transition.
+        Defaults to empty dict.
     """
 
     from_mode: str
@@ -115,7 +118,8 @@ class ModeConfig:
     backgrounds : List[Background], optional
         List of background processes for the mode. Defaults to empty list.
     action_execution_mode : Optional[str], optional
-        Execution mode for actions (e.g., "concurrent", "sequential", "dependencies"). Defaults to concurrent.
+        Execution mode for actions (e.g., "concurrent", "sequential",
+        "dependencies"). Defaults to concurrent.
     action_dependencies : Optional[Dict[str, List[str]]], optional
         Dependencies between actions for execution order. Defaults to None.
     _raw_inputs : List[Dict], optional
@@ -365,7 +369,8 @@ def load_mode_config(
     config_name : str
         Name of the configuration file (without .json5 extension)
     mode_source_path : Optional[str]
-        Optional path to the configuration file. If None, defaults to the config directory.
+        Optional path to the configuration file.
+        If None, defaults to the config directory.
         The path is relative to the ../../../config directory.
 
     Returns

--- a/src/runtime/multi_mode/cortex.py
+++ b/src/runtime/multi_mode/cortex.py
@@ -80,7 +80,8 @@ class ModeCortexRuntime:
             self.config_path = self.mode_manager._get_runtime_config_path()
             self.last_modified = self._get_file_mtime()
             logging.info(
-                f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
+                f"Hot-reload enabled for runtime config: {self.config_path} "
+                f"(check interval: {check_interval}s)"
             )
 
         # Current runtime components
@@ -156,7 +157,8 @@ class ModeCortexRuntime:
                     self._pending_transition_reason = None
 
                     logging.info(
-                        f"Processing mode transition to: {target_mode} (reason: {transition_reason})"
+                        f"Processing mode transition to: {target_mode} "
+                        f"(reason: {transition_reason})"
                     )
 
                     success = await self.mode_manager._execute_transition(
@@ -180,7 +182,8 @@ class ModeCortexRuntime:
 
     async def _on_mode_transition(self, from_mode: str, to_mode: str):
         """
-        Handle mode transitions by gracefully stopping current components and starting new ones for the target mode.
+        Handle mode transitions by gracefully stopping current components
+        and starting new ones for the target mode.
 
         Parameters
         ----------
@@ -529,7 +532,8 @@ class ModeCortexRuntime:
             self._pending_transition_reason = transition_reason
             self._mode_transition_event.set()
             logging.info(
-                f"Scheduled mode transition to: {new_mode} (reason: {transition_reason})"
+                f"Scheduled mode transition to: {new_mode} "
+                f"(reason: {transition_reason})"
             )
             return
 
@@ -656,7 +660,8 @@ class ModeCortexRuntime:
 
             if current_mode not in new_mode_config.modes:
                 logging.warning(
-                    f"Current mode '{current_mode}' not found in reloaded config, switching to default mode '{new_mode_config.default_mode}'"
+                    f"Current mode '{current_mode}' not found in reloaded config, "
+                    f"switching to default mode '{new_mode_config.default_mode}'"
                 )
                 current_mode = new_mode_config.default_mode
 

--- a/src/runtime/multi_mode/hook.py
+++ b/src/runtime/multi_mode/hook.py
@@ -164,7 +164,8 @@ class CommandHookHandler(LifecycleHookHandler):
                 return True
             else:
                 logging.error(
-                    f"Hook command failed with code {process.returncode}: {stderr.decode().strip()}"
+                    f"Hook command failed with code {process.returncode}: "
+                    f"{stderr.decode().strip()}"
                 )
                 return False
 
@@ -271,12 +272,14 @@ class FunctionHookHandler(LifecycleHookHandler):
                     if hasattr(module, function_name):
                         func = getattr(module, function_name)
                         logging.debug(
-                            f"Successfully loaded function {function_name} from hooks.{module_name}"
+                            f"Successfully loaded function {function_name} "
+                            f"from hooks.{module_name}"
                         )
                         return func
                     else:
                         logging.error(
-                            f"Function {function_name} found in file but not importable from hooks.{module_name}"
+                            f"Function {function_name} found in file but not "
+                            f"importable from hooks.{module_name}"
                         )
                         return None
 
@@ -290,7 +293,8 @@ class FunctionHookHandler(LifecycleHookHandler):
 
         except Exception as e:
             logging.error(
-                f"Error searching for function {function_name} in module {module_name}: {e}"
+                f"Error searching for function {function_name} "
+                f"in module {module_name}: {e}"
             )
             return None
 
@@ -460,7 +464,8 @@ async def execute_lifecycle_hooks(
                     all_successful = False
                     if hook.on_failure == "abort":
                         logging.error(
-                            "Lifecycle hook failed with abort policy, stopping execution"
+                            "Lifecycle hook failed with abort policy, "
+                            "stopping execution"
                         )
                         return False
                     if hook.on_failure == "ignore":

--- a/src/runtime/multi_mode/manager.py
+++ b/src/runtime/multi_mode/manager.py
@@ -270,7 +270,8 @@ class ModeManager:
                 ) and rule.transition_type == TransitionType.TIME_BASED:
                     if self._can_transition(rule):
                         logging.info(
-                            f"Time-based transition triggered: {self.state.current_mode} -> {rule.to_mode}"
+                            f"Time-based transition triggered: "
+                            f"{self.state.current_mode} -> {rule.to_mode}"
                         )
                         return rule.to_mode
 
@@ -278,7 +279,8 @@ class ModeManager:
 
     async def check_context_aware_transitions(self) -> Optional[str]:
         """
-        Check if any context-aware transitions should be triggered based on current user context.
+        Check if any context-aware transitions should be triggered based on
+        current user context.
 
         Returns
         -------
@@ -302,8 +304,10 @@ class ModeManager:
             matching_rules.sort(key=lambda r: r.priority, reverse=True)
             target_rule = matching_rules[0]
             logging.info(
-                f"Context-aware transition triggered: {self.state.current_mode} -> {target_rule.to_mode} "
-                f"(priority: {target_rule.priority}, conditions: {target_rule.context_conditions})"
+                f"Context-aware transition triggered: "
+                f"{self.state.current_mode} -> {target_rule.to_mode} "
+                f"(priority: {target_rule.priority}, "
+                f"conditions: {target_rule.context_conditions})"
             )
             return target_rule.to_mode
 
@@ -347,7 +351,8 @@ class ModeManager:
             matching_rules.sort(key=lambda r: r.priority, reverse=True)
             best_rule = matching_rules[0]
             logging.info(
-                f"Input-triggered transition: {self.state.current_mode} -> {best_rule.to_mode}"
+                f"Input-triggered transition: "
+                f"{self.state.current_mode} -> {best_rule.to_mode}"
             )
             logging.info(f"Triggered by keywords: {best_rule.trigger_keywords}")
             return best_rule.to_mode
@@ -356,7 +361,8 @@ class ModeManager:
 
     def _can_transition(self, rule: TransitionRule) -> bool:
         """
-        Check if a transition rule can be executed based on cooldowns and other constraints.
+        Check if a transition rule can be executed based on cooldowns
+        and other constraints.
 
         Parameters
         ----------
@@ -443,7 +449,7 @@ class ModeManager:
 
         # Handle different condition types
         if isinstance(expected_value, dict):
-            # Support for complex conditions like {"min": 5, "max": 10} or {"contains": "pattern"}
+            # Complex conditions like {"min": 5, "max": 10} or {"contains": "..."}
             if "min" in expected_value or "max" in expected_value:
                 # Numeric range condition
                 if not isinstance(actual_value, (int, float)):
@@ -529,7 +535,8 @@ class ModeManager:
         async with self._transition_lock:
             if self._is_transitioning:
                 logging.debug(
-                    f"Transition already in progress, skipping transition to {target_mode}"
+                    f"Transition already in progress, "
+                    f"skipping transition to {target_mode}"
                 )
                 return True
 

--- a/src/runtime/robotics.py
+++ b/src/runtime/robotics.py
@@ -12,7 +12,8 @@ def load_unitree(unitree_ethernet: str):
     Parameters
     ----------
     unitree_ethernet : str
-        Configuration object containing the Unitree Ethernet adapter string, such as "eth0"
+        Configuration object containing the Unitree Ethernet adapter string,
+        such as "eth0"
 
     Returns
     -------

--- a/src/runtime/single_mode/config.py
+++ b/src/runtime/single_mode/config.py
@@ -58,7 +58,8 @@ class RuntimeConfig:
     unitree_ethernet : Optional[str]
         Optional Unitree ethernet port.
     action_execution_mode : Optional[str]
-        Optional action execution mode (e.g., "concurrent", "sequential", "dependencies"). Defaults to "concurrent".
+        Optional action execution mode (e.g., "concurrent", "sequential",
+        "dependencies"). Defaults to "concurrent".
     action_dependencies : Optional[Dict[str, List[str]]]
         Optional mapping of action dependencies.
     """
@@ -105,7 +106,8 @@ def load_config(
     config_name : str
         Name of the configuration file (without .json extension)
     config_source_path : Optional[str]
-        Optional path to the configuration file to load. If not provided, the default path based on config_name will be used.
+        Optional path to the configuration file to load.
+        If not provided, the default path based on config_name will be used.
 
     Returns
     -------
@@ -147,7 +149,8 @@ def load_config(
     g_robot_ip = raw_config.get("robot_ip", None)
     if g_robot_ip is None or g_robot_ip == "" or g_robot_ip == "192.168.0.241":
         logging.warning(
-            "No robot ip found in the configuration file. Checking for backup robot ip in your .env file."
+            "No robot ip found in the configuration file. "
+            "Checking for backup robot ip in your .env file."
         )
         backup_key = os.environ.get("ROBOT_IP")
         g_robot_ip = backup_key
@@ -156,12 +159,14 @@ def load_config(
             logging.info("Success - Found ROBOT_IP in your .env file.")
         else:
             logging.warning(
-                "Could not find robot ip address. Please find your robot IP address and add it to the configuration file or .env file."
+                "Could not find robot ip address. Please find your robot IP "
+                "address and add it to the configuration file or .env file."
             )
     g_api_key = raw_config.get("api_key", None)
     if g_api_key is None or g_api_key == "" or g_api_key == "openmind_free":
         logging.warning(
-            "No API key found in the configuration file. Checking for backup OM_API_KEY in your .env file."
+            "No API key found in the configuration file. "
+            "Checking for backup OM_API_KEY in your .env file."
         )
         backup_key = os.environ.get("OM_API_KEY")
         g_api_key = backup_key
@@ -170,13 +175,15 @@ def load_config(
             logging.info("Success - Found OM_API_KEY in your .env file.")
         else:
             logging.warning(
-                "Could not find any API keys. Please get a free key at portal.openmind.org."
+                "Could not find any API keys. "
+                "Please get a free key at portal.openmind.org."
             )
 
     g_URID = raw_config.get("URID", None)
     if g_URID is None or g_URID == "":
         logging.warning(
-            "No URID found in the configuration file. Multirobot deployments will conflict."
+            "No URID found in the configuration file. "
+            "Multirobot deployments will conflict."
         )
 
     if g_URID == "default":
@@ -187,7 +194,8 @@ def load_config(
             logging.info("Success - Found URID in your .env file.")
         else:
             logging.warning(
-                "Could not find backup URID in your .env file. Using 'default'. Multirobot deployments will conflict."
+                "Could not find backup URID in your .env file. "
+                "Using 'default'. Multirobot deployments will conflict."
             )
 
     g_ut_eth = raw_config.get("unitree_ethernet", None)

--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -59,7 +59,8 @@ class CortexRuntime:
         hot_reload : bool
             Whether to enable hot-reload functionality. (default: True)
         check_interval : float
-            Interval in seconds between config file checks for hot-reload. (default: 60.0)
+            Interval in seconds between config file checks for hot-reload.
+            (default: 60.0)
         """
         self.config = config
         self.config_name = config_name
@@ -88,7 +89,8 @@ class CortexRuntime:
             self.config_path = self._create_runtime_config_file()
             self.last_modified = self._get_file_mtime()
             logging.info(
-                f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
+                f"Hot-reload enabled for runtime config: {self.config_path} "
+                f"(check interval: {check_interval}s)"
             )
 
     def _get_runtime_config_path(self) -> str:

--- a/src/runtime/version.py
+++ b/src/runtime/version.py
@@ -99,7 +99,8 @@ def verify_runtime_version(
     except ValueError as e:
         logging.error(f"Version compatibility check failed for {config_name}: {e}")
         raise ValueError(
-            f"Configuration version '{config_version}' is incompatible with runtime version '{runtime_version}': {e}"
+            f"Configuration version '{config_version}' is incompatible with "
+            f"runtime version '{runtime_version}': {e}"
         )
     except Exception as e:
         logging.error(


### PR DESCRIPTION
## Summary

Fix 36 E501 (line too long) violations in the `src/runtime/` directory by wrapping long lines to comply with the 88 character limit.

### Changes by File

| File | Fixes | Type |
|------|-------|------|
| `logging.py` | 1 | Docstring |
| `version.py` | 1 | Error message |
| `multi_mode/config.py` | 5 | Docstrings |
| `multi_mode/cortex.py` | 5 | Log messages, docstrings |
| `multi_mode/hook.py` | 5 | Log messages |
| `multi_mode/manager.py` | 8 | Log messages, docstrings, comments |
| `single_mode/config.py` | 8 | Log messages, docstrings |
| `single_mode/cortex.py` | 2 | Docstring, log message |
| `robotics.py` | 1 | Docstring |
| **Total** | **36** | |

### Example Fix

```python
# Before
logging.warning(
    "No robot ip found in the configuration file. Checking for backup robot ip in your .env file."
)

# After
logging.warning(
    "No robot ip found in the configuration file. "
    "Checking for backup robot ip in your .env file."
)
```

### Verification

```bash
✅ uv run ruff check src/runtime/ --select=E501  # All checks passed
✅ uv run ruff check src/runtime/                 # All checks passed
✅ uv run pyright src/runtime/                    # 0 errors, 1 warning (optional import)
✅ uv run black src/runtime/ --check              # All files unchanged
✅ uv run isort src/runtime/ --check-only         # No issues
✅ uv run pytest                                  # 689 passed, 8 skipped
```

### Related

- Part of E501 fix series
- See also: #1455 (providers)

## Test plan

- [x] Run `uv run ruff check src/runtime/ --select=E501` - all checks pass
- [x] Run `uv run pyright src/runtime/` - no new errors
- [x] Run `uv run black src/runtime/ --check` - no changes needed
- [x] Run `uv run isort src/runtime/ --check-only` - no changes needed
- [x] Run `uv run pytest` - 689 passed, 8 skipped