### PR TITLE
fix: correct publisher attribute name and cleanup method in ROS2Publi…

### DIFF
--- a/src/providers/ros2_publisher_provider.py
+++ b/src/providers/ros2_publisher_provider.py
@@ -103,5 +103,5 @@ class ROS2PublisherProvider(Node):
         self.running = False
         if self._thread:
             self._thread.join(timeout=5)
-        self._publisher.Close()
+        self.destroy_publisher(self.publisher_)
         logging.info("ROS2 Publisher Provider stopped")


### PR DESCRIPTION
## Summary
Fixes incorrect attribute name and method call in stop() cleanup.

## Bug
In `ros2_publisher_provider.py`, the `stop()` method had two issues:
1. Wrong attribute name: `self._publisher` instead of `self.publisher_`
2. Wrong method: `Close()` doesn't exist for ROS2 publishers

## Fix
Changed `self._publisher.Close()` to `self.destroy_publisher(self.publisher_)` which:
- Uses the correct attribute name (`publisher_` as defined on line 28)
- Uses the proper ROS2 cleanup method (`destroy_publisher()`)

## Changes
- `src/providers/ros2_publisher_provider.py` - Line 106