### PR TITLE
fix: correct logging name in simple_paths_processor

### DIFF
--- a/src/providers/simple_paths_provider.py
+++ b/src/providers/simple_paths_provider.py
@@ -28,7 +28,7 @@ def simple_paths_processor(
     control_queue : mp.Queue
         Queue for sending control commands.
     """
-    setup_logging("rplidar_processor", logging_config=logging_config)
+    setup_logging("simple_paths_processor", logging_config=logging_config)
 
     def paths_callback(msg: zenoh.Sample):
         """


### PR DESCRIPTION
## Summary
Fixes copy-paste error in logging setup.

## Bug
In `simple_paths_provider.py`, the `setup_logging()` call was using `"rplidar_processor"` instead of `"simple_paths_processor"`. This causes incorrect logging labels.

## Fix
Changed logging name from `"rplidar_processor"` to `"simple_paths_processor"`.

## Changes
- `src/providers/simple_paths_provider.py` - Line 31