### PR TITLE
fix: correct GPS coordinate validation logic in fabric connector

### DIFF
--- a/src/actions/gps/connector/fabric.py
+++ b/src/actions/gps/connector/fabric.py
@@ -73,9 +73,12 @@ class GPSFabricConnector(ActionConnector[GPSFabricConfig, GPSInput]):
         logging.info(f"GPSFabricConnector: Longitude: {longitude}")
         logging.info(f"GPSFabricConnector: Yaw: {yaw}")
 
-        if latitude is None and longitude is None and yaw is None:
-            # If no coordinates are available, log an error and return
-            logging.error("GPSFabricConnector: Coordinates not available.")
+        if latitude is None or longitude is None or yaw is None:
+            # If any coordinate is missing, log an error and return
+            logging.error(
+                f"GPSFabricConnector: Incomplete coordinates - "
+                f"latitude: {latitude}, longitude: {longitude}, yaw: {yaw}"
+            )
             return None
 
         try:


### PR DESCRIPTION
## Summary
- Fixed GPS coordinate validation logic that used `and` instead of `or`
- Previously only caught the case when ALL coordinates were None
- This allowed partial/incomplete coordinates to be sent to the Fabric network

## Changes
- Changed `if latitude is None and longitude is None and yaw is None:` to `if latitude is None or longitude is None or yaw is None:`
- Improved error message to show which specific coordinates are missing

## Test plan
- [x] All 339 existing tests pass
- [x] Ruff linting passes

Closes #1608

🤖 Generated with [Claude Code](https://claude.ai/code)