### PR TITLE
fix(hooks): resolve E501 line too long violations

### DIFF
--- a/src/hooks/nav2_hook.py
+++ b/src/hooks/nav2_hook.py
@@ -48,12 +48,9 @@ async def start_nav2_hook(context: Dict[str, Any]):
                         error_info = await response.json()
                     except Exception as _:
                         error_info = {"message": "Unknown error"}
-                    logging.error(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
-                    raise Exception(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
+                    err_msg = error_info.get("message", "Unknown error")
+                    logging.error(f"Failed to start Nav2: {err_msg}")
+                    raise Exception(f"Failed to start Nav2: {err_msg}")
 
     except aiohttp.ClientError as e:
         logging.error(f"Error calling Nav2 API: {str(e)}")
@@ -95,12 +92,9 @@ async def stop_nav2_hook(context: Dict[str, Any]):
                         error_info = await response.json()
                     except Exception as _:
                         error_info = {"message": "Unknown error"}
-                    logging.error(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
-                    raise Exception(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
+                    err_msg = error_info.get("message", "Unknown error")
+                    logging.error(f"Failed to start Nav2: {err_msg}")
+                    raise Exception(f"Failed to start Nav2: {err_msg}")
 
     except aiohttp.ClientError as e:
         logging.error(f"Error calling Nav2 API: {str(e)}")

--- a/src/hooks/slam_hook.py
+++ b/src/hooks/slam_hook.py
@@ -41,12 +41,9 @@ async def start_slam_hook(context: Dict[str, Any]):
                         error_info = await response.json()
                     except Exception as _:
                         error_info = {"message": "Unknown error"}
-                    logging.error(
-                        f"Failed to start SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
-                    raise Exception(
-                        f"Failed to start SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
+                    err_msg = error_info.get("message", "Unknown error")
+                    logging.error(f"Failed to start SLAM: {err_msg}")
+                    raise Exception(f"Failed to start SLAM: {err_msg}")
 
     except aiohttp.ClientError as e:
         logging.error(f"Error calling SLAM API: {str(e)}")
@@ -83,9 +80,8 @@ async def stop_slam_hook(context: Dict[str, Any]):
 
                 if save_response.status == 200:
                     save_result = await save_response.json()
-                    logging.info(
-                        f"SLAM map saved successfully: {save_result.get('message', 'Success')}"
-                    )
+                    msg = save_result.get("message", "Success")
+                    logging.info(f"SLAM map saved successfully: {msg}")
                     elevenlabs_provider.add_pending_message(
                         "Map has been saved successfully."
                     )
@@ -94,12 +90,9 @@ async def stop_slam_hook(context: Dict[str, Any]):
                         error_info = await save_response.json()
                     except Exception as _:
                         error_info = {"message": "Unknown error"}
-                    logging.error(
-                        f"Failed to save SLAM map: {error_info.get('message', 'Unknown error')}"
-                    )
-                    raise Exception(
-                        f"Failed to save SLAM map: {error_info.get('message', 'Unknown error')}"
-                    )
+                    err_msg = error_info.get("message", "Unknown error")
+                    logging.error(f"Failed to save SLAM map: {err_msg}")
+                    raise Exception(f"Failed to save SLAM map: {err_msg}")
 
             # Stop the SLAM process
             async with session.post(
@@ -123,12 +116,9 @@ async def stop_slam_hook(context: Dict[str, Any]):
                         error_info = await response.json()
                     except Exception as _:
                         error_info = {"message": "Unknown error"}
-                    logging.error(
-                        f"Failed to stop SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
-                    raise Exception(
-                        f"Failed to stop SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
+                    err_msg = error_info.get("message", "Unknown error")
+                    logging.error(f"Failed to stop SLAM: {err_msg}")
+                    raise Exception(f"Failed to stop SLAM: {err_msg}")
 
     except aiohttp.ClientError as e:
         logging.error(f"Error calling SLAM API: {str(e)}")


### PR DESCRIPTION
## Summary
- Fix E501 (line too long > 88 chars) violations in `src/hooks/`
- Part of E501 fix series across the codebase

## Changes

| File | Violations | Fix Type |
|------|------------|----------|
| `nav2_hook.py` | 4 | Extract error message to variable |
| `slam_hook.py` | 7 | Extract error/success message to variable |

**Total: 2 files, 11 violations fixed**

## Example Fix

```python
# Before
logging.error(
    f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
)
raise Exception(
    f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
)

# After
err_msg = error_info.get("message", "Unknown error")
logging.error(f"Failed to start Nav2: {err_msg}")
raise Exception(f"Failed to start Nav2: {err_msg}")
```

## Related PRs
- PR #1455: `fix(providers): resolve E501 line too long violations`
- PR #1456: `fix(runtime): resolve E501 line too long violations`
- PR #1458: `fix(actions): resolve E501 line too long violations`
- PR #1460: `fix(inputs): resolve E501 line too long violations`
- PR #1462: `fix(llm): resolve E501 line too long violations`
- PR #1463: `fix(backgrounds): resolve E501 line too long violations`

## Test Plan
- [x] `ruff check src/hooks/` - No E501 violations
- [x] `pre-commit run --files src/hooks/*` - All checks pass