### PR TITLE
fix(actions): wrap long lines to comply with E501 line length

### DIFF
--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -112,7 +112,8 @@ def load_action(
 
     if connector_class is None:
         raise ValueError(
-            f"No connector found for action {action_config['name']} connector {action_config['connector']}"
+            f"No connector found for action {action_config['name']} "
+            f"connector {action_config['connector']}"
         )
 
     if config_class is not None:

--- a/src/actions/dimo/connector/tesla.py
+++ b/src/actions/dimo/connector/tesla.py
@@ -82,7 +82,8 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
 
             if not client_id or not domain or not private_key or not self.token_id:
                 raise ValueError(
-                    "DIMOTeslaConnector: Missing DIMO configuration in config or IOProvider dynamic variables"
+                    "DIMOTeslaConnector: Missing DIMO configuration in config "
+                    "or IOProvider dynamic variables"
                 )
 
             try:
@@ -148,7 +149,8 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
                         logging.info("DIMO Tesla: Door locked")
                     else:
                         logging.error(
-                            f"Error locking door: {response.status_code} {response.text}"
+                            f"Error locking door: {response.status_code} "
+                            f"{response.text}"
                         )
                 elif output_interface.action == "unlock doors":
                     url = f"{self.base_url}/{self.token_id}/commands/doors/unlock"
@@ -161,7 +163,8 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
                         logging.info("DIMO Tesla: Door unlocked")
                     else:
                         logging.error(
-                            f"Error unlocking door: {response.status_code} {response.text}"
+                            f"Error unlocking door: {response.status_code} "
+                            f"{response.text}"
                         )
                 elif output_interface.action == "open frunk":
                     url = f"{self.base_url}/{self.token_id}/commands/frunk/open"
@@ -174,7 +177,8 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
                         logging.info("DIMO Tesla: Frunk opened")
                     else:
                         logging.error(
-                            f"Error opening frunk: {response.status_code} {response.text}"
+                            f"Error opening frunk: {response.status_code} "
+                            f"{response.text}"
                         )
                 elif output_interface.action == "open trunk":
                     url = f"{self.base_url}/{self.token_id}/commands/trunk/open"
@@ -187,7 +191,8 @@ class DIMOTeslaConnector(ActionConnector[DIMOTeslaConfig, TeslaInput]):
                         logging.info("DIMO Tesla: Trunk opened")
                     else:
                         logging.error(
-                            f"Error opening trunk: {response.status_code} {response.text}"
+                            f"Error opening trunk: {response.status_code} "
+                            f"{response.text}"
                         )
                 elif output_interface.action == "idle":
                     logging.info("DIMO Tesla: Idle")

--- a/src/actions/move_game_controller/connector/go2_game_controller.py
+++ b/src/actions/move_game_controller/connector/go2_game_controller.py
@@ -5,12 +5,12 @@ from typing import Optional
 
 import zenoh
 from pydantic import Field
+from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
 
 from actions.base import ActionConfig, ActionConnector
 from actions.move_game_controller.interface import IDLEInput
 from providers.odom_provider import OdomProvider, RobotState
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
 from zenoh_msgs import AudioStatus, open_zenoh_session
 
 try:
@@ -66,7 +66,8 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
     """
     Game controller for Unitree Go2 robots.
 
-    NOTE: This connector has been deprecated. OM1 Orchestrator docker automatically supports game controller.
+    NOTE: This connector has been deprecated. OM1 Orchestrator docker
+    automatically supports game controller.
     """
 
     def __init__(self, config: Go2GameControllerConfig):
@@ -167,7 +168,8 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
                     try:
                         self.gamepad = hid.Device(vendor_id, product_id)
                         logging.info(
-                            f"Connected {device['product_string']} {vendor_id} {product_id}"
+                            f"Connected {device['product_string']} "
+                            f"{vendor_id} {product_id}"
                         )
                         self.xbox = True
                         break
@@ -180,7 +182,8 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
                     try:
                         self.gamepad = hid.Device(vendor_id, product_id)
                         logging.info(
-                            f"Connected {device['product_string']} {vendor_id} {product_id}"
+                            f"Connected {device['product_string']} "
+                            f"{vendor_id} {product_id}"
                         )
                         self.sony_dualsense = True
                         break
@@ -193,7 +196,8 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
                     try:
                         self.gamepad = hid.Device(vendor_id, product_id)
                         logging.info(
-                            f"Connected {device['product_string']} {vendor_id} {product_id}"
+                            f"Connected {device['product_string']} "
+                            f"{vendor_id} {product_id}"
                         )
                         self.sony_edge = True
                         break
@@ -320,8 +324,9 @@ class Go2GameControllerConnector(ActionConnector[Go2GameControllerConfig, IDLEIn
 
     def tick(self) -> None:
         """
-        Tick function is called periodically to check for input from the Xbox controller.
-        It reads the input from the controller and sends the corresponding commands to the robot.
+        Tick function is called periodically to check for input from the Xbox
+        controller. It reads the input from the controller and sends the
+        corresponding commands to the robot.
 
         Returns
         -------

--- a/src/actions/move_game_controller/interface.py
+++ b/src/actions/move_game_controller/interface.py
@@ -23,9 +23,10 @@ class GameController(Interface[IDLEInput, IDLEInput]):
     """
     This action allows manual control of Unitree GO2 robots using game controllers.
 
-    Effect: Enables teleoperation through physical game controllers (Xbox Wireless Controller,
-    Sony DualSense, or Sony DualSense Edge). D-pad controls movement (forward/backward/left/right),
-    triggers control rotation (clockwise/counter-clockwise), and face buttons control stance
+    Effect: Enables teleoperation through physical game controllers
+    (Xbox Wireless Controller, Sony DualSense, or Sony DualSense Edge).
+    D-pad controls movement (forward/backward/left/right), triggers control
+    rotation (clockwise/counter-clockwise), and face buttons control stance
     (stand up/sit down).
 
     Note: This connector has been deprecated. The OM1 Orchestrator now automatically

--- a/src/actions/move_go2_teleops/connector/remote.py
+++ b/src/actions/move_go2_teleops/connector/remote.py
@@ -5,12 +5,12 @@ from enum import Enum
 
 from om1_utils import ws
 from pydantic import Field
+from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
 
 from actions.base import ActionConfig, ActionConnector
 from actions.move_go2_teleops.interface import MoveInput
 from providers import CommandStatus
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
 
 
 class RobotState(Enum):
@@ -42,7 +42,8 @@ class MoveGo2RemoteConnector(ActionConnector[MoveGo2RemoteConfig, MoveInput]):
     """
     Remote connector for the Move Go2 teleops action.
 
-    NOTE: This connector has been deprecated. OM1 Orchestrator docker automatically supports remote teleops
+    NOTE: This connector has been deprecated. OM1 Orchestrator docker
+    automatically supports remote teleops
     """
 
     def __init__(self, config: MoveGo2RemoteConfig):
@@ -103,7 +104,8 @@ class MoveGo2RemoteConnector(ActionConnector[MoveGo2RemoteConfig, MoveInput]):
                 command_status.vx, command_status.vy, command_status.vyaw
             )
             logging.info(
-                f"Published command: {command_status.to_dict()} - latency: {(time.time() - float(command_status.timestamp)):.3f} seconds"
+                f"Published command: {command_status.to_dict()} - latency: "
+                f"{(time.time() - float(command_status.timestamp)):.3f} seconds"
             )
         except Exception as e:
             logging.error(f"Error processing command status: {e}")

--- a/src/actions/move_serial_arduino/connector/serial_arduino.py
+++ b/src/actions/move_serial_arduino/connector/serial_arduino.py
@@ -1,5 +1,7 @@
 """
-This only works if you actually have a serial port connected to your computer, such as, via a USB serial dongle. On Mac, you can determine the correct name to use via `ls /dev/cu.usb*`.
+This only works if you actually have a serial port connected to your
+computer, such as, via a USB serial dongle. On Mac, you can determine
+the correct name to use via `ls /dev/cu.usb*`.
 """
 
 import logging
@@ -19,12 +21,16 @@ class MoveSerialConfig(ActionConfig):
     Parameters
     ----------
     port : str
-        The serial port to connect to the Arduino (e.g., COM3 or /dev/cu.usbmodem14101). Leave empty to simulate.
+        The serial port to connect to the Arduino
+        (e.g., COM3 or /dev/cu.usbmodem14101). Leave empty to simulate.
     """
 
     port: str = Field(
         default="",
-        description="The serial port to connect to the Arduino (e.g., COM3 or /dev/cu.usbmodem14101). Leave empty to simulate.",
+        description=(
+            "The serial port to connect to the Arduino "
+            "(e.g., COM3 or /dev/cu.usbmodem14101). Leave empty to simulate."
+        ),
     )
 
 

--- a/src/actions/move_turtle/connector/zenoh.py
+++ b/src/actions/move_turtle/connector/zenoh.py
@@ -363,7 +363,7 @@ class MoveZenohConnector(ActionConnector[MoveZenohConfig, MoveInput]):
                     logging.debug("Phase 1 - Gap is decreasing, using smaller steps")
                     self.movement_attempts += 1
                     # rotate only because we are so close
-                    # no need to check barriers because we are just performing small rotations
+                    # no need to check barriers - just performing small rotations
                     if gap > 0:
                         self.move(0, 0.2)
                     elif gap < 0:
@@ -412,7 +412,8 @@ class MoveZenohConnector(ActionConnector[MoveZenohConfig, MoveInput]):
                         self.move(-1 * fb * 0.1, 0.0)
                 else:
                     logging.info(
-                        "advance is completed, gap is small enough, done, pop 1 off queue"
+                        "advance is completed, gap is small enough, done, "
+                        "pop 1 off queue"
                     )
                     self.pending_movements.get()
 

--- a/src/actions/move_turtle/connector/zenoh_remote.py
+++ b/src/actions/move_turtle/connector/zenoh_remote.py
@@ -90,7 +90,8 @@ class MoveZenohRemoteConnector(ActionConnector[MoveZenohRemoteConfig, MoveInput]
             )
             self.session.put(self.cmd_vel, t.serialize())
             logging.info(
-                f"Published command: {command_status.to_dict()} - latency: {(time.time() - float(command_status.timestamp)):.3f} seconds"
+                f"Published command: {command_status.to_dict()} - latency: "
+                f"{(time.time() - float(command_status.timestamp)):.3f} seconds"
             )
         except Exception as e:
             logging.error(f"Error processing message: {e}")

--- a/src/actions/navigate_location/interface.py
+++ b/src/actions/navigate_location/interface.py
@@ -8,8 +8,9 @@ class NavigateLocationInput:
     """
     Input payload for navigating to a stored location.
 
-    CRITICAL: The 'action' field must contain ONLY the location name from the saved locations list.
-    DO NOT include phrases like "go to", "navigate to", "move to", etc.
+    CRITICAL: The 'action' field must contain ONLY the location name from the
+    saved locations list. DO NOT include phrases like "go to", "navigate to",
+    "move to", etc.
 
     Examples (assuming saved locations are: kitchen, sofa, table):
     - User says: "Go to the kitchen" → action = "kitchen"

--- a/src/actions/orchestrator.py
+++ b/src/actions/orchestrator.py
@@ -108,7 +108,8 @@ class ActionOrchestrator:
         Returns
         -------
         tuple[list[T.Any], list[asyncio.Task[T.Any]]]
-            A tuple containing a list of completed promise results and a list of pending promise tasks.
+            A tuple containing a list of completed promise results and a list
+            of pending promise tasks.
         """
         if not self.promise_queue:
             return [], []
@@ -330,7 +331,8 @@ class ActionOrchestrator:
             The result of the action execution.
         """
         logging.debug(
-            f"Calling action {agent_action.llm_label} with type {action.type.lower()} and argument {action.value}"
+            f"Calling action {agent_action.llm_label} with type "
+            f"{action.type.lower()} and argument {action.value}"
         )
         input_interface = T.get_type_hints(agent_action.interface)["input"](
             **{"action": action.value}

--- a/src/actions/remember_location/interface.py
+++ b/src/actions/remember_location/interface.py
@@ -9,14 +9,17 @@ class RememberLocationInput:
     """
     Input payload for remembering/saving a named location.
 
-    The 'action' field contains the location name to save (e.g. "kitchen", "office", "living room").
-    The 'description' field is optional additional information about the location.
+    The 'action' field contains the location name to save
+    (e.g. "kitchen", "office", "living room").
+    The 'description' field is optional additional information about the
+    location.
 
     Examples
     --------
     - User says: "Remember this location as kitchen" → action = "kitchen"
     - User says: "Save this spot as my office" → action = "office"
-    - User says: "Remember this place as the charging station" → action = "charging station"
+    - User says: "Remember this place as the charging station" →
+      action = "charging station"
     """
 
     action: str
@@ -29,7 +32,8 @@ class RememberLocation(Interface[RememberLocationInput, RememberLocationInput]):
     Save/remember the robot's current location with a name.
 
     The 'action' field should contain the location name.
-    Extract the location name from user commands like "remember this as [name]" or "save this location as [name]".
+    Extract the location name from user commands like "remember this as [name]"
+    or "save this location as [name]".
     """
 
     input: RememberLocationInput

--- a/src/actions/selfie/connector/selfie.py
+++ b/src/actions/selfie/connector/selfie.py
@@ -190,7 +190,8 @@ class SelfieConnector(ActionConnector[SelfieConfig, SelfieInput]):
         Parameters
         ----------
         output_interface : SelfieInput
-            The selfie action interface containing parameters like `id` and `timeout_sec`.
+            The selfie action interface containing parameters like `id` and
+            `timeout_sec`.
         """
         name = (output_interface.action or "").strip()
         timeout_sec = int(output_interface.timeout_sec or self.default_timeout)
@@ -222,7 +223,8 @@ class SelfieConnector(ActionConnector[SelfieConfig, SelfieInput]):
                     time.time(),
                 )
                 self.evelenlabs_tts_provider.add_pending_message(
-                    f"Woof! Woof! I saw {faces} faces. Please make sure only your face is visible and try again."
+                    f"Woof! Woof! I saw {faces} faces. Please make sure only "
+                    "your face is visible and try again."
                 )
                 return
 

--- a/src/actions/speak/connector/elevenlabs_tts.py
+++ b/src/actions/speak/connector/elevenlabs_tts.py
@@ -220,7 +220,8 @@ class SpeakElevenLabsTTSConnector(
         ):
             self.silence_counter += 1
             logging.info(
-                f"Skipping TTS due to silence_rate {self.silence_rate}, counter {self.silence_counter}"
+                f"Skipping TTS due to silence_rate {self.silence_rate}, "
+                f"counter {self.silence_counter}"
             )
             return
 

--- a/src/actions/speak/connector/ub_tts.py
+++ b/src/actions/speak/connector/ub_tts.py
@@ -96,7 +96,8 @@ class UbTtsConnector(ActionConnector[UbTtsConfig, SpeakInput]):
 
         # Call the provider's speak method using data from SpeakInput.
         # The text comes from the 'action' field.
-        # 'interrupt' and 'timestamp' use default values since they are not in SpeakInput.
+        # 'interrupt' and 'timestamp' use default values since they are not
+        # in SpeakInput.
         self.tts.speak(
             tts=output_interface.action,
             interrupt=True,

--- a/src/actions/telegram/connector/telegramAPI.py
+++ b/src/actions/telegram/connector/telegramAPI.py
@@ -69,7 +69,8 @@ class TelegramAPIConnector(ActionConnector[TelegramAPIConfig, TelegramInput]):
                         data = await response.json()
                         message_id = data.get("result", {}).get("message_id")
                         logging.info(
-                            f"Telegram message sent successfully! Message ID: {message_id}"
+                            f"Telegram message sent successfully! "
+                            f"Message ID: {message_id}"
                         )
                     else:
                         error_text = await response.text()


### PR DESCRIPTION
## Summary

Fix 36 E501 (line too long) violations in the `src/actions/` directory by wrapping long lines to comply with the 88 character limit.

### Changes by File

| File | Fixes | Type |
|------|-------|------|
| `__init__.py` | 1 | Error message |
| `dimo/connector/tesla.py` | 6 | Error messages |
| `move_game_controller/connector/go2_game_controller.py` | 4 | Docstrings, logs |
| `move_game_controller/interface.py` | 3 | Docstring |
| `move_go2_teleops/connector/remote.py` | 2 | Docstring, log |
| `move_serial_arduino/connector/serial_arduino.py` | 3 | Docstrings |
| `move_to_peer/connector/ros2.py` | 2 | Log messages |
| `move_turtle/connector/zenoh.py` | 2 | Comment, log |
| `move_turtle/connector/zenoh_remote.py` | 1 | Log message |
| `navigate_location/interface.py` | 2 | Docstring |
| `orchestrator.py` | 2 | Docstring, log |
| `remember_location/interface.py` | 3 | Docstrings |
| `selfie/connector/selfie.py` | 2 | Docstring, message |
| `speak/connector/elevenlabs_tts.py` | 1 | Log message |
| `speak/connector/ub_tts.py` | 1 | Comment |
| `telegram/connector/telegramAPI.py` | 1 | Log message |
| **Total** | **36** | |

### Example Fix

```python
# Before
raise ValueError(
    "DIMOTeslaConnector: Missing DIMO configuration in config or IOProvider dynamic variables"
)

# After
raise ValueError(
    "DIMOTeslaConnector: Missing DIMO configuration in config "
    "or IOProvider dynamic variables"
)
```

### Verification

```bash
✅ uv run ruff check src/actions/ --select=E501  # All checks passed
✅ uv run ruff check src/actions/                 # All checks passed
✅ uv run black src/actions/ --check              # All files unchanged
✅ uv run isort src/actions/ --check-only         # No issues
✅ uv run pytest                                  # 689 passed, 8 skipped
```

### Related

- Part of E501 fix series
- See also: #1455 (providers), #1456 (runtime)

## Test plan

- [x] Run `uv run ruff check src/actions/ --select=E501` - all checks pass
- [x] Run `uv run black src/actions/ --check` - no changes needed
- [x] Run `uv run isort src/actions/ --check-only` - no changes needed
- [x] Run `uv run pytest` - 689 passed, 8 skipped