### PR TITLE
test: add unit tests for provider tooling

### DIFF
--- a/tests/providers/test_function_call_provider.py
+++ b/tests/providers/test_function_call_provider.py
@@ -1,0 +1,106 @@
+import typing as T
+
+from providers.function_call_provider import FunctionGenerator, LLMFunction
+
+
+def test_llm_function_decorator_sets_metadata() -> None:
+    @LLMFunction(description="Test description", name="custom_name")
+    def sample_method(param: str) -> None:
+        pass
+
+    assert getattr(sample_method, "_llm_function") is True  # type: ignore[attr-defined]
+    assert (
+        getattr(sample_method, "_llm_description")  # type: ignore[attr-defined]
+        == "Test description"
+    )
+    assert (
+        getattr(sample_method, "_llm_name")  # type: ignore[attr-defined]
+        == "custom_name"
+    )
+
+
+def test_python_type_to_json_schema_basic_types() -> None:
+    mapping = {
+        str: {"type": "string"},
+        int: {"type": "integer"},
+        float: {"type": "number"},
+        bool: {"type": "boolean"},
+        list: {"type": "array"},
+        dict: {"type": "object"},
+    }
+
+    for py_type, expected_schema in mapping.items():
+        assert FunctionGenerator.python_type_to_json_schema(py_type) == expected_schema
+
+    class CustomType:
+        pass
+
+    # Unknown/custom types fall back to string representation
+    assert FunctionGenerator.python_type_to_json_schema(CustomType) == {
+        "type": "string"
+    }
+
+
+def test_python_type_to_json_schema_optional_and_union() -> None:
+    optional_int = T.Optional[int]
+    schema_optional = FunctionGenerator.python_type_to_json_schema(optional_int)
+    assert schema_optional == {"type": "integer"}
+
+    union_type = T.Union[int, str]
+    schema_union = FunctionGenerator.python_type_to_json_schema(union_type)
+    # For non-optional unions, current behavior is to fall back to string
+    assert schema_union == {"type": "string"}
+
+
+def test_extract_function_schema_includes_parameters_and_required() -> None:
+    class Sample:
+        @LLMFunction(description="Does something")
+        def do_something(self, a: int, b: str = "default") -> None:
+            """Example method.
+
+            Parameters
+            ----------
+            a : int
+                First value
+            b : str
+                Second value
+            """
+
+    instance = Sample()
+    method = instance.do_something
+
+    schema = FunctionGenerator.extract_function_schema(method)
+
+    assert schema["type"] == "function"
+    fn = schema["function"]
+    assert fn["name"] == "do_something"
+    assert fn["description"] == "Does something"
+
+    params = fn["parameters"]
+    assert params["type"] == "object"
+    assert set(params["properties"].keys()) == {"a", "b"}
+
+    # Current implementation marks both parameters as required
+    assert set(params["required"]) == {"a", "b"}
+
+    a_schema = params["properties"]["a"]
+    b_schema = params["properties"]["b"]
+    assert a_schema["type"] == "integer"
+    assert b_schema["type"] == "string"
+
+
+def test_generate_functions_from_class_collects_decorated_methods() -> None:
+    class Sample:
+        @LLMFunction(description="First")
+        def first(self, x: int) -> None:
+            pass
+
+        def not_exposed(self) -> None:
+            pass
+
+    functions = FunctionGenerator.generate_functions_from_class(Sample())
+
+    assert "first" in functions
+    assert functions["first"]["function"]["name"] == "first"
+    assert "not_exposed" not in functions
+

--- a/tests/providers/test_teleops_conversation_provider.py
+++ b/tests/providers/test_teleops_conversation_provider.py
@@ -1,0 +1,160 @@
+import time
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from providers.teleops_conversation_provider import (
+    ConversationMessage,
+    MessageType,
+    TeleopsConversationProvider,
+)
+
+
+def reset_teleops_provider() -> None:
+    """Reset singleton instance between tests."""
+    TeleopsConversationProvider.reset()  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def provider() -> Generator[TeleopsConversationProvider, None, None]:
+    reset_teleops_provider()
+    instance = TeleopsConversationProvider(api_key="test-key", base_url="https://example.com")
+    yield instance
+    reset_teleops_provider()
+
+
+def test_conversation_message_roundtrip() -> None:
+    ts = time.time()
+    original = ConversationMessage(
+        message_type=MessageType.USER,
+        content="hello",
+        timestamp=ts,
+    )
+
+    as_dict = original.to_dict()
+    restored = ConversationMessage.from_dict(as_dict)
+
+    assert restored.message_type == MessageType.USER
+    assert restored.content == "hello"
+    assert restored.timestamp == ts
+
+
+def test_is_enabled_true_when_api_key_present() -> None:
+    reset_teleops_provider()
+    provider = TeleopsConversationProvider(api_key="token")
+    assert provider.is_enabled()
+
+
+def test_is_enabled_false_when_api_key_missing_or_empty() -> None:
+    reset_teleops_provider()
+    provider_none = TeleopsConversationProvider(api_key=None)
+    assert not provider_none.is_enabled()
+
+    reset_teleops_provider()
+    provider_empty = TeleopsConversationProvider(api_key="")
+    assert not provider_empty.is_enabled()
+
+
+@patch("providers.teleops_conversation_provider.requests.post")
+def test_store_message_worker_skips_when_api_key_missing(mock_post: MagicMock) -> None:
+    reset_teleops_provider()
+    provider = TeleopsConversationProvider(api_key=None)
+
+    msg = ConversationMessage(
+        message_type=MessageType.USER,
+        content="hello",
+        timestamp=time.time(),
+    )
+
+    provider._store_message_worker(msg)  # type: ignore[attr-defined]
+    mock_post.assert_not_called()
+
+
+@patch("providers.teleops_conversation_provider.requests.post")
+def test_store_message_worker_skips_empty_content(mock_post: MagicMock, provider: TeleopsConversationProvider) -> None:
+    msg = ConversationMessage(
+        message_type=MessageType.USER,
+        content="   ",  # whitespace only
+        timestamp=time.time(),
+    )
+
+    provider._store_message_worker(msg)  # type: ignore[attr-defined]
+    mock_post.assert_not_called()
+
+
+@patch("providers.teleops_conversation_provider.requests.post")
+def test_store_message_worker_sends_request_on_valid_message(
+    mock_post: MagicMock, provider: TeleopsConversationProvider
+) -> None:
+    response = MagicMock()
+    response.status_code = 200
+    response.text = "ok"
+    mock_post.return_value = response
+
+    msg = ConversationMessage(
+        message_type=MessageType.USER,
+        content="hello world",
+        timestamp=time.time(),
+    )
+
+    provider._store_message_worker(msg)  # type: ignore[attr-defined]
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == provider.base_url
+    assert kwargs["headers"]["Authorization"] == f"Bearer {provider.api_key}"
+    assert kwargs["json"] == msg.to_dict()
+    assert kwargs["timeout"] == 2
+
+
+@patch("providers.teleops_conversation_provider.requests.post")
+def test_store_message_worker_handles_non_200_response(
+    mock_post: MagicMock, provider: TeleopsConversationProvider
+) -> None:
+    response = MagicMock()
+    response.status_code = 500
+    response.text = "error"
+    mock_post.return_value = response
+
+    msg = ConversationMessage(
+        message_type=MessageType.ROBOT,
+        content="status update",
+        timestamp=time.time(),
+    )
+
+    # Should not raise even on non-200
+    provider._store_message_worker(msg)  # type: ignore[attr-defined]
+    mock_post.assert_called_once()
+
+
+@patch("providers.teleops_conversation_provider.requests.post")
+def test_store_message_worker_handles_exception(mock_post: MagicMock, provider: TeleopsConversationProvider) -> None:
+    mock_post.side_effect = Exception("network error")
+
+    msg = ConversationMessage(
+        message_type=MessageType.USER,
+        content="hello",
+        timestamp=time.time(),
+    )
+
+    # Should swallow exceptions and not propagate
+    provider._store_message_worker(msg)  # type: ignore[attr-defined]
+
+
+def test_store_message_submits_to_executor(provider: TeleopsConversationProvider) -> None:
+    message = ConversationMessage(
+        message_type=MessageType.USER,
+        content="queued message",
+        timestamp=time.time(),
+    )
+
+    provider.executor = MagicMock()
+
+    provider._store_message(message)  # type: ignore[attr-defined]
+
+    provider.executor.submit.assert_called_once()
+    submit_args, submit_kwargs = provider.executor.submit.call_args
+    assert submit_args[0] == provider._store_message_worker  # type: ignore[attr-defined]
+    assert isinstance(submit_args[1], ConversationMessage)
+


### PR DESCRIPTION
Overview
Adds unit tests for the function call provider and the Teleops conversation provider, improving test coverage without changing runtime behavior.
(If applicable, linked issue: [ ])

Type of change
[ ] Bug fix
[ ] New feature
[ ] Documentation improvement
[ ] Bounty issue submission
[x] Other: Test coverage improvement

Changes
Added tests for LLMFunction and FunctionGenerator to validate metadata and JSON schema generation.
Added tests for TeleopsConversationProvider to check API key handling, empty content skipping, HTTP error handling, and executor submission.

Checklist
[x] Code complies with style guidelines
[x] Self-review completed
[ ] Documentation updated (if applicable)
[ ] Local testing completed (blocked on Windows env; rely on CI)
[x] Tests added/updated (if applicable)

Impact
Improves confidence and safety around function-call tooling and Teleops integration with low risk, since only tests are added.

Additional Information
Tests are in tests/providers/test_function_call_provider.py and tests/providers/test_teleops_conversation_provider.py.
