### PR TITLE
test(rtk_provider): add unit tests for get_latest_gngga_message

### DIFF
--- a/tests/providers/test_rtk_provider.py
+++ b/tests/providers/test_rtk_provider.py
@@ -1,7 +1,5 @@
-# tests/providers/test_rtk_provider.py
-
 import pytest
-import re
+
 from src.providers.rtk_provider import RtkProvider
 
 
@@ -9,11 +7,9 @@ from src.providers.rtk_provider import RtkProvider
 def rtk_provider():
     """
     Fixture to create an RtkProvider instance for testing.
-    Uses _singleton_class to get the original class and __new__ to avoid running __init__.
     """
-    original_class = RtkProvider._singleton_class
+    original_class = RtkProvider._singleton_class  # type: ignore
     provider = original_class.__new__(original_class)
-    # No specific initialization needed for get_latest_gngga_message
     return provider
 
 
@@ -42,14 +38,14 @@ def test_get_latest_gngga_message_multiple_messages(rtk_provider):
 def test_get_latest_gngga_message_multiple_messages_same_time(rtk_provider):
     """Test with multiple GNGGA messages having the same time, should return the first one encountered."""
     nmea_data = (
-        "$GNGGA,123456.000,1234.5678,N,00123.4567,E,1,8,1.0,100.0,M,47.0,M,,*62\n" # First one encountered, same time
+        "$GNGGA,123456.000,1234.5678,N,00123.4567,E,1,8,1.0,100.0,M,47.0,M,,*62\n"  # First one encountered, same time
         "Some other data\n"
-        "$GNGGA,123456.000,9999.9999,S,00999.9999,W,0,0,0.0,200.0,M,47.0,M,,*78\n" # Second one, same time
+        "$GNGGA,123456.000,9999.9999,S,00999.9999,W,0,0,0.0,200.0,M,47.0,M,,*78\n"  # Second one, same time
     )
-    # Because times are equal, max() will return the first entry found with that max time value.
     expected = "$GNGGA,123456.000,1234.5678,N,00123.4567,E,1,8,1.0,100.0,M,47.0,M,,*62"
     result = rtk_provider.get_latest_gngga_message(nmea_data)
     assert result == expected
+
 
 def test_get_latest_gngga_message_no_gngga(rtk_provider):
     """Test with data that contains no GNGGA messages."""
@@ -70,8 +66,8 @@ def test_get_latest_gngga_message_invalid_checksums(rtk_provider):
     # Note: These checksums are intentionally incorrect for the data.
     # The regex doesn't validate checksums, only structure.
     nmea_data = (
-        "$GNGGA,123454.000,1234.5678,N,00123.4567,E,1,8,1.0,99.0,M,47.0,M,,*FF\n" # Earlier time
-        "$GNGGA,123458.000,1234.5678,N,00123.4567,E,1,8,1.0,102.0,M,47.0,M,,*AA\n" # Later time
+        "$GNGGA,123454.000,1234.5678,N,00123.4567,E,1,8,1.0,99.0,M,47.0,M,,*FF\n"  # Earlier time
+        "$GNGGA,123458.000,1234.5678,N,00123.4567,E,1,8,1.0,102.0,M,47.0,M,,*AA\n"  # Later time
     )
     expected = "$GNGGA,123458.000,1234.5678,N,00123.4567,E,1,8,1.0,102.0,M,47.0,M,,*AA"
     result = rtk_provider.get_latest_gngga_message(nmea_data)
@@ -81,9 +77,9 @@ def test_get_latest_gngga_message_invalid_checksums(rtk_provider):
 def test_get_latest_gngga_message_malformed_time_field(rtk_provider):
     """Test with a GNGGA message having a malformed time field, should skip it."""
     nmea_data = (
-        "$GNGGA,123453.000,1234.5678,N,00123.4567,E,1,8,1.0,98.0,M,47.0,M,,*65\n" # Valid earlier time
-        "$GNGGA,NOTATIME,1234.5678,N,00123.4567,E,1,8,1.0,99.0,M,47.0,M,,*66\n"    # Malformed time
-        "$GNGGA,123459.000,1234.5678,N,00123.4567,E,1,8,1.0,103.0,M,47.0,M,,*67\n" # Valid later time
+        "$GNGGA,123453.000,1234.5678,N,00123.4567,E,1,8,1.0,98.0,M,47.0,M,,*65\n"  # Valid earlier time
+        "$GNGGA,NOTATIME,1234.5678,N,00123.4567,E,1,8,1.0,99.0,M,47.0,M,,*66\n"  # Malformed time
+        "$GNGGA,123459.000,1234.5678,N,00123.4567,E,1,8,1.0,103.0,M,47.0,M,,*67\n"  # Valid later time
     )
     expected = "$GNGGA,123459.000,1234.5678,N,00123.4567,E,1,8,1.0,103.0,M,47.0,M,,*67"
     result = rtk_provider.get_latest_gngga_message(nmea_data)


### PR DESCRIPTION
## Overview
This PR adds initial unit tests for the `RtkProvider` class in `src/providers/rtk_provider.py`. Specifically, it targets the `get_latest_gngga_message` method, which processes NMEA data strings to find the most recent GNGGA message based on its timestamp.

## Type of change
- [x] Other: Added unit tests

## Changes
* Added `tests/providers/test_rtk_provider.py`.
* Implemented unit tests for the `get_latest_gngga_message` method in `RtkProvider`, covering various scenarios including single/multiple messages, identical timestamps, missing messages, empty input, and malformed time fields.

## Impact
The primary impact is an improvement in code quality and reliability through increased test coverage for the `RtkProvider`. There are no functional changes to the main application code. The new tests provide confidence that the `get_latest_gngga_message` function behaves as expected under different conditions.

## Additional Information
The tests were written to isolate the underlying class behind the `@singleton` decorator. Local environment setup required installing external dependencies (`pyserial`, `pynmeagps`) for the `rtk_provider.py` module to import correctly.
