### PR TITLE
fix: handle missing unitree sdk

### DIFF
--- a/src/providers/unitree_camera_vlm_provider.py
+++ b/src/providers/unitree_camera_vlm_provider.py
@@ -58,8 +58,13 @@ class UnitreeCameraVideoStream(VideoStream):
             jpeg_quality=jpeg_quality,
         )
 
-        self.video_client = VideoClient()  # type: ignore
-        self.video_client.Init()
+        try:
+            self.video_client = VideoClient()  # type: ignore
+            self.video_client.Init()
+        except NameError:
+            print("Unitree SDK not found. Camera stream will not function.")
+            self.video_client = None
+
 
     def on_video(self):
         """


### PR DESCRIPTION
## Summary
This PR prevents the Unitree Camera provider from causing import/initialization errors in environments where the Unitree SDK is not installed.

## Changes
- Added a `try-except` block around the `VideoClient` initialization.
- catches `NameError` (which occurs when the SDK types/classes are not imported).
- Sets `self.video_client` to `None` if the SDK is missing.

## Motivation
The code previously assumed the presence of the Unitree SDK. In simulation or non-robot environments (like macOS testing), this caused the application to crash. This fix allows for graceful degradation.