### PR TITLE
fix: Copy-paste error in logging message - says OpenAI 

### DIFF
--- a/src/llm/plugins/near_ai_llm.py
+++ b/src/llm/plugins/near_ai_llm.py
@@ -126,7 +126,7 @@ class NearAILLM(LLM[R]):
                 actions = convert_function_calls_to_actions(function_call_data)
 
                 result = CortexOutputModel(actions=actions)
-                logging.info(f"OpenAI LLM function call output: {result}")
+                logging.info(f"NearAI LLM function call output: {result}")
                 return T.cast(R, result)
 
             return None


### PR DESCRIPTION
## Summary
Auto-generated bug fix by TeamVT Bug Hunter Agent v3.1

## Bug
Copy-paste error in logging message - says "OpenAI LLM" instead of "NearAI LLM"

## Changes
- src/llm/plugins/near_ai_llm.py

---