### PR TITLE
fix: add null check before os.path.exists in fabric_map_provider

### DIFF
--- a/src/providers/fabric_map_provider.py
+++ b/src/providers/fabric_map_provider.py
@@ -226,7 +226,8 @@ class FabricDataSubmitter:
             raise ValueError("Provided data must be a dictionary.")
 
         if (
-            os.path.exists(self.filename_current)
+            self.filename_current is not None
+            and os.path.exists(self.filename_current)
             and os.path.getsize(self.filename_current) > self.max_file_size_bytes
         ):
             self.filename_current = self.update_filename()


### PR DESCRIPTION
## Summary
Add null check for `filename_current` before calling `os.path.exists()` to prevent potential TypeError.

## Problem
In `fabric_map_provider.py`, `os.path.exists(self.filename_current)` is called without first checking if `filename_current` is None. This can cause a TypeError if the filename has not been initialized.

## Solution
Add `self.filename_current is not None` check before calling `os.path.exists()`.

This follows the same defensive pattern used in `rplidar_provider.py` (line 313).

## Changes
- `src/providers/fabric_map_provider.py`: Add null check in `write_dict_to_file` method

## Test plan
- [x] Syntax check passed
- [x] Follows existing pattern in codebase