### PR TITLE
docs(LifecycleHookHandler): add missing __init__ docstring

### DIFF
--- a/src/runtime/multi_mode/hook.py
+++ b/src/runtime/multi_mode/hook.py
@@ -66,6 +66,14 @@ class LifecycleHookHandler:
     """
 
     def __init__(self, config: Dict[str, Any]):
+        """
+        Initialize the LifecycleHookHandler with configuration.
+
+        Parameters
+        ----------
+        config : Dict[str, Any]
+            Configuration object for the hook handler.
+        """
         self.config = config
 
     async def execute(self, context: Dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

This PR adds a missing docstring to the `__init__` method of the `LifecycleHookHandler` class in `src/runtime/multi_mode/hook.py`. This fixes an inconsistency where the constructor lacked documentation.

## Changes

- Added a docstring to `LifecycleHookHandler.__init__` following the NumPy style guide.
- The docstring documents the `config` parameter.



