### PR TITLE
fix: correct copy-paste errors in rplidar_driver exception messages

### DIFF
--- a/src/providers/rplidar_driver.py
+++ b/src/providers/rplidar_driver.py
@@ -309,7 +309,7 @@ class RPDriver(object):
         self._send_cmd(GET_HEALTH_BYTE)
         dsize, is_single, dtype = self._read_descriptor()
         if dsize != HEALTH_LEN:
-            raise RPLidarException("Wrong get_info reply length")
+            raise RPLidarException("Wrong get_health reply length")
         if not is_single:
             raise RPLidarException("Not a single response mode")
         if dtype != HEALTH_TYPE:
@@ -377,7 +377,7 @@ class RPDriver(object):
 
         dsize, is_single, dtype = self._read_descriptor()
         if dsize != _SCAN_TYPE[scan_type]["size"]:
-            raise RPLidarException("Wrong get_info reply length")
+            raise RPLidarException("Wrong scan reply length")
         if is_single:
             raise RPLidarException("Not a multiple response mode")
         if dtype != _SCAN_TYPE[scan_type]["response"]:


### PR DESCRIPTION
## Summary
Fixes copy-paste errors in exception messages in rplidar_driver.py.

## Bug
Two exception messages incorrectly referenced `get_info` instead of the actual function context:

1. Line 312: Inside `get_health()` function, error message said "Wrong get_info reply length" - should say "Wrong get_health reply length"

2. Line 380: Inside scan function, error message said "Wrong get_info reply length" - should say "Wrong scan reply length"

## Changes
- `src/providers/rplidar_driver.py` - Fixed 2 exception messages