### PR TITLE
fix(backgrounds): resolve E501 line too long violations

### DIFF
--- a/src/backgrounds/plugins/odom.py
+++ b/src/backgrounds/plugins/odom.py
@@ -50,12 +50,13 @@ class Odom(Background[OdomConfig]):
         Parameters
         ----------
         config : OdomConfig
-            Configuration object for the odometry background task. The configuration
-            specifies the connection method (Zenoh or Unitree Ethernet) and
-            required connection parameters (URID for Zenoh, ethernet channel for Unitree).
-            If use_zenoh is True, the provider will subscribe to odometry data via Zenoh
-            using the specified URID. If use_zenoh is False and unitree_ethernet is provided,
-            the provider will connect directly to Unitree hardware via Ethernet.
+            Configuration object for the odometry background task. The
+            configuration specifies the connection method (Zenoh or Unitree
+            Ethernet) and required connection parameters (URID for Zenoh,
+            ethernet channel for Unitree). If use_zenoh is True, the provider
+            will subscribe to odometry data via Zenoh using the specified URID.
+            If use_zenoh is False and unitree_ethernet is provided, the provider
+            will connect directly to Unitree hardware via Ethernet.
         """
         super().__init__(config)
 

--- a/src/backgrounds/plugins/rf_mapper.py
+++ b/src/backgrounds/plugins/rf_mapper.py
@@ -159,8 +159,9 @@ class RFmapper(Background[RFmapperConfig]):
             if advdata.service_uuids:
                 service_uuid = advdata.service_uuids[0]
 
-            # we want to update everything EXCEPT we do not want to overwrite a resolved name
-            # and we do not want to replace a long mfgval with a short one
+            # we want to update everything EXCEPT we do not want to overwrite
+            # a resolved name and we do not want to replace a long mfgval
+            # with a short one
             # we also want to update the TX power if we receive those data
             rssi = advdata.rssi
             tx_power = advdata.tx_power

--- a/src/backgrounds/plugins/unitree_g1_locations.py
+++ b/src/backgrounds/plugins/unitree_g1_locations.py
@@ -73,5 +73,6 @@ class UnitreeG1Locations(Background[UnitreeG1LocationsConfig]):
         )
         self.locations_provider.start()
         logging.info(
-            f"G1 Locations Provider initialized in background (base_url: {base_url}, refresh: {refresh_interval}s)"
+            f"G1 Locations Provider initialized in background "
+            f"(base_url: {base_url}, refresh: {refresh_interval}s)"
         )

--- a/src/backgrounds/plugins/unitree_go2_amcl.py
+++ b/src/backgrounds/plugins/unitree_go2_amcl.py
@@ -6,15 +6,17 @@ from providers.unitree_go2_amcl_provider import UnitreeGo2AMCLProvider
 
 class UnitreeGo2AMCL(Background[BackgroundConfig]):
     """
-    Background task for reading AMCL (Adaptive Monte Carlo Localization) data from Unitree Go2 robot.
+    Background task for reading AMCL (Adaptive Monte Carlo Localization) data
+    from Unitree Go2 robot.
 
-    This background task initializes and manages the UnitreeGo2AMCLProvider, which subscribes to
-    AMCL pose data via Zenoh messaging. AMCL is a probabilistic localization algorithm that uses
-    particle filters to estimate the robot's pose in a known map.
+    This background task initializes and manages the UnitreeGo2AMCLProvider,
+    which subscribes to AMCL pose data via Zenoh messaging. AMCL is a
+    probabilistic localization algorithm that uses particle filters to
+    estimate the robot's pose in a known map.
 
-    The provider continuously monitors the robot's localization status and pose information,
-    which is essential for autonomous navigation, path planning, and obstacle avoidance on the
-    Unitree Go2 platform.
+    The provider continuously monitors the robot's localization status and
+    pose information, which is essential for autonomous navigation, path
+    planning, and obstacle avoidance on the Unitree Go2 platform.
 
     Notes
     -----
@@ -35,9 +37,10 @@ class UnitreeGo2AMCL(Background[BackgroundConfig]):
 
         Notes
         -----
-        The UnitreeGo2AMCLProvider is automatically started during initialization and will
-        begin subscribing to AMCL pose messages via Zenoh. The provider runs as a singleton,
-        so multiple instances of this background task will share the same provider instance.
+        The UnitreeGo2AMCLProvider is automatically started during
+        initialization and will begin subscribing to AMCL pose messages via
+        Zenoh. The provider runs as a singleton, so multiple instances of
+        this background task will share the same provider instance.
         """
         super().__init__(config)
 

--- a/src/backgrounds/plugins/unitree_go2_locations.py
+++ b/src/backgrounds/plugins/unitree_go2_locations.py
@@ -56,5 +56,6 @@ class UnitreeGo2Locations(Background[UnitreeGo2LocationsConfig]):
         self.locations_provider.start()
 
         logging.info(
-            f"Locations Provider initialized in background (base_url: {base_url}, refresh: {refresh_interval}s)"
+            f"Locations Provider initialized in background "
+            f"(base_url: {base_url}, refresh: {refresh_interval}s)"
         )


### PR DESCRIPTION
## Summary
- Fix E501 (line too long > 88 chars) violations in `src/backgrounds/plugins/`
- Part of E501 fix series across the codebase

## Changes

| File | Violations | Fix Type |
|------|------------|----------|
| `odom.py` | 3 | Docstring line wrapping |
| `rf_mapper.py` | 1 | Comment line wrapping |
| `unitree_g1_locations.py` | 1 | Log message f-string wrapping |
| `unitree_go2_amcl.py` | 7 | Docstring line wrapping |
| `unitree_go2_locations.py` | 1 | Log message f-string wrapping |

**Total: 5 files, 13 violations fixed**

## Example Fixes

### Docstring wrapping (unitree_go2_amcl.py)
```python
# Before
"""
Background task for reading AMCL (Adaptive Monte Carlo Localization) data from Unitree Go2 robot.
"""

# After
"""
Background task for reading AMCL (Adaptive Monte Carlo Localization) data
from Unitree Go2 robot.
"""
```

### Log message f-string wrapping (unitree_g1_locations.py)
```python
# Before
logging.info(f"G1 Locations Provider initialized in background (base_url: {base_url}, refresh: {refresh_interval}s)")

# After
logging.info(
    f"G1 Locations Provider initialized in background "
    f"(base_url: {base_url}, refresh: {refresh_interval}s)"
)
```

## Related PRs
- PR #1455: `fix(providers): resolve E501 line too long violations`
- PR #1456: `fix(runtime): resolve E501 line too long violations`
- PR #1458: `fix(actions): resolve E501 line too long violations`
- PR #1460: `fix(inputs): resolve E501 line too long violations`
- PR #1462: `fix(llm): resolve E501 line too long violations`

## Test Plan
- [x] `ruff check src/backgrounds/` - No E501 violations
- [x] `pre-commit run --all-files` - All checks pass
- [x] `uv run pytest` - 689 passed, 1 failed (ubtech unrelated), 8 skipped