### PR TITLE
fix(tests): correct import paths in provider tests

### DIFF
--- a/tests/providers/test_d435_provider.py
+++ b/tests/providers/test_d435_provider.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from src.providers.d435_provider import D435Provider
+from providers.d435_provider import D435Provider
 
 
 @pytest.fixture

--- a/tests/providers/test_rtk_provider.py
+++ b/tests/providers/test_rtk_provider.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.providers.rtk_provider import RtkProvider
+from providers.rtk_provider import RtkProvider
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Fixes incorrect import paths in 2 test files that cause `ModuleNotFoundError` when running tests locally.

## Problem
The following test files use `from src.providers.X` instead of `from providers.X`:
- `tests/providers/test_d435_provider.py`
- `tests/providers/test_rtk_provider.py`

This works in CI (where root directory is in PYTHONPATH) but fails locally:
```
ModuleNotFoundError: No module named 'src'
```

### Why it passed CI but fails locally

| Environment | PYTHONPATH | `from src.providers...` |
|-------------|------------|------------------------|
| CI (GitHub Actions) | `[".", "src"]` | Works |
| Local (pytest) | `["src"]` | Fails |

## Solution
Change imports to match the standard pattern used in 22 other test files:
```python
# Before (incorrect)
from src.providers.rtk_provider import RtkProvider

# After (correct)
from providers.rtk_provider import RtkProvider
```

## Test plan
- [x] Both test files run successfully locally
- [x] 14 tests pass (7 RTK + 7 D435)
- [x] Pre-commit checks pass