### PR TITLE
docs(MoveZenohRemoteConnector): fix __init__ config type in docstring

### DIFF
--- a/src/actions/move_turtle/connector/zenoh_remote.py
+++ b/src/actions/move_turtle/connector/zenoh_remote.py
@@ -45,7 +45,7 @@ class MoveZenohRemoteConnector(ActionConnector[MoveZenohRemoteConfig, MoveInput]
 
         Parameters
         ----------
-        config : ActionConfig
+        config : MoveZenohRemoteConfig
             The configuration for the action connector.
         """
         super().__init__(config)


### PR DESCRIPTION
## Summary

This PR fixes an incorrect type annotation in the docstring of the `__init__` method of the `MoveZenohRemoteConnector` class in `src/actions/move_turtle/connector/zenoh_remote.py`.

## Changes

- Corrected the documented type for the `config` parameter in `MoveZenohRemoteConnector.__init__` docstring from `ActionConfig` to `MoveZenohRemoteConfig`.

