### PR TITLE
fix(inputs): resolve E501 line too long violations

### DIFF
--- a/src/inputs/plugins/amcl_localization_input.py
+++ b/src/inputs/plugins/amcl_localization_input.py
@@ -59,20 +59,30 @@ class AMCLLocalizationInput(FuserInput[SensorConfig, Optional[str]]):
             pose = self.amcl_provider.pose
 
             if is_localized and pose is not None:
-                status_msg = "LOCALIZED: Robot position is confirmed. Navigation commands are safe to execute."
+                status_msg = (
+                    "LOCALIZED: Robot position is confirmed. "
+                    "Navigation commands are safe to execute."
+                )
                 pos = pose.position
                 logging.debug(
-                    f"Robot localized at position x:{pos.x:.2f}, y:{pos.y:.2f}, z:{pos.z:.2f}"
+                    f"Robot localized at position "
+                    f"x:{pos.x:.2f}, y:{pos.y:.2f}, z:{pos.z:.2f}"
                 )
             else:
-                status_msg = "NOT LOCALIZED: Robot position uncertain. DO NOT attempt navigation until localized."
+                status_msg = (
+                    "NOT LOCALIZED: Robot position uncertain. "
+                    "DO NOT attempt navigation until localized."
+                )
                 logging.debug("Robot localization status: NOT LOCALIZED")
 
             return status_msg
 
         except Exception as e:
             logging.error(f"Error polling localization status: {e}")
-            return "LOCALIZATION ERROR: Unable to determine robot position. Navigation not recommended."
+            return (
+                "LOCALIZATION ERROR: Unable to determine robot position. "
+                "Navigation not recommended."
+            )
 
     async def _raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
         """

--- a/src/inputs/plugins/battery_turtlebot4.py
+++ b/src/inputs/plugins/battery_turtlebot4.py
@@ -89,7 +89,8 @@ class TurtleBot4Battery(FuserInput[TurtleBot4BatteryConfig, List[str]]):
             f"{self.URID}/c3/dock_status", self.listener_dock
         )
 
-        # Simple description of sensor output to help LLM understand its importance and utility
+        # Simple description of sensor output to help LLM understand its
+        # importance and utility
         self.descriptor_for_LLM = "Energy Level"
 
     def listener_battery(self, sample: zenoh.Sample):

--- a/src/inputs/plugins/dimo_tesla.py
+++ b/src/inputs/plugins/dimo_tesla.py
@@ -195,8 +195,9 @@ class DIMOTesla(FuserInput[DIMOTeslaConfig, Optional[str]]):
             logging.error(f"Error parsing Tesla data: {e}")
             return None
 
+        powertrain_dist = powertrainTransmissionTravelledDistance
         return f"""
-        Powertrain Transmission Travelled Distance: {powertrainTransmissionTravelledDistance} km
+        Powertrain Transmission Travelled Distance: {powertrain_dist} km
         Exterior Air Temperature: {exteriorAirTemperature} C
         Speed: {speed} km/h
         Powertrain Range: {powertrainRange} km

--- a/src/inputs/plugins/ethereum_governance.py
+++ b/src/inputs/plugins/ethereum_governance.py
@@ -72,7 +72,8 @@ class GovernanceEthereum(FuserInput[SensorConfig, Optional[str]]):
                     logging.error("Error: No valid result in blockchain response")
             else:
                 logging.error(
-                    f"Error: Blockchain request failed with status {response.status_code}"
+                    f"Error: Blockchain request failed with status "
+                    f"{response.status_code}"
                 )
 
         except Exception as e:
@@ -130,7 +131,10 @@ class GovernanceEthereum(FuserInput[SensorConfig, Optional[str]]):
         # The current rule set can be obtained from
         # getLatestRuleSetVersion(0x254e2f1e)
         # It's currently = 2
-        self.function_argument = "0000000000000000000000000000000000000000000000000000000000000002"  # Argument
+        # Function argument for getRuleSet()
+        self.function_argument = (
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        )
 
         self.universal_rule = self.load_rules_from_blockchain()
         self.messages: list[Message] = []

--- a/src/inputs/plugins/fabric_closest_peer.py
+++ b/src/inputs/plugins/fabric_closest_peer.py
@@ -80,7 +80,8 @@ class FabricClosestPeer(FuserInput[FabricClosestPeerConfig, Optional[str]]):
             peer_lat = self.config.mock_lat
             peer_lon = self.config.mock_lon
             logging.info(
-                f"FabricClosestPeer (mock): fabricated peer {peer_lat:.6f},{peer_lon:.6f}"
+                f"FabricClosestPeer (mock): fabricated peer "
+                f"{peer_lat:.6f},{peer_lon:.6f}"
             )
         else:
             if requests is None:

--- a/src/inputs/plugins/face_presence_input.py
+++ b/src/inputs/plugins/face_presence_input.py
@@ -90,7 +90,8 @@ class FacePresence(FuserInput[FacePresenceConfig, Optional[str]]):
         Parameters
         ----------
         text_line : str
-            A single, already formatted line (e.g., "present=[alice], unknown=0, ts=...").
+            A single, already formatted line
+            (e.g., "present=[alice], unknown=0, ts=...").
         """
         try:
             self.message_buffer.put_nowait(text_line)

--- a/src/inputs/plugins/gallery_identities_input.py
+++ b/src/inputs/plugins/gallery_identities_input.py
@@ -86,7 +86,8 @@ class GalleryIdentities(FuserInput[GalleryIdentitiesConfig, Optional[str]]):
         Parameters
         ----------
         text_line : str
-            A single preformatted summary string (e.g., "total=3 ids=[alice, bob, wendy]").
+            A single preformatted summary string
+            (e.g., "total=3 ids=[alice, bob, wendy]").
         """
         try:
             self.message_buffer.put_nowait(text_line)

--- a/src/inputs/plugins/google_asr.py
+++ b/src/inputs/plugins/google_asr.py
@@ -127,7 +127,9 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
 
         if language not in LANGUAGE_CODE_MAP:
             logging.error(
-                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
+                f"Language {language} not supported. "
+                f"Current supported languages are: "
+                f"{list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
             )
             language = "english"
 

--- a/src/inputs/plugins/google_asr_rtsp.py
+++ b/src/inputs/plugins/google_asr_rtsp.py
@@ -69,7 +69,8 @@ class GoogleASRRTSPSensorConfig(SensorConfig):
 
 class GoogleASRRTSPInput(FuserInput[GoogleASRRTSPSensorConfig, Optional[str]]):
     """
-    Google ASR RTSP input handler for processing speech recognition from RTSP audio streams.
+    Google ASR RTSP input handler for processing speech recognition
+    from RTSP audio streams.
     """
 
     def __init__(self, config: GoogleASRRTSPSensorConfig):
@@ -106,7 +107,9 @@ class GoogleASRRTSPInput(FuserInput[GoogleASRRTSPSensorConfig, Optional[str]]):
 
         if language not in LANGUAGE_CODE_MAP:
             logging.error(
-                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
+                f"Language {language} not supported. "
+                f"Current supported languages are: "
+                f"{list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
             )
             language = "english"
 

--- a/src/inputs/plugins/gps.py
+++ b/src/inputs/plugins/gps.py
@@ -90,7 +90,10 @@ class Gps(FuserInput[SensorConfig, Optional[dict]]):
                 lon *= -1.0
 
             if qua > 0:
-                msg = f"Your rough GPS location is {lat} {lat_string}, {lon} {lon_string} at {alt}m altitude. "
+                msg = (
+                    f"Your rough GPS location is {lat} {lat_string}, "
+                    f"{lon} {lon_string} at {alt}m altitude. "
+                )
                 return Message(timestamp=time.time(), message=msg)
             else:
                 return None

--- a/src/inputs/plugins/gps_odom_reader.py
+++ b/src/inputs/plugins/gps_odom_reader.py
@@ -64,7 +64,8 @@ class GPSOdomReader(FuserInput[GPSOdomReaderConfig, Optional[str]]):
         yaw0_deg = self.config.origin_yaw_deg
         if self.lat0 is None or self.lon0 is None or yaw0_deg is None:
             logging.error(
-                "GPSOdomReader: origin_lat, origin_lon, and origin_yaw_deg must be set in the config."
+                "GPSOdomReader: origin_lat, origin_lon, and origin_yaw_deg "
+                "must be set in the config."
             )
             raise ValueError("Missing origin coordinates or yaw in config.")
         self._yaw_offset = math.radians(yaw0_deg) if yaw0_deg is not None else 0.0

--- a/src/inputs/plugins/lidar_localization_input.py
+++ b/src/inputs/plugins/lidar_localization_input.py
@@ -63,20 +63,30 @@ class LidarLocalizationInput(FuserInput[SensorConfig, Optional[str]]):
             pose = self.lidar_localization_provider.pose
 
             if is_localized and pose is not None:
-                status_msg = "LOCALIZED: Robot position is confirmed. Navigation commands are safe to execute."
+                status_msg = (
+                    "LOCALIZED: Robot position is confirmed. "
+                    "Navigation commands are safe to execute."
+                )
                 pos = pose.position
                 logging.debug(
-                    f"Robot localized at position x:{pos.x:.2f}, y:{pos.y:.2f}, z:{pos.z:.2f}"
+                    f"Robot localized at position "
+                    f"x:{pos.x:.2f}, y:{pos.y:.2f}, z:{pos.z:.2f}"
                 )
             else:
-                status_msg = "NOT LOCALIZED: Robot position uncertain. DO NOT attempt navigation until localized."
+                status_msg = (
+                    "NOT LOCALIZED: Robot position uncertain. "
+                    "DO NOT attempt navigation until localized."
+                )
                 logging.debug("Robot localization status: NOT LOCALIZED")
 
             return status_msg
 
         except Exception as e:
             logging.error(f"Error polling localization status: {e}")
-            return "LOCALIZATION ERROR: Unable to determine robot position. Navigation not recommended."
+            return (
+                "LOCALIZATION ERROR: Unable to determine robot position. "
+                "Navigation not recommended."
+            )
 
     async def _raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
         """

--- a/src/inputs/plugins/mock_input.py
+++ b/src/inputs/plugins/mock_input.py
@@ -69,7 +69,7 @@ class MockInput(FuserInput[MockSensorConfig, Optional[str]]):
         ----------
         config : MockSensorConfig
             Configuration object containing the input settings. The config includes:
-            - `input_name`: Name identifier for this input source (default: "Mock Input")
+            - `input_name`: Name identifier for this input source
             - `host`: Host address for the WebSocket server (default: "localhost")
             - `port`: Port number for the WebSocket server (default: 8765)
 
@@ -162,7 +162,8 @@ class MockInput(FuserInput[MockSensorConfig, Optional[str]]):
                             text = message.decode("utf-8")
                         except Exception as e:
                             logging.warning(
-                                f"Received binary data that couldn't be decoded. Skipping: {e}"
+                                f"Received binary data that couldn't be decoded. "
+                                f"Skipping: {e}"
                             )
                             continue
 

--- a/src/inputs/plugins/odom.py
+++ b/src/inputs/plugins/odom.py
@@ -70,7 +70,10 @@ class Odom(FuserInput[OdomConfig, Optional[dict]]):
             logging.info(f"Odom using Zenoh and URID: {self.URID}")
 
         self.odom = OdomProvider(self.URID, use_zenoh, unitree_ethernet)
-        self.descriptor_for_LLM = "Information about your location and body pose, to help plan your movements."
+        self.descriptor_for_LLM = (
+            "Information about your location and body pose, "
+            "to help plan your movements."
+        )
 
     async def _poll(self) -> Optional[dict]:
         """

--- a/src/inputs/plugins/rplidar.py
+++ b/src/inputs/plugins/rplidar.py
@@ -93,7 +93,10 @@ class RPLidar(FuserInput[RPLidarConfig, Optional[str]]):
         self.lidar: RPLidarProvider = RPLidarProvider(**lidar_config)
         self.lidar.start()
 
-        self.descriptor_for_LLM = "Information about objects and walls around you, to plan your movements and avoid bumping into things."
+        self.descriptor_for_LLM = (
+            "Information about objects and walls around you, "
+            "to plan your movements and avoid bumping into things."
+        )
 
     async def _poll(self) -> Optional[str]:
         """

--- a/src/inputs/plugins/rtk.py
+++ b/src/inputs/plugins/rtk.py
@@ -94,7 +94,10 @@ class Rtk(FuserInput[SensorConfig, Optional[dict]]):
                 lon *= -1.0
 
             if qua > 0:
-                msg = f"Your precise location is {lat} {lat_string}, {lon} {lon_string} at {alt}m altitude. "
+                msg = (
+                    f"Your precise location is {lat} {lat_string}, "
+                    f"{lon} {lon_string} at {alt}m altitude. "
+                )
                 return Message(timestamp=time.time(), message=msg)
             else:
                 return None

--- a/src/inputs/plugins/simple_paths.py
+++ b/src/inputs/plugins/simple_paths.py
@@ -43,7 +43,10 @@ class SimplePaths(FuserInput[SensorConfig, Optional[str]]):
         self.paths_provider: SimplePathsProvider = SimplePathsProvider()
         self.paths_provider.start()
 
-        self.descriptor_for_LLM = "Information about objects and walls around you, to plan your movements and avoid bumping into things."
+        self.descriptor_for_LLM = (
+            "Information about objects and walls around you, "
+            "to plan your movements and avoid bumping into things."
+        )
 
     async def _poll(self) -> Optional[str]:
         """

--- a/src/inputs/plugins/vlm_coco_local.py
+++ b/src/inputs/plugins/vlm_coco_local.py
@@ -70,10 +70,12 @@ class VLM_COCO_Local(FuserInput[VLM_COCO_LocalConfig, Optional[np.ndarray]]):
         # Messages buffer
         self.messages: list[Message] = []
 
-        # Simple description of sensor output to help LLM understand its importance and utility
+        # Simple description of sensor output to help LLM understand its
+        # importance and utility
         self.descriptor_for_LLM = "Object Detector"
 
-        # Low resolution Faster R-CNN model with a MobileNetV3-Large backbone tuned for mobile use cases.
+        # Low resolution Faster R-CNN model with a MobileNetV3-Large backbone
+        # tuned for mobile use cases.
         self.model = detection_model.fasterrcnn_mobilenet_v3_large_320_fpn(
             weights="FasterRCNN_MobileNet_V3_Large_320_FPN_Weights.COCO_V1",
             progress=True,

--- a/src/inputs/plugins/vlm_local_yolo.py
+++ b/src/inputs/plugins/vlm_local_yolo.py
@@ -115,7 +115,8 @@ class VLM_Local_YOLO(FuserInput[VLM_Local_YOLOConfig, Optional[List]]):
         # Messages buffer
         self.messages: list[Message] = []
 
-        # Simple description of sensor output to help LLM understand its importance and utility
+        # Simple description of sensor output to help LLM understand its
+        # importance and utility
         self.descriptor_for_LLM = "Eyes"
 
         # Load model
@@ -271,8 +272,9 @@ class VLM_Local_YOLO(FuserInput[VLM_Local_YOLOConfig, Optional[List]]):
 
     def write_str_to_file(self, json_line: str):
         """
-        Writes a dictionary to a file in JSON lines format. If the file exceeds max_file_size_bytes,
-        creates a new file with a timestamp.
+        Writes a dictionary to a file in JSON lines format.
+
+        If the file exceeds max_file_size_bytes, creates a new file with a timestamp.
 
         Parameters
         ----------

--- a/src/inputs/plugins/wallet_coinbase.py
+++ b/src/inputs/plugins/wallet_coinbase.py
@@ -64,7 +64,8 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
         API_SECRET = os.environ.get("COINBASE_API_SECRET")
         if not API_KEY or not API_SECRET:
             logging.error(
-                "COINBASE_API_KEY or COINBASE_API_SECRET environment variable is not set"
+                "COINBASE_API_KEY or COINBASE_API_SECRET "
+                "environment variable is not set"
             )
         else:
             Cdp.configure(API_KEY, API_SECRET)
@@ -107,7 +108,9 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
         try:
             self.wallet = Wallet.fetch(self.COINBASE_WALLET_ID)  # type: ignore
             logging.info(
-                f"WalletCoinbase: Wallet refreshed: {self.wallet.balance(self.asset_id)}, the current balance is {self.balance}"
+                f"WalletCoinbase: Wallet refreshed: "
+                f"{self.wallet.balance(self.asset_id)}, "
+                f"the current balance is {self.balance}"
             )
             self.balance = float(self.wallet.balance(self.asset_id))
             balance_change = self.balance - self.balance_previous

--- a/src/inputs/plugins/wallet_ethereum.py
+++ b/src/inputs/plugins/wallet_ethereum.py
@@ -82,7 +82,8 @@ class WalletEthereum(FuserInput[SensorConfig, List[float]]):
                 "balance": self.balance_eth,
             }
             logging.debug(
-                f"Block: {self.eth_info['block_number']}, Account Balance: {self.eth_info['balance']:.3f} ETH"
+                f"Block: {self.eth_info['block_number']}, "
+                f"Account Balance: {self.eth_info['balance']:.3f} ETH"
             )
 
             # randomly simulate ETH inbound transfers for debugging purposes


### PR DESCRIPTION
## Summary
- Fix 33 E501 (line too long > 88 characters) violations in the `src/inputs/plugins/` directory
- Apply consistent line wrapping patterns throughout the inputs module

## Changes
| File | Violations Fixed | Description |
|------|-----------------|-------------|
| `amcl_localization_input.py` | 4 | Status messages wrapped at sentence boundaries |
| `battery_turtlebot4.py` | 1 | Comment wrapped |
| `dimo_tesla.py` | 1 | F-string template with variable alias |
| `ethereum_governance.py` | 2 | Error log and hex argument |
| `fabric_closest_peer.py` | 1 | Log message wrapped |
| `face_presence_input.py` | 1 | Docstring parameter wrapped |
| `gallery_identities_input.py` | 1 | Docstring parameter wrapped |
| `google_asr.py` | 1 | Error message wrapped |
| `google_asr_rtsp.py` | 2 | Docstring and error message |
| `gps.py` | 1 | Location message wrapped |
| `gps_odom_reader.py` | 1 | Error message wrapped |
| `lidar_localization_input.py` | 4 | Status messages wrapped |
| `mock_input.py` | 2 | Docstring and warning message |
| `odom.py` | 1 | Descriptor string wrapped |
| `rplidar.py` | 1 | Descriptor string wrapped |
| `rtk.py` | 1 | Message string wrapped |
| `simple_paths.py` | 1 | Descriptor string wrapped |
| `vlm_coco_local.py` | 2 | Comments wrapped |
| `vlm_local_yolo.py` | 2 | Comment and docstring |
| `wallet_coinbase.py` | 2 | Error and log messages |
| `wallet_ethereum.py` | 1 | Log message wrapped |

## Line Wrapping Patterns Applied
```python
# Status messages with parentheses
status_msg = (
    "LOCALIZED: Robot position is confirmed. "
    "Navigation commands are safe to execute."
)

# F-string concatenation
logging.info(
    f"Block: {self.eth_info['block_number']}, "
    f"Account Balance: {self.eth_info['balance']:.3f} ETH"
)

# Comment wrapping
# Simple description of sensor output to help LLM understand its
# importance and utility
```

## Verification
```bash
uv run ruff check src/inputs/ --select=E501 --exclude="*ubtech*,*unitree*"
# All checks passed!

uv run black --check src/inputs/
# All done! 49 files would be left unchanged.

uv run isort --check-only src/inputs/
# No issues

uv run pytest tests/ --ignore=tests/ubtech --ignore=tests/unitree
# 689 passed, 8 skipped
```

## Test Plan
- [x] All E501 violations resolved
- [x] Ruff check passes
- [x] Black formatting check passes
- [x] isort check passes
- [x] Existing tests pass (689 passed, 8 skipped)

## Related PRs
- Part of the E501 fix series
- Related: #1455 (providers), #1456 (runtime), #1458 (actions)