### PR TITLE
fix(llm): resolve E501 line too long violations

### DIFF
--- a/src/llm/function_schemas.py
+++ b/src/llm/function_schemas.py
@@ -38,10 +38,13 @@ def generate_function_schema_from_action(action) -> dict:
     for field_name, field_type in get_type_hints(input_interface).items():
         if isinstance(field_type, type) and issubclass(field_type, Enum):
             enum_values = [v.value for v in field_type]
+            enum_list = ", ".join(enum_values)
             properties[field_name] = {
                 "type": "string",
                 "enum": enum_values,
-                "description": f"The {field_name} to perform. Must be one of: {', '.join(enum_values)}",
+                "description": (
+                    f"The {field_name} to perform. Must be one of: {enum_list}"
+                ),
             }
         elif isinstance(field_type, str):
             properties[field_name] = {

--- a/src/llm/output_model.py
+++ b/src/llm/output_model.py
@@ -10,7 +10,8 @@ class Action(BaseModel):
     type : str
         Type of action to execute, such as 'move' or 'speak'
     value : str
-        The action argument, such as the magnitude of a movement or the sentence to speak
+        The action argument, such as the magnitude of a movement or the
+        sentence to speak
     """
 
     type: str = Field(

--- a/src/llm/plugins/dual_llm.py
+++ b/src/llm/plugins/dual_llm.py
@@ -109,7 +109,8 @@ class DualLLM(LLM[R]):
         Parameters
         ----------
         config : DualLLMConfig
-            Configuration settings for the Dual LLM, including local and cloud LLM details.
+            Configuration settings for the Dual LLM, including local and
+            cloud LLM details.
         available_actions : list[AgentAction], optional
             List of available actions for function calling.
         """
@@ -223,24 +224,20 @@ class DualLLM(LLM[R]):
                 for a in cloud_entry["result"].actions
             ]
 
-            eval_prompt = f"""You are evaluating two AI responses to determine which better answers the user's question.
-
-Original User Question/Context:
-{prompt[:500]}
-
-Response A (local model):
-{json.dumps(local_actions, indent=2)}
-
-Response B (cloud model):
-{json.dumps(cloud_actions, indent=2)}
-
-Evaluate based on:
-1. Relevance - Which response better addresses the user's question?
-2. Completeness - Does it fully answer what was asked?
-3. Appropriateness - Are the actions suitable for the context?
-4. Quality - Is the content natural and engaging?
-
-Respond with ONLY a single word: either "A" or "B" for the better response."""
+            eval_prompt = (
+                "You are evaluating two AI responses to determine "
+                "which better answers the user's question.\n\n"
+                f"Original User Question/Context:\n{prompt[:500]}\n\n"
+                f"Response A (local model):\n{json.dumps(local_actions, indent=2)}\n\n"
+                f"Response B (cloud model):\n{json.dumps(cloud_actions, indent=2)}\n\n"
+                "Evaluate based on:\n"
+                "1. Relevance - Which response better addresses the user's question?\n"
+                "2. Completeness - Does it fully answer what was asked?\n"
+                "3. Appropriateness - Are the actions suitable for the context?\n"
+                "4. Quality - Is the content natural and engaging?\n\n"
+                "Respond with ONLY a single word: either 'A' or 'B' for the better "
+                "response."
+            )
 
             response = await self._eval_client.chat.completions.create(
                 model=self._eval_model,
@@ -366,7 +363,8 @@ Respond with ONLY a single word: either "A" or "B" for the better response."""
             elif len(in_time) == 1:
                 chosen = list(in_time.values())[0]
                 logging.debug(
-                    f"One LLM responded in time, using its response. {chosen['source']} LLM selected."
+                    f"One LLM responded in time, using its response. "
+                    f"{chosen['source']} LLM selected."
                 )
                 # Cancel the other task
                 for name, task in tasks.items():
@@ -386,7 +384,8 @@ Respond with ONLY a single word: either "A" or "B" for the better response."""
                     )
                     chosen = list(done)[0].result()
                     logging.debug(
-                        f"Using first completed LLM response from {chosen['source']} LLM."
+                        f"Using first completed LLM response from "
+                        f"{chosen['source']} LLM."
                     )
                     for task in rest:
                         task.cancel()

--- a/src/llm/plugins/multi_llm.py
+++ b/src/llm/plugins/multi_llm.py
@@ -89,7 +89,9 @@
 
 #             logging.debug(f"MultiLLM system_prompt: {request['system_prompt']}")
 #             logging.debug(f"MultiLLM inputs: {request['inputs']}")
-#             logging.debug(f"MultiLLM available_actions: {request['available_actions']}")
+#             logging.debug(
+#                 f"MultiLLM available_actions: {request['available_actions']}"
+#             )
 
 #             response = requests.post(
 #                 self.endpoint,

--- a/src/llm/plugins/multi_llm_healthy.py
+++ b/src/llm/plugins/multi_llm_healthy.py
@@ -93,7 +93,9 @@
 #             if current_qs is not None:
 #                 request["question_state"] = current_qs
 
-#             logging.debug(f"MultiLLMHealthy system_prompt: {request['system_prompt']}")
+#             logging.debug(
+#                 f"MultiLLMHealthy system_prompt: {request['system_prompt']}"
+#             )
 #             logging.debug(f"MultiLLMHealthy inputs: {request['inputs']}")
 #             logging.debug(
 #                 f"MultiLLMHealthy available_actions: {request['available_actions']}"
@@ -107,13 +109,15 @@
 
 #             if response.status_code != 200:
 #                 logging.error(
-#                     f"API request failed with status {response.status_code}: {response.text}"
+#                     f"API request failed with status {response.status_code}: "
+#                     f"{response.text}"
 #                 )
 #                 return None
 
 #             response_json = response.json()
 
-#             if "extra" in response_json and "question_states" in response_json["extra"]:
+#             if ("extra" in response_json
+#                     and "question_states" in response_json["extra"]):
 #                 new_qs = response_json["extra"].get("question_states")
 #                 self.io_provider.add_dynamic_variable("question_states", new_qs)
 

--- a/src/llm/plugins/openai_spatial_memory.py
+++ b/src/llm/plugins/openai_spatial_memory.py
@@ -56,7 +56,9 @@
 #             self.unitree_go2_location_provider.get_llm_function_mapping()
 #         )
 
-#     async def _execute_function(self, function_name: str, arguments: T.Dict) -> T.Dict:
+#     async def _execute_function(
+#         self, function_name: str, arguments: T.Dict
+#     ) -> T.Dict:
 #         """
 #         Execute a function call using the generated mapping.
 #         Parameters
@@ -81,7 +83,10 @@
 #                 }
 #         except Exception as e:
 #             logging.error(f"Error executing function {function_name}: {e}")
-#             return {"success": False, "message": f"Error executing function: {str(e)}"}
+#             return {
+#                 "success": False,
+#                 "message": f"Error executing function: {str(e)}"
+#             }
 
 #     async def ask(
 #         self, prompt: str, messages: T.List[T.Dict[str, str]] = []
@@ -105,7 +110,8 @@
 #             if self.available_functions:
 #                 prompt += "\n\nAVAILABLE FUNCTIONS:\n"
 #                 for func in self.available_functions.values():
-#                     prompt += f'- {func["function"]["name"]}: {func["function"]["description"]}\n'
+#                     fn = func["function"]
+#                     prompt += f'- {fn["name"]}: {fn["description"]}\n'
 #                 available_locations = (
 #                     self.unitree_go2_location_provider.list_location_names()
 #                 )
@@ -141,7 +147,8 @@
 #                 function_args = json.loads(tool_call.function.arguments)
 
 #                 logging.info(
-#                     f"Function call detected: {function_name} with args {function_args}"
+#                     f"Function call detected: {function_name} "
+#                     f"with args {function_args}"
 #                 )
 #                 function_result = await self._execute_function(
 #                     function_name, function_args
@@ -151,7 +158,8 @@
 #                 prompt += f"\n\nFunction {function_name} returned: {function_result}"
 
 #                 prompt += (
-#                     "\n\nBased on the function result, please provide a final response."
+#                     "\n\nBased on the function result, "
+#                     "please provide a final response."
 #                 )
 
 #             response = await self._client.beta.chat.completions.parse(

--- a/src/llm/plugins/openrouter.py
+++ b/src/llm/plugins/openrouter.py
@@ -16,11 +16,13 @@ R = T.TypeVar("R", bound=BaseModel)
 
 class OpenRouter(LLM[R]):
     """
-    An OpenRouter-based Language Learning Model implementation with function call support.
+    An OpenRouter-based Language Learning Model implementation with function
+    call support.
 
-    This class implements the LLM interface for OpenRouter's models (Meta and Anthropic), handling
-    configuration, authentication, and async API communication. It supports both
-    traditional JSON structured output and function calling.
+    This class implements the LLM interface for OpenRouter's models (Meta and
+    Anthropic), handling configuration, authentication, and async API
+    communication. It supports both traditional JSON structured output and
+    function calling.
 
     Parameters
     ----------

--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -91,8 +91,8 @@ class QwenLLM(LLM[R]):
         """
         Initialize the QwenLLM instance.
 
-        Sets up the async client for the local Qwen model, configures extra body parameters,
-        and initializes the history manager.
+        Sets up the async client for the local Qwen model, configures extra
+        body parameters, and initializes the history manager.
 
         Parameters
         ----------

--- a/src/llm/plugins/rag_multi_llm.py
+++ b/src/llm/plugins/rag_multi_llm.py
@@ -107,7 +107,8 @@
 #                             if rag_tools:
 #                                 logging.info(f"RAG tools data: {rag_tools}")
 #                                 tools_lines = [
-#                                     "\n\nThe following tools were used to gather this information:"
+#                                     "\n\nThe following tools were used "
+#                                     "to gather this information:"
 #                                 ]
 #                                 tools_lines += [
 #                                     f"- {tool.get('tool_name', 'Unknown tool')}"
@@ -151,7 +152,9 @@
 
 #             logging.debug(f"MultiLLM system_prompt: {request['system_prompt']}")
 #             logging.debug(f"MultiLLM inputs: {request['inputs']}")
-#             logging.debug(f"MultiLLM available_actions: {request['available_actions']}")
+#             logging.debug(
+#                 f"MultiLLM available_actions: {request['available_actions']}"
+#             )
 
 #             response = requests.post(
 #                 self.endpoint,


### PR DESCRIPTION
## Summary
- Fix 20 E501 (line too long > 88 characters) violations in the `src/llm/` directory
- Apply consistent line wrapping patterns throughout the LLM module

## Changes
| File | Violations Fixed | Description |
|------|-----------------|-------------|
| `function_schemas.py` | 1 | Description f-string wrapped with parentheses |
| `output_model.py` | 1 | Docstring parameter wrapped |
| `plugins/dual_llm.py` | 5 | Docstrings, eval prompt, log messages |
| `plugins/multi_llm.py` | 1 | Commented debug log wrapped |
| `plugins/multi_llm_healthy.py` | 4 | Commented code wrapped |
| `plugins/openai_spatial_memory.py` | 5 | Commented code wrapped |
| `plugins/openrouter.py` | 2 | Class docstring wrapped |
| `plugins/qwen_llm.py` | 1 | Method docstring wrapped |
| `plugins/rag_multi_llm.py` | 2 | Commented code wrapped |

## Verification
```bash
uv run ruff check src/llm/ --select=E501
# All checks passed!

uv run black --check src/llm/
# All done! 17 files would be left unchanged.

uv run isort --check-only src/llm/
# No issues

uv run pytest tests/ --ignore=tests/ubtech --ignore=tests/unitree
# 689 passed, 8 skipped
```

## Test Plan
- [x] All E501 violations resolved
- [x] Full ruff check passes
- [x] Black formatting check passes
- [x] isort check passes
- [x] Existing tests pass (689 passed, 8 skipped)

## Related PRs
- Part of the E501 fix series
- Related: #1455 (providers), #1456 (runtime), #1458 (actions), #1460 (inputs)