### PR TITLE
fix: add directory existence check in schema generator

### DIFF
--- a/scripts/generate_schema.py
+++ b/scripts/generate_schema.py
@@ -398,6 +398,8 @@ class ConfigSchemaGenerator:
         List[str]
             List of absolute paths to Python files.
         """
+        if not os.path.exists(directory):
+            return []
         return [
             os.path.join(directory, f)
             for f in os.listdir(directory)


### PR DESCRIPTION
## Summary
Added directory existence check in `_py_files` method to prevent `FileNotFoundError` when scanning missing directories.

## Problem
```python
# Before: crashes if directory doesn't exist
def _py_files(self, directory: str) -> List[str]:
    return [
        os.path.join(directory, f)
        for f in os.listdir(directory)  # ❌ FileNotFoundError
        ...
    ]
```

## Solution
```python
# After: handles missing directories gracefully
def _py_files(self, directory: str) -> List[str]:
    if not os.path.exists(directory):
        return []  # ✅ Return empty list
    return [...]
```

## Test plan
- [x] Schema generation runs successfully
- [x] Ruff linting passes

Closes #1653

🤖 Generated with [Claude Code](https://claude.ai/code)