### PR TITLE
feat: auto-create wallet if ID missing

### DIFF
--- a/src/inputs/plugins/wallet_coinbase.py
+++ b/src/inputs/plugins/wallet_coinbase.py
@@ -60,10 +60,19 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
 
         try:
             # fetch wallet data
+            # fetch wallet data
             if not self.COINBASE_WALLET_ID:
-                raise ValueError("COINBASE_WALLET_ID environment variable is not set")
-
-            self.wallet = Wallet.fetch(self.COINBASE_WALLET_ID)
+                logging.warning("COINBASE_WALLET_ID environment variable is not set. Attempting to create a new wallet...")
+                try:
+                    self.wallet = Wallet.create()
+                except Exception:
+                    # Fallback for SDKs requiring network_id
+                    self.wallet = Wallet.create(network_id="base-sepolia")
+                
+                logging.warning(f"Created new wallet: {self.wallet.id}")
+                logging.warning("IMPORTANT: Persist this WALLET_ID to your .env file to maintain access to these funds!")
+            else:
+                self.wallet = Wallet.fetch(self.COINBASE_WALLET_ID)
             logging.info(f"Wallet: {self.wallet}")
 
             self.balance = float(self.wallet.balance(self.asset_id))


### PR DESCRIPTION
## Summary
This PR improves the onboarding experience for the Wallet Coinbase plugin by removing the hard dependency on a pre-existing wallet ID.

## Changes
- Modified `WalletCoinbase` to catch the missing `COINBASE_WALLET_ID` environment variable.
- Added logic to automatically call `Wallet.create()` if the ID is missing.
- Added a fallback to `base-sepolia` network if the default creation fails.
- Logs the newly created Wallet ID with a warning to persist it.

## Motivation
Previously, the plugin would raise a `ValueError` if the environment variable was missing, requiring manual setup. This change allows the plugin to function "out of the box" for development and testing.