### PR TITLE
fix: add robust JSON extraction for LLM responses

### DIFF
--- a/src/llm/function_schemas.py
+++ b/src/llm/function_schemas.py
@@ -4,12 +4,12 @@ Utility functions for generating OpenAI function schemas from AgentActions.
 This module is separate from both the actions and llm modules to avoid circular imports.
 """
 
-import json
 import logging
 from enum import Enum
 from typing import get_type_hints
 
 from llm.output_model import Action
+from utils.json_parser import safe_json_loads
 
 
 def generate_function_schema_from_action(action) -> dict:
@@ -140,10 +140,10 @@ def convert_function_calls_to_actions(function_calls: list[dict]) -> list[Action
             function_args = call.get("function", {}).get("arguments", "{}")
 
             # Parse arguments if they're a string
+            # Uses safe_json_loads to handle Markdown-wrapped JSON from LLMs
             if isinstance(function_args, str):
-                try:
-                    args = json.loads(function_args)
-                except json.JSONDecodeError:
+                args = safe_json_loads(function_args, default=None)
+                if args is None:
                     logging.error(
                         f"Failed to parse function arguments: {function_args}"
                     )

--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -12,6 +12,7 @@ from llm.function_schemas import convert_function_calls_to_actions
 from llm.output_model import CortexOutputModel
 from providers.avatar_llm_state_provider import AvatarLLMState
 from providers.llm_history_manager import LLMHistoryManager
+from utils.json_parser import safe_json_loads
 
 R = T.TypeVar("R", bound=BaseModel)
 
@@ -36,23 +37,21 @@ def _parse_qwen_tool_calls(text: str) -> list:
     if not isinstance(text, str):
         return tool_calls
     for i, raw in enumerate(_QWEN_TOOL_CALL_RE.findall(text)):
-        try:
-            obj = json.loads(raw)
-            if name := obj.get("name"):
-                tool_calls.append(
-                    {
-                        "id": f"call_{i}",
-                        "type": "function",
-                        "function": {
-                            "name": name,
-                            "arguments": json.dumps(
-                                obj.get("arguments", {}), ensure_ascii=False
-                            ),
-                        },
-                    }
-                )
-        except Exception:
-            continue
+        # Use safe_json_loads to handle potentially malformed JSON
+        obj = safe_json_loads(raw, default=None, log_errors=False)
+        if obj and (name := obj.get("name")):
+            tool_calls.append(
+                {
+                    "id": f"call_{i}",
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": json.dumps(
+                            obj.get("arguments", {}), ensure_ascii=False
+                        ),
+                    },
+                }
+            )
     return tool_calls
 
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils module

--- a/src/utils/json_parser.py
+++ b/src/utils/json_parser.py
@@ -1,0 +1,219 @@
+"""
+Robust JSON extraction and parsing utilities for LLM responses.
+
+This module provides utilities to safely parse JSON from LLM responses
+that may be wrapped in Markdown code blocks or contain other text.
+
+Addresses Issue #1700: LLM responses occasionally include Markdown formatting
+which causes json.loads() to fail.
+"""
+
+import json
+import logging
+import re
+from typing import Any, Optional
+
+# Pattern to match JSON inside Markdown code blocks: ```json ... ``` or ``` ... ```
+_MARKDOWN_JSON_PATTERN = re.compile(
+    r"```(?:json|JSON)?\s*\n?([\s\S]*?)\n?\s*```",
+    re.MULTILINE
+)
+
+# Pattern to match a JSON object (starts with { ends with })
+_JSON_OBJECT_PATTERN = re.compile(
+    r"(\{[\s\S]*\})",
+    re.MULTILINE
+)
+
+# Pattern to match a JSON array (starts with [ ends with ])
+_JSON_ARRAY_PATTERN = re.compile(
+    r"(\[[\s\S]*\])",
+    re.MULTILINE
+)
+
+
+def extract_json_string(text: str) -> Optional[str]:
+    """
+    Extract JSON string from text that may contain Markdown formatting.
+
+    Extraction priority:
+    1. Content inside Markdown code blocks (```json ... ``` or ``` ... ```)
+    2. Raw JSON object ({...})
+    3. Raw JSON array ([...])
+    4. Original text (if none of the above match)
+
+    Parameters
+    ----------
+    text : str
+        The input text potentially containing JSON
+
+    Returns
+    -------
+    Optional[str]
+        Extracted JSON string, or None if input is invalid
+
+    Examples
+    --------
+    >>> extract_json_string('```json\\n{"key": "value"}\\n```')
+    '{"key": "value"}'
+    >>> extract_json_string('Here is the response: {"key": "value"}')
+    '{"key": "value"}'
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    text = text.strip()
+
+    # Try to extract from Markdown code block first
+    markdown_match = _MARKDOWN_JSON_PATTERN.search(text)
+    if markdown_match:
+        extracted = markdown_match.group(1).strip()
+        if extracted:
+            return extracted
+
+    # Try to find a JSON object
+    obj_match = _JSON_OBJECT_PATTERN.search(text)
+    if obj_match:
+        return obj_match.group(1)
+
+    # Try to find a JSON array
+    arr_match = _JSON_ARRAY_PATTERN.search(text)
+    if arr_match:
+        return arr_match.group(1)
+
+    # Return original text as fallback
+    return text
+
+
+def safe_json_loads(
+    text: str,
+    default: Any = None,
+    log_errors: bool = True,
+    context: str = ""
+) -> Any:
+    """
+    Safely parse JSON from text, with support for Markdown-wrapped responses.
+
+    This function attempts multiple parsing strategies:
+    1. Direct JSON parsing
+    2. Extract from Markdown code blocks and parse
+    3. Find and parse embedded JSON objects/arrays
+
+    Parameters
+    ----------
+    text : str
+        The text to parse as JSON
+    default : Any, optional
+        Value to return if parsing fails (default: None)
+    log_errors : bool, optional
+        Whether to log parsing errors (default: True)
+    context : str, optional
+        Additional context for error messages (default: "")
+
+    Returns
+    -------
+    Any
+        Parsed JSON object, or default value if parsing fails
+
+    Examples
+    --------
+    >>> safe_json_loads('{"action": "move"}')
+    {'action': 'move'}
+    >>> safe_json_loads('```json\\n{"action": "move"}\\n```')
+    {'action': 'move'}
+    >>> safe_json_loads('invalid', default={})
+    {}
+    """
+    if not isinstance(text, str) or not text.strip():
+        if log_errors and text is not None:
+            logging.debug(f"Empty or invalid input for JSON parsing{_ctx(context)}")
+        return default
+
+    # Strategy 1: Try direct parsing first (most common case)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Strategy 2: Try to extract JSON from the text
+    extracted = extract_json_string(text)
+    if extracted and extracted != text:
+        try:
+            return json.loads(extracted)
+        except json.JSONDecodeError as e:
+            if log_errors:
+                logging.warning(
+                    f"Failed to parse extracted JSON{_ctx(context)}: {e}. "
+                    f"Extracted: {_truncate(extracted)}"
+                )
+
+    # Strategy 3: Try to find and parse nested JSON
+    # This handles cases like: "The response is {"key": "value"} as shown"
+    if extracted:
+        try:
+            return json.loads(extracted)
+        except json.JSONDecodeError:
+            pass
+
+    # All strategies failed
+    if log_errors:
+        logging.error(
+            f"Could not parse JSON from text{_ctx(context)}: {_truncate(text)}"
+        )
+
+    return default
+
+
+def safe_parse_function_args(
+    args_string: str,
+    default: Optional[dict] = None
+) -> Optional[dict]:
+    """
+    Safely parse function call arguments from LLM responses.
+
+    Specifically designed for parsing the 'arguments' field from
+    OpenAI-style function calls.
+
+    Parameters
+    ----------
+    args_string : str
+        The arguments string to parse
+    default : dict, optional
+        Default value if parsing fails (default: None)
+
+    Returns
+    -------
+    Optional[dict]
+        Parsed arguments dictionary, or default if parsing fails
+    """
+    if default is None:
+        default = {}
+
+    result = safe_json_loads(
+        args_string,
+        default=default,
+        log_errors=True,
+        context="function_args"
+    )
+
+    # Ensure result is a dict
+    if not isinstance(result, dict):
+        logging.warning(
+            f"Function args parsed to non-dict type: {type(result)}. "
+            f"Returning default."
+        )
+        return default
+
+    return result
+
+
+def _truncate(text: str, max_length: int = 200) -> str:
+    """Truncate text for logging purposes."""
+    if len(text) <= max_length:
+        return text
+    return text[:max_length] + "..."
+
+
+def _ctx(context: str) -> str:
+    """Format context string for logging."""
+    return f" [{context}]" if context else ""

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# Utils tests

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -1,0 +1,324 @@
+"""
+Unit tests for the JSON parser utility.
+
+Tests cover:
+1. Normal JSON parsing (backward compatibility)
+2. Markdown-wrapped JSON extraction
+3. Embedded JSON in text
+4. Edge cases and error handling
+5. Function argument parsing
+"""
+
+import json
+import pytest
+import sys
+import os
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../src'))
+
+from utils.json_parser import (
+    extract_json_string,
+    safe_json_loads,
+    safe_parse_function_args,
+)
+
+
+class TestExtractJsonString:
+    """Tests for extract_json_string function."""
+
+    def test_plain_json_object(self):
+        """Plain JSON should be returned as-is."""
+        text = '{"action": "move", "value": "forward"}'
+        result = extract_json_string(text)
+        assert result == text
+
+    def test_markdown_json_block(self):
+        """Should extract JSON from ```json ... ``` blocks."""
+        text = '```json\n{"action": "move"}\n```'
+        result = extract_json_string(text)
+        assert result == '{"action": "move"}'
+
+    def test_markdown_block_no_language(self):
+        """Should extract JSON from ``` ... ``` blocks without language tag."""
+        text = '```\n{"key": "value"}\n```'
+        result = extract_json_string(text)
+        assert result == '{"key": "value"}'
+
+    def test_markdown_block_uppercase_json(self):
+        """Should handle uppercase JSON language tag."""
+        text = '```JSON\n{"key": "value"}\n```'
+        result = extract_json_string(text)
+        assert result == '{"key": "value"}'
+
+    def test_json_with_surrounding_text(self):
+        """Should extract JSON object from surrounding text."""
+        text = 'Here is the response: {"action": "stop"} as requested.'
+        result = extract_json_string(text)
+        assert result == '{"action": "stop"}'
+
+    def test_json_array(self):
+        """Should extract JSON arrays."""
+        text = 'The list is: [1, 2, 3]'
+        result = extract_json_string(text)
+        assert result == '[1, 2, 3]'
+
+    def test_empty_string(self):
+        """Should return None for empty string."""
+        assert extract_json_string('') is None
+        assert extract_json_string('   ') is None
+
+    def test_none_input(self):
+        """Should return None for None input."""
+        assert extract_json_string(None) is None
+
+    def test_non_string_input(self):
+        """Should return None for non-string input."""
+        assert extract_json_string(123) is None
+        assert extract_json_string(['list']) is None
+
+    def test_nested_json(self):
+        """Should handle nested JSON objects."""
+        text = '```json\n{"outer": {"inner": "value"}}\n```'
+        result = extract_json_string(text)
+        assert result == '{"outer": {"inner": "value"}}'
+
+    def test_json_with_newlines(self):
+        """Should handle JSON with internal newlines."""
+        text = '''```json
+{
+    "action": "move",
+    "value": "forward"
+}
+```'''
+        result = extract_json_string(text)
+        assert '"action": "move"' in result
+        assert '"value": "forward"' in result
+
+
+class TestSafeJsonLoads:
+    """Tests for safe_json_loads function."""
+
+    def test_valid_json_direct(self):
+        """Should parse valid JSON directly."""
+        text = '{"action": "move", "value": "forward"}'
+        result = safe_json_loads(text)
+        assert result == {"action": "move", "value": "forward"}
+
+    def test_valid_json_array(self):
+        """Should parse valid JSON arrays."""
+        text = '[1, 2, 3]'
+        result = safe_json_loads(text)
+        assert result == [1, 2, 3]
+
+    def test_markdown_wrapped_json(self):
+        """Should parse JSON from Markdown code blocks."""
+        text = '```json\n{"action": "stop"}\n```'
+        result = safe_json_loads(text)
+        assert result == {"action": "stop"}
+
+    def test_markdown_with_explanation(self):
+        """Should handle Markdown with surrounding explanation."""
+        text = '''Here is the JSON response:
+```json
+{"status": "ok", "code": 200}
+```
+This indicates success.'''
+        result = safe_json_loads(text)
+        assert result == {"status": "ok", "code": 200}
+
+    def test_invalid_json_returns_default(self):
+        """Should return default for invalid JSON."""
+        text = 'not valid json at all'
+        result = safe_json_loads(text, default={"fallback": True})
+        assert result == {"fallback": True}
+
+    def test_invalid_json_returns_none(self):
+        """Should return None by default for invalid JSON."""
+        text = 'not valid json'
+        result = safe_json_loads(text)
+        assert result is None
+
+    def test_empty_string_returns_default(self):
+        """Should return default for empty string."""
+        result = safe_json_loads('', default={})
+        assert result == {}
+
+    def test_none_input_returns_default(self):
+        """Should return default for None input."""
+        result = safe_json_loads(None, default=[])
+        assert result == []
+
+    def test_whitespace_only_returns_default(self):
+        """Should return default for whitespace-only input."""
+        result = safe_json_loads('   \n\t  ', default="default")
+        assert result == "default"
+
+    def test_json_embedded_in_text(self):
+        """Should extract and parse JSON embedded in text."""
+        text = 'The robot should do {"action": "dance"} now.'
+        result = safe_json_loads(text)
+        assert result == {"action": "dance"}
+
+    def test_complex_nested_json(self):
+        """Should handle complex nested structures."""
+        data = {
+            "actions": [
+                {"type": "move", "params": {"direction": "forward", "speed": 1.5}},
+                {"type": "speak", "params": {"text": "Hello!"}}
+            ],
+            "metadata": {"timestamp": 12345}
+        }
+        text = f'```json\n{json.dumps(data)}\n```'
+        result = safe_json_loads(text)
+        assert result == data
+
+    def test_json_with_unicode(self):
+        """Should handle JSON with unicode characters."""
+        text = '{"message": "你好世界", "emoji": "🤖"}'
+        result = safe_json_loads(text)
+        assert result == {"message": "你好世界", "emoji": "🤖"}
+
+    def test_json_with_escaped_characters(self):
+        """Should handle JSON with escaped characters."""
+        text = '{"text": "line1\\nline2", "path": "C:\\\\Users"}'
+        result = safe_json_loads(text)
+        assert result["text"] == "line1\nline2"
+        assert result["path"] == "C:\\Users"
+
+    def test_log_errors_false_suppresses_logging(self, caplog):
+        """Should not log when log_errors=False."""
+        import logging
+        with caplog.at_level(logging.DEBUG):
+            safe_json_loads('invalid', log_errors=False)
+        assert len(caplog.records) == 0
+
+    def test_context_in_error_message(self, caplog):
+        """Should include context in error messages."""
+        import logging
+        with caplog.at_level(logging.ERROR):
+            safe_json_loads('invalid', context="test_context")
+        assert any("test_context" in r.message for r in caplog.records)
+
+
+class TestSafeParseunctionArgs:
+    """Tests for safe_parse_function_args function."""
+
+    def test_valid_function_args(self):
+        """Should parse valid function arguments."""
+        args = '{"action": "move_forward", "speed": 1.0}'
+        result = safe_parse_function_args(args)
+        assert result == {"action": "move_forward", "speed": 1.0}
+
+    def test_empty_args(self):
+        """Should return empty dict for empty args."""
+        result = safe_parse_function_args('{}')
+        assert result == {}
+
+    def test_invalid_args_returns_default(self):
+        """Should return default for invalid args."""
+        result = safe_parse_function_args('not json')
+        assert result == {}
+
+    def test_custom_default(self):
+        """Should use custom default."""
+        result = safe_parse_function_args('invalid', default={"default": True})
+        assert result == {"default": True}
+
+    def test_non_dict_result_returns_default(self):
+        """Should return default if parsed result is not a dict."""
+        result = safe_parse_function_args('[1, 2, 3]')
+        assert result == {}
+
+    def test_markdown_wrapped_args(self):
+        """Should handle Markdown-wrapped function args."""
+        args = '```json\n{"action": "stop"}\n```'
+        result = safe_parse_function_args(args)
+        assert result == {"action": "stop"}
+
+
+class TestRealWorldScenarios:
+    """Tests based on real-world LLM response patterns."""
+
+    def test_openai_style_response(self):
+        """Test typical OpenAI function call arguments."""
+        args = '{"action":"move forward","distance":2.5}'
+        result = safe_json_loads(args)
+        assert result["action"] == "move forward"
+        assert result["distance"] == 2.5
+
+    def test_anthropic_style_response(self):
+        """Test response with Markdown formatting (common in Claude)."""
+        text = '''I'll execute the move action for you.
+
+```json
+{
+  "action": "move",
+  "direction": "forward",
+  "units": 3
+}
+```
+
+This will move the robot forward by 3 units.'''
+        result = safe_json_loads(text)
+        assert result["action"] == "move"
+        assert result["direction"] == "forward"
+        assert result["units"] == 3
+
+    def test_qwen_tool_call_format(self):
+        """Test Qwen-style tool call response."""
+        # Qwen sometimes returns JSON without proper formatting
+        text = 'Based on your request, here is the action: {"name": "move", "arguments": {"direction": "left"}}'
+        result = safe_json_loads(text)
+        assert result["name"] == "move"
+
+    def test_vlm_response_with_description(self):
+        """Test VLM response with scene description before JSON."""
+        text = '''I can see a person standing in front of the robot.
+{"objects": ["person", "chair", "table"], "person_distance": 2.3, "should_stop": true}'''
+        result = safe_json_loads(text)
+        assert "person" in result["objects"]
+        assert result["should_stop"] is True
+
+    def test_malformed_but_recoverable(self):
+        """Test slightly malformed but recoverable JSON."""
+        # Extra whitespace and newlines
+        text = '''
+        {
+            "action"  :  "wait"  ,
+            "duration" : 5
+        }
+        '''
+        result = safe_json_loads(text)
+        assert result["action"] == "wait"
+        assert result["duration"] == 5
+
+
+class TestBackwardCompatibility:
+    """Tests to ensure backward compatibility with existing json.loads usage."""
+
+    def test_all_json_types(self):
+        """Should handle all JSON types correctly."""
+        assert safe_json_loads('"string"') == "string"
+        assert safe_json_loads('123') == 123
+        assert safe_json_loads('12.5') == 12.5
+        assert safe_json_loads('true') is True
+        assert safe_json_loads('false') is False
+        assert safe_json_loads('null') is None
+        assert safe_json_loads('[]') == []
+        assert safe_json_loads('{}') == {}
+
+    def test_preserves_original_behavior_for_valid_json(self):
+        """Verify that valid JSON is parsed identically to json.loads."""
+        test_cases = [
+            '{"key": "value"}',
+            '[1, 2, 3]',
+            '{"nested": {"a": 1}}',
+            '{"array": [1, "two", null]}',
+        ]
+        for test in test_cases:
+            assert safe_json_loads(test) == json.loads(test)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Closes #1700

The OM1 runtime relies on LLM providers returning strictly formatted JSON. However, modern LLMs (especially OpenAI, Anthropic, and local models like Qwen) occasionally wrap their responses in Markdown code blocks:

```
```json
{"action": "move", "value": "forward"}
```
```

When this happens, `json.loads()` fails, causing:
- Agent threads to crash or enter unrecoverable states
- "Silent deaths" in long-running agent sessions
- Lost function call instructions

## Solution

This PR introduces a resilient JSON parsing utility (`src/utils/json_parser.py`) that:

1. **Extracts JSON from Markdown**: Uses regex to identify and isolate JSON objects within backticks
2. **Bracket-based fallback**: If no markdown is found, locates the primary JSON object using pattern matching
3. **Graceful degradation**: Instead of raising `JSONDecodeError`, logs the error and returns a configurable default value

## Changes

### New Files
- `src/utils/__init__.py` - Utils module init
- `src/utils/json_parser.py` - Core parsing utility with:
  - `extract_json_string()` - Extract JSON from text
  - `safe_json_loads()` - Safe JSON parsing with Markdown support
  - `safe_parse_function_args()` - Specialized function for LLM function call arguments

### Modified Files
- `src/llm/function_schemas.py` - Use `safe_json_loads()` for parsing function call arguments
- `src/llm/plugins/qwen_llm.py` - Use `safe_json_loads()` for parsing Qwen tool calls

### New Tests
- `tests/utils/__init__.py`
- `tests/utils/test_json_parser.py` - Comprehensive test suite covering:
  - Basic JSON parsing (backward compatibility)
  - Markdown code block extraction
  - Embedded JSON in text
  - Error handling and edge cases
  - Real-world LLM response scenarios

## Test Plan

- [x] All existing tests pass
- [x] New unit tests cover various JSON formats:
  - Plain JSON objects and arrays
  - Markdown-wrapped JSON
  - JSON embedded in conversational text
  - Unicode and escaped characters
- [x] Backward compatibility verified - valid JSON parses identically to `json.loads()`
- [x] Tested with simulated OpenAI, Anthropic, and Qwen response patterns

## Example

Before (crashes):
```python
text = '```json\n{"action": "move"}\n```'
json.loads(text)  # JSONDecodeError!
```

After (works):
```python
text = '```json\n{"action": "move"}\n```'
safe_json_loads(text)  # {'action': 'move'}
```