### PR TITLE
fix: correct inverted required field logic in schema generator

### DIFF
--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -534,7 +534,7 @@ class ConfigSchemaGenerator:
                 "name": name,
                 "type": self._annotation_to_type(item.annotation),
                 "label": name.replace("_", " ").title(),
-                "required": has_default,
+                "required": not has_default,
                 "description": description,
             }
 


### PR DESCRIPTION
## Summary
- Fixed inverted `required` field logic in schema generator
- Fields WITH default values were incorrectly marked as required
- Fields WITHOUT default values were incorrectly marked as optional

## Changes
- Changed `"required": has_default` to `"required": not has_default` in `scripts/generate_schema.py:537`

## Test plan
- [x] All 339 existing tests pass
- [x] Ruff linting passes

Closes #1610

🤖 Generated with [Claude Code](https://claude.ai/code)