### PR TITLE
docs(MoveUnitreeSDKConnector): add missing __init__ docstring

### DIFF
--- a/src/actions/move/connector/ros2.py
+++ b/src/actions/move/connector/ros2.py
@@ -10,6 +10,14 @@ class MoveUnitreeSDKConnector(ActionConnector[ActionConfig, MoveInput]):
     """
 
     def __init__(self, config: ActionConfig):
+        """
+        Initialize the MoveUnitreeSDKConnector.
+
+        Parameters
+        ----------
+        config : ActionConfig
+            Configuration for the action connector.
+        """
         super().__init__(config)
 
     async def connect(self, output_interface: MoveInput) -> None:


### PR DESCRIPTION
## Summary

This PR adds a missing docstring to the `__init__` method of the `MoveUnitreeSDKConnector` class in `src/actions/move/connector/ros2.py`.

## Changes

- Added a docstring to `MoveUnitreeSDKConnector.__init__` following the NumPy style guide.
- The docstring documents the `config` parameter.


