### PR TITLE
docs(MoveTronSDKConnector): fix __init__ config type in docstring

### DIFF
--- a/src/actions/move_tron/connector/tron_sdk.py
+++ b/src/actions/move_tron/connector/tron_sdk.py
@@ -32,7 +32,7 @@ class MoveTronSDKConnector(ActionConnector[MoveTronSDKConfig, MoveInput]):
 
         Parameters
         ----------
-        config : ActionConfig
+        config : MoveTronSDKConfig
             Configuration object for the connector.
         """
         super().__init__(config)


### PR DESCRIPTION
## Summary

This PR fixes an incorrect type annotation in the docstring of the `__init__` method of the `MoveTronSDKConnector` class in `src/actions/move_tron/connector/tron_sdk.py`.

## Changes

- Corrected the documented type for the `config` parameter in `MoveTronSDKConnector.__init__` docstring from `ActionConfig` to `MoveTronSDKConfig`.

