### PR TITLE
docs: add macOS camera permission troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ After launching OM1, the Spot agent will interact with you and perform (simulate
 Note: This is just an example agent configuration.
 If you want to interact with the agent and see how it works, make sure ASR and TTS are configured in spot.json5.
 
+#### macOS Camera Permission (Important!)
+
+If you're running on macOS and the Spot agent uses camera inputs, you may see an error like:
+```
+OpenCV: not authorized to capture video (status 0), requesting...
+OpenCV: camera failed to properly initialize!
+ERROR: COCO did not find cam: 0
+```
+
+**To fix this:**
+
+1. Open **System Settings** → **Privacy & Security** → **Camera**
+2. Find and enable camera access for:
+   - **Terminal** (if running from Terminal.app)
+   - **iTerm** (if using iTerm2)
+   - **Your IDE** (if running from VS Code, PyCharm, etc.)
+3. Restart the OM1 application after granting permission
+
+**Alternative:** You can test with a simulated camera input by modifying the agent configuration to use a different input source that doesn't require camera access.
+
 ## What's Next?
 
 * Try out some [examples](https://docs.openmind.org/examples)


### PR DESCRIPTION
## Summary
Fixes #1176 by adding comprehensive macOS camera permission documentation to the Getting Started guide.

## Problem
macOS users encounter camera permission errors when running the Spot agent:
```
OpenCV: not authorized to capture video (status 0), requesting...
OpenCV: camera failed to properly initialize!
ERROR: COCO did not find cam: 0
```

The README didn't mention this macOS-specific requirement, leaving users confused about why vision inputs fail.

## Solution
Added a dedicated "macOS Camera Permission (Important!)" section to the README under "Launching OM1" that:
- Shows the exact error message users will encounter
- Provides clear, step-by-step fix instructions
- Covers multiple terminal environments (Terminal.app, iTerm, IDEs)
- Includes alternative workaround for testing without camera access

## Changes
- `README.md`:
  - Added "macOS Camera Permission (Important!)" subsection after "Launching OM1"
  - Included actual error output for easy searchability
  - Step-by-step instructions with System Settings navigation
  - Alternative solution for non-camera testing

## Testing
- ✅ Verified error message matches actual OpenCV output on macOS
- ✅ Confirmed fix works (tested during OM1 setup on macOS Sequoia)
- ✅ Documentation clearly visible in Getting Started workflow

## Impact
- ✅ Prevents confusion for new macOS users
- ✅ Reduces support burden for maintainers
- ✅ Improves first-run experience
- ✅ Easy to find (appears immediately after launch instructions)

## Real-World Validation
This documentation was created based on actual experience running OM1 on macOS and encountering this exact issue. The solution steps were verified to work on:
- macOS Sequoia
- Terminal.app
- With Spot agent using VLM_COCO_Local input

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)