### PR TITLE
docs: complete __init__ docstrings for multiple classes

### DIFF
--- a/src/inputs/plugins/dimo_tesla.py
+++ b/src/inputs/plugins/dimo_tesla.py
@@ -55,6 +55,11 @@ class DIMOTesla(FuserInput[DIMOTeslaConfig, Optional[str]]):
 
         Sets up the required providers and buffers for handling Tesla data processing.
         Initializes connection to the Tesla service and registers message handlers.
+
+        Parameters
+        ----------
+        config : DIMOTeslaConfig
+            Configuration settings for the sensor input.
         """
         super().__init__(config)
 

--- a/src/inputs/plugins/ethereum_governance.py
+++ b/src/inputs/plugins/ethereum_governance.py
@@ -112,6 +112,11 @@ class GovernanceEthereum(FuserInput[SensorConfig, Optional[str]]):
     def __init__(self, config: SensorConfig):
         """
         Initialize GovernanceEthereum instance.
+
+        Parameters
+        ----------
+        config : SensorConfig
+            Configuration settings for the sensor input.
         """
         super().__init__(config)
 

--- a/src/inputs/plugins/face_presence_input.py
+++ b/src/inputs/plugins/face_presence_input.py
@@ -54,6 +54,11 @@ class FacePresence(FuserInput[FacePresenceConfig, Optional[str]]):
     def __init__(self, config: FacePresenceConfig):
         """
         Initialize the face presence input.
+
+        Parameters
+        ----------
+        config : FacePresenceConfig
+            Configuration settings for the sensor input.
         """
         super().__init__(config)
 


### PR DESCRIPTION
## Summary

This PR completes the docstrings for the `__init__` methods of several classes where the `config` parameter was missing documentation. This follows the suggestion to group related docstring fixes.

## Changes

- Added documentation for the `config` parameter in `DIMOTesla.__init__` docstring.
- Added documentation for the `config` parameter in `GovernanceEthereum.__init__` docstring.
- Added documentation for the `config` parameter in `FacePresence.__init__` docstring.


