### PR TITLE
docs(TelegramAPIConnector): fix __init__ config type in docstring

### DIFF
--- a/src/actions/telegram/connector/telegramAPI.py
+++ b/src/actions/telegram/connector/telegramAPI.py
@@ -29,7 +29,7 @@ class TelegramAPIConnector(ActionConnector[TelegramAPIConfig, TelegramInput]):
 
         Parameters
         ----------
-        config : ActionConfig
+        config : TelegramAPIConfig
             Configuration object for the connector.
         """
         super().__init__(config)


### PR DESCRIPTION
## Summary

This PR fixes an incorrect type annotation in the docstring of the `__init__` method of the `TelegramAPIConnector` class in `src/actions/telegram/connector/telegramAPI.py`.

## Changes

- Corrected the documented type for the `config` parameter in `TelegramAPIConnector.__init__` docstring from `ActionConfig` to `TelegramAPIConfig`.

