### PR TITLE
docs: fix systemd target typo in pre_config

### DIFF
--- a/docs/full_autonomy_guidelines/pre_config.mdx
+++ b/docs/full_autonomy_guidelines/pre_config.mdx
@@ -219,7 +219,7 @@ Note: To stop the kiosk service, use sudo systemctl stop kiosk.service.
     RemainAfterExit=no
 
     [Install]
-    WantedBy=multi-user.Target
+    WantedBy=multi-user.target
 
     sudo systemctl daemon-reload
     sudo systemctl enable om1-container.service

--- a/mintlify/full_autonomy_guidelines/pre_config.mdx
+++ b/mintlify/full_autonomy_guidelines/pre_config.mdx
@@ -219,7 +219,7 @@ Note: To stop the kiosk service, use sudo systemctl stop kiosk.service.
     RemainAfterExit=no
 
     [Install]
-    WantedBy=multi-user.Target
+    WantedBy=multi-user.target
 
     sudo systemctl daemon-reload
     sudo systemctl enable om1-container.service


### PR DESCRIPTION
## Summary
- Fix case-sensitive typo in systemd unit file example: `WantedBy=multi-user.Target` → `WantedBy=multi-user.target`
- systemd target names must be lowercase; the typo would cause `om1-container.service` to fail on enable

## Test plan
- [x] Verified typo fix in both `docs/` and `mintlify/` directories
- [x] Ran `mintlify.sh` to sync changes
- [x] Pre-commit checks passed (`typos`, `trailing-whitespace`, `end-of-file-fixer`)