### PR TITLE
fix: Copy-paste error - log message says OpenAI LLM fun

### DIFF
--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -117,7 +117,7 @@ class GeminiLLM(LLM[R]):
                 actions = convert_function_calls_to_actions(function_call_data)
 
                 result = CortexOutputModel(actions=actions)
-                logging.info(f"OpenAI LLM function call output: {result}")
+                logging.info(f"Gemini LLM function call output: {result}")
                 return T.cast(R, result)
 
             return None


### PR DESCRIPTION
## Summary
Auto-generated bug fix by TeamVT Bug Hunter Agent v3.1

## Bug
Copy-paste error - log message says "OpenAI LLM function call output" but this is Gemini LLM

## Changes
- src/llm/plugins/gemini_llm.py