### PR TITLE
git push origin docs-update-riva-tts-docstring

### DIFF
--- a/src/providers/riva_tts_provider.py
+++ b/src/providers/riva_tts_provider.py
@@ -28,12 +28,15 @@ class RivaTTSProvider:
         api_key: Optional[str] = None,
     ):
         """
-        Initialize the TTS provider with given URL.
+        Initialize the TTS provider with given URL and API key.
 
         Parameters
         ----------
         url : str
-            The URL endpoint for the TTS service
+            The URL endpoint for the TTS service.
+        api_key : str, optional
+            The API key for the TTS service. If provided, it's used in the
+            request headers. Defaults to None.
         """
         self.running: bool = False
         self._audio_stream: AudioOutputStream = AudioOutputStream(


### PR DESCRIPTION
Add detailed documentation for the missing `api_key` parameter of the `__init__` method in `RivaTTSProvider`.