### PR TITLE
docs: add missing Attributes section to AMCLLocalizationInput docstring

### DIFF
--- a/src/inputs/plugins/amcl_localization_input.py
+++ b/src/inputs/plugins/amcl_localization_input.py
@@ -16,7 +16,19 @@ class AMCLLocalizationInput(FuserInput[SensorConfig, Optional[str]]):
     Monitors the robot's localization status via AMCL and provides
     clear feedback to the LLM about whether navigation is safe to proceed.
     """
-
+    
+    Attributes
+    ----------
+    amcl_provider : UnitreeGo2AMCLProvider
+        AMCL provider instance.
+    io_provider : IOProvider
+        IO provider instance.
+    messages : List[Message]
+        Message buffer.
+    descriptor_for_LLM : str
+        Description for LLM context.
+    """
+            
     def __init__(self, config: SensorConfig):
         """
         Initialize the LocalizationInput plugin.


### PR DESCRIPTION
Adds missing `Attributes` section to `AMCLLocalizationInput` class docstring.

**Issue:**
The `AMCLLocalizationInput` class lacks an `Attributes` section to document 
its instance attributes, which is required by NumPy docstring style.

**Changes:**
- Added `Attributes` section documenting 4 instance attributes:
  - amcl_provider: AMCL provider instance
  - io_provider: IO provider instance
  - messages: Message buffer
  - descriptor_for_LLM: Description for LLM context

**File:** `src/inputs/plugins/amcl_localization_input.py`
**Lines:** 19 - 31