### PR TITLE
fix(docs): correct unitree_camera_vlm_provider docstrings

### DIFF
--- a/src/providers/unitree_camera_vlm_provider.py
+++ b/src/providers/unitree_camera_vlm_provider.py
@@ -176,7 +176,7 @@ class UnitreeCameraVLMProvider:
 
         Parameters
         ----------
-        message_callback : Optional[callable]
+        message_callback : Optional[Callable]
             The callback function to process VLM results.
         """
         if message_callback is not None:


### PR DESCRIPTION
Fix docstring issues in UnitreeCameraVLMProvider:
- Correct parameter name `callback` → `message_callback`
- Fix type hint `callable` → `Callable`
- Fix fps default value (15 → 60)