### PR TITLE
fix: detect complex config content changes for selective hot-reload

### DIFF
--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -309,23 +309,10 @@ class CortexRuntime:
             old_value = getattr(old_config, field, None)
             new_value = getattr(new_config, field, None)
             try:
-                # Simple length check first
-                if old_value is None and new_value is not None:
+                if old_value != new_value:
                     changed_fields.add(field)
-                elif old_value is not None and new_value is None:
-                    changed_fields.add(field)
-                elif old_value is not None and new_value is not None:
-                    # Check if both are lists and compare lengths
-                    if hasattr(old_value, "__len__") and hasattr(new_value, "__len__"):
-                        if len(old_value) != len(new_value):
-                            changed_fields.add(field)
-                            logging.debug(
-                                f"Config field '{field}' changed (length differs)"
-                            )
-                    elif old_value is not new_value:
-                        # Different objects, assume changed
-                        changed_fields.add(field)
-            except (TypeError, AttributeError):
+                    logging.debug(f"Config field '{field}' changed")
+            except Exception:
                 # If comparison fails, assume it changed to be safe
                 changed_fields.add(field)
                 logging.debug(

--- a/tests/runtime/single_mode/test_selective_hot_reload.py
+++ b/tests/runtime/single_mode/test_selective_hot_reload.py
@@ -158,6 +158,16 @@ class TestDetectConfigChanges:
 
         assert "agent_inputs" in changed
 
+
+    def test_detects_agent_inputs_content_change_same_length(self, runtime):
+        """Detect changes when agent_inputs content changes but length stays the same."""
+        old_config = MockRuntimeConfig(agent_inputs=[MagicMock(name="old_input")])
+        new_config = MockRuntimeConfig(agent_inputs=[MagicMock(name="new_input")])
+
+        changed = runtime._detect_config_changes(old_config, new_config)
+
+        assert "agent_inputs" in changed
+
     def test_detects_cortex_llm_change(self, runtime):
         """Test detection of cortex_llm instance change."""
         llm1 = MagicMock()


### PR DESCRIPTION
## Overview
Fixes a false-negative in selective hot-reload config change detection: complex fields (e.g., `agent_inputs`) were previously checked by length/identity, so same-length content changes could be missed. This can skip a required full reload for unsafe config changes.

Linked issue: #984  
Related PR: #1312

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [x] Bounty issue submission
- [ ] Other:

## Changes
- Update `_detect_config_changes` to compare complex config fields using deep equality (`old_value != new_value`) instead of only length/identity checks.
- Add a regression test ensuring `agent_inputs` content changes are detected even when list length stays the same.

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not needed)
- [x] Local testing completed
- [x] Tests added/updated

## Impact
Improves correctness of hot-reload behavior by ensuring unsafe config changes are reliably detected and trigger a full reload when required. Low risk: if deep comparison fails, logic fails safe by treating the field as changed.

## Additional Information
Tested with:
- `uv run pytest tests/runtime/single_mode/test_selective_hot_reload.py -v` (18 passed)
