### PR TITLE
fix: correct format string and add null check

### DIFF
--- a/src/inputs/plugins/vlm_local_yolo.py
+++ b/src/inputs/plugins/vlm_local_yolo.py
@@ -92,7 +92,7 @@ def check_webcam(index_to_check):
 
     # Set the best available resolution
     width, height = set_best_resolution(cap, RESOLUTIONS)
-    logging.info(f"YOLO found cam: {index_to_check} set to {width}{height}")
+    logging.info(f"YOLO found cam: {index_to_check} set to {width}x{height}")
     return width, height
 
 

--- a/src/providers/fabric_map_provider.py
+++ b/src/providers/fabric_map_provider.py
@@ -226,7 +226,8 @@ class FabricDataSubmitter:
             raise ValueError("Provided data must be a dictionary.")
 
         if (
-            os.path.exists(self.filename_current)
+            self.filename_current is not None
+            and os.path.exists(self.filename_current)
             and os.path.getsize(self.filename_current) > self.max_file_size_bytes
         ):
             self.filename_current = self.update_filename()


### PR DESCRIPTION
## Summary
Two small bug fixes:

1. **vlm_local_yolo.py line 95**: Fix missing separator in resolution format string
   - Changed `{width}{height}` to `{width}x{height}`
   - Output now shows "1920x1080" instead of "19201080"

2. **fabric_map_provider.py line 229**: Add null check before `os.path.exists()`
   - Added `self.filename_current is not None` check
   - Matches the pattern used in `rplidar_provider.py` (line 313)
   - Prevents potential TypeError if filename_current is None

## Test plan
- [x] Syntax check passed
- [x] Ruff lint passed