### PR TITLE
docs(Rtk): add missing __init__ docstring

### DIFF
--- a/src/backgrounds/plugins/rtk.py
+++ b/src/backgrounds/plugins/rtk.py
@@ -28,6 +28,14 @@ class Rtk(Background[RtkConfig]):
     """
 
     def __init__(self, config: RtkConfig):
+        """
+        Initialize the Rtk background task with configuration.
+
+        Parameters
+        ----------
+        config : RtkConfig
+            Configuration object for the background task, specifying the serial port.
+        """
         super().__init__(config)
 
         port = self.config.serial_port


### PR DESCRIPTION
## Summary

This PR adds a missing docstring to the `__init__` method of the `Rtk` class in `src/backgrounds/plugins/rtk.py`.

## Changes

- Added a docstring to `Rtk.__init__` following the NumPy style guide.
- The docstring documents the `config` parameter.

