### PR TITLE
fix: skip LLM calls when all sensor inputs are empty

### DIFF
--- a/src/fuser/__init__.py
+++ b/src/fuser/__init__.py
@@ -40,7 +40,7 @@ class Fuser:
         self.config = config
         self.io_provider = IOProvider()
 
-    def fuse(self, inputs: list[Sensor], finished_promises: list[T.Any]) -> str:
+    def fuse(self, inputs: list[Sensor], finished_promises: list[T.Any]) -> str | None:
         """
         Combine all inputs into a single formatted prompt string.
 
@@ -56,8 +56,9 @@ class Fuser:
 
         Returns
         -------
-        str
-            Fused prompt string combining all inputs and context.
+        str | None
+            Fused prompt string combining all inputs and context, or None if
+            no meaningful inputs are available (prevents wasteful LLM calls).
         """
         # Record the timestamp of the input
         self.io_provider.fuser_start_time = time.time()
@@ -68,7 +69,19 @@ class Fuser:
         # Combine all inputs, memories, and configurations into a single prompt
         system_prompt = "\nBASIC CONTEXT:\n" + self.config.system_prompt_base + "\n"
 
-        inputs_fused = " ".join([s for s in input_strings if s is not None])
+        # Filter out None and empty/whitespace-only strings
+        inputs_fused = " ".join([s for s in input_strings if s and s.strip()])
+
+        # Skip LLM call if no meaningful inputs are present (fixes Issue #1025)
+        # This prevents wasteful API calls and 429 rate limiting
+        if not inputs_fused or not inputs_fused.strip():
+            logging.debug(
+                "Skipping LLM call: no meaningful sensor inputs available. "
+                "This prevents wasteful API consumption and rate limiting."
+            )
+            # Record the timestamp before returning
+            self.io_provider.fuser_end_time = time.time()
+            return None
 
         # if we provide laws from blockchain, these override the locally stored rules
         # the rules are not provided in the system prompt, but as a separate INPUT,

--- a/tests/fuser/test_init.py
+++ b/tests/fuser/test_init.py
@@ -10,11 +10,12 @@ from runtime.single_mode.config import RuntimeConfig
 
 @dataclass
 class MockSensor(Sensor[SensorConfig, Any]):
-    def __init__(self):
+    def __init__(self, buffer_value="test input"):
         super().__init__(SensorConfig())
+        self._buffer_value = buffer_value
 
     def formatted_latest_buffer(self):
-        return "test input"
+        return self._buffer_value
 
 
 @dataclass
@@ -94,3 +95,67 @@ def test_fuser_with_inputs_and_actions(mock_describe):
             io_provider.fuser_available_actions
             == "AVAILABLE ACTIONS:\naction description\n\naction description\n\n\n\nWhat will you do? Actions:"
         )
+
+
+@patch("time.time")
+def test_fuser_skips_empty_inputs(mock_time):
+    """Test that fuser returns None when all inputs are empty (fixes Issue #1025)."""
+    mock_time.return_value = 1000
+    config = create_mock_config()
+    io_provider = IOProvider()
+
+    # Test with empty string inputs
+    empty_inputs: list[Sensor[Any, Any]] = [MockSensor(""), MockSensor("   ")]
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(empty_inputs, [])
+
+        # Should return None to prevent wasteful LLM calls
+        assert result is None
+        assert io_provider.fuser_start_time == 1000
+
+
+@patch("time.time")
+def test_fuser_skips_none_inputs(mock_time):
+    """Test that fuser returns None when all inputs are None."""
+    mock_time.return_value = 1000
+    config = create_mock_config()
+    io_provider = IOProvider()
+
+    # Test with None inputs
+    none_inputs: list[Sensor[Any, Any]] = [MockSensor(None), MockSensor(None)]
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(none_inputs, [])
+
+        # Should return None to prevent wasteful LLM calls
+        assert result is None
+        assert io_provider.fuser_start_time == 1000
+
+
+@patch("fuser.describe_action")
+@patch("time.time")
+def test_fuser_processes_mixed_inputs(mock_time, mock_describe):
+    """Test that fuser processes inputs when at least one is meaningful."""
+    mock_time.return_value = 1000
+    mock_describe.return_value = "action description"
+    config = create_mock_config(agent_actions=[MockAction("action1")])
+    io_provider = IOProvider()
+
+    # Mix of empty and meaningful inputs
+    mixed_inputs: list[Sensor[Any, Any]] = [
+        MockSensor(""),
+        MockSensor("meaningful input"),
+        MockSensor(None),
+    ]
+
+    with patch("fuser.IOProvider", return_value=io_provider):
+        fuser = Fuser(config)
+        result = fuser.fuse(mixed_inputs, [])
+
+        # Should process the meaningful input
+        assert result is not None
+        assert "meaningful input" in result
+        assert io_provider.fuser_inputs == "meaningful input"


### PR DESCRIPTION
## Summary
Fixes #1025 and #1372 by preventing empty or meaningless sensor inputs from triggering LLM API calls, eliminating wasteful requests and 429 rate limiting errors.

## Problem
When all sensor inputs are empty/None:
- Fuser still constructs and sends prompts to LLM
- Causes rapid, meaningless API requests
- Triggers 429 rate limiting
- Wastes API quota and credits
- Reported in Issue #1025: "Spot repeatedly sends empty sensor prompts causing rapid LLM requests and 429 rate limiting"

## Root Cause
In `src/fuser/__init__.py` line 71, the code only filtered `None` values:
```python
inputs_fused = " ".join([s for s in input_strings if s is not None])
```
Empty strings and whitespace-only strings passed through, resulting in meaningless prompts.

## Solution
1. **Enhanced filtering**: Now filters both `None` AND empty/whitespace strings
2. **Early return**: Returns `None` when no meaningful inputs exist
3. **Graceful handling**: Runtime already checks for `None` and skips LLM calls
4. **Proper logging**: Logs why LLM call was skipped for debugging

## Changes
- `src/fuser/__init__.py`:
  - Updated input filtering logic (line 73)
  - Added meaningful input validation (lines 75-84)
  - Updated return type annotation to `str | None`
  - Ensure `fuser_end_time` is set even when returning None

- `tests/fuser/test_init.py`:
  - Made `MockSensor` configurable for testing different input values
  - Added `test_fuser_skips_empty_inputs()` - validates empty string handling
  - Added `test_fuser_skips_none_inputs()` - validates None handling
  - Added `test_fuser_processes_mixed_inputs()` - ensures valid inputs still process

## Testing
```bash
$ uv run pytest tests/fuser/test_init.py -v
...
tests/fuser/test_init.py::test_fuser_skips_empty_inputs PASSED
tests/fuser/test_init.py::test_fuser_skips_none_inputs PASSED
tests/fuser/test_init.py::test_fuser_processes_mixed_inputs PASSED
============================== 6 passed in 0.18s ===============================
```

## Impact
- ✅ Eliminates 429 rate limiting errors from empty inputs
- ✅ Preserves API quota and reduces costs
- ✅ Improves system responsiveness (skips unnecessary network calls)
- ✅ Fully backward compatible (runtime already handles None)
- ✅ Comprehensive test coverage

## Before vs After
**Before:**
```
Empty sensors → Fuser creates prompt → LLM call → Wastes API quota → 429 error
```

**After:**
```
Empty sensors → Fuser detects → Returns None → Runtime skips LLM → No API waste
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)