### PR TITLE
fix: use default_factory for mutable dataclass defaults in zenoh_msgs

### DIFF
--- a/src/zenoh_msgs/idl/status_msgs.py
+++ b/src/zenoh_msgs/idl/status_msgs.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from pycdr2 import IdlStruct
@@ -93,7 +93,9 @@ class ModeStatusRequest(IdlStruct, typename="ModeStatusRequest"):
     header: Header
     request_id: String
     code: int8
-    mode: String = String("")  # Target mode for SWITCH_MODE, ignored for STATUS
+    mode: String = field(
+        default_factory=lambda: String("")
+    )  # Target mode for SWITCH_MODE, ignored for STATUS
 
 
 @dataclass
@@ -194,7 +196,7 @@ class ConfigRequest(IdlStruct, typename="ConfigRequest"):
 
     header: Header
     request_id: String
-    config: String = String("")  # ignored for GET_CONFIG
+    config: String = field(default_factory=lambda: String(""))  # ignored for GET_CONFIG
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fixed a critical Python dataclass mutable default value error that was blocking the entire OM1 application and all pytest test execution.

## Problem
```python
# Before (broken):
mode: String = String("")  # ❌ Mutable default value
config: String = String("")  # ❌ Mutable default value
```

This caused:
```
ValueError: mutable default String(IdlStruct, idl_typename='String')
for field mode is not allowed: use default_factory
```

## Solution
```python
# After (fixed):
mode: String = field(default_factory=lambda: String(""))  # ✅
config: String = field(default_factory=lambda: String(""))  # ✅
```

## Changes
- `src/zenoh_msgs/idl/status_msgs.py`: Added `field` import and converted mutable defaults to `default_factory`

## Test plan
- [x] Module imports successfully after fix
- [x] Ruff linting passes
- [x] Code formatted with ruff

Closes #1681

🤖 Generated with [Claude Code](https://claude.ai/code)