### PR TITLE
docs(ElevenLabsTTSProvider): improve __init__ docstring

### DIFF
--- a/src/providers/elevenlabs_tts_provider.py
+++ b/src/providers/elevenlabs_tts_provider.py
@@ -39,7 +39,35 @@ class ElevenLabsTTSProvider:
         enable_tts_interrupt: bool = False,
     ):
         """
-        Initialize the TTS provider with given URL.
+        Initialize the ElevenLabsTTSProvider instance.
+
+        Sets up the configuration for the Eleven Labs TTS service, including API keys,
+        voice/model selection, output format, and interrupt settings. It initializes
+        the underlying audio output stream.
+
+        Parameters
+        ----------
+        url : str, optional
+            The URL endpoint for the TTS service.
+            Defaults to "https://api.openmind.org/api/core/elevenlabs/tts".
+        api_key : str, optional
+            The primary API key for the TTS service. If provided, it's used in the
+            request headers. Defaults to None.
+        elevenlabs_api_key : str, optional
+            An alternative Eleven Labs specific API key. If provided, it's included
+            in the request payload for TTS generation. Defaults to None.
+        voice_id : str, optional
+            The ID/name of the voice to use for TTS synthesis.
+            Defaults to "JBFqnCBsd6RMkjVDRZzb".
+        model_id : str, optional
+            The ID/name of the model to use for TTS synthesis.
+            Defaults to "eleven_flash_v2_5".
+        output_format : str, optional
+            The desired audio output format (e.g., mp3, wav).
+            Defaults to "mp3_44100_128".
+        enable_tts_interrupt : bool, optional
+            If True, enables the ability to interrupt ongoing TTS playback when ASR
+            detects new speech input. Defaults to False.
         """
         self.api_key = api_key
         self.elevenlabs_api_key = elevenlabs_api_key


### PR DESCRIPTION
Add detailed documentation for the parameters of the `__init__` method in `ElevenLabsTTSProvider`.
