### PR TITLE
fix: Wrong service type mentioned in class docstring - 

### DIFF
--- a/src/providers/vlm_openai_rtsp_provider.py
+++ b/src/providers/vlm_openai_rtsp_provider.py
@@ -14,7 +14,7 @@ from .singleton import singleton
 @singleton
 class VLMOpenAIRTSPProvider:
     """
-    VLM Provider that handles audio streaming and websocket communication.
+    VLM Provider that handles video streaming and websocket communication.
 
     This class implements a singleton pattern to manage video stream from RTSP and websocket
     communication for vlm services. It runs in a separate thread to handle


### PR DESCRIPTION
## Summary
Wrong service type mentioned in class docstring - says "audio streaming" but this is a video/VLM provider

## Changes
- src/providers/vlm_openai_rtsp_provider.py

## Fix Details
- Changed VLM Provider that handles audio streaming and websocket communication. to VLM Provider that handles video streaming and websocket communication.