### PR TITLE
fix: improve error handling for file writes and resource cleanup

### DIFF
--- a/src/inputs/plugins/vlm_local_yolo.py
+++ b/src/inputs/plugins/vlm_local_yolo.py
@@ -281,18 +281,23 @@ class VLM_Local_YOLO(FuserInput[VLM_Local_YOLOConfig, Optional[List]]):
         if not isinstance(json_line, str):
             raise ValueError("Provided json_line must be a json string.")
 
-        if (
-            self.filename_current is not None
-            and os.path.exists(self.filename_current)
-            and os.path.getsize(self.filename_current) > self.max_file_size_bytes
-        ):
-            self.filename_current = self.update_filename()
-            logging.info(f"New yolo file name: {self.filename_current}")
+        try:
+            if (
+                self.filename_current is not None
+                and os.path.exists(self.filename_current)
+                and os.path.getsize(self.filename_current) > self.max_file_size_bytes
+            ):
+                self.filename_current = self.update_filename()
+                logging.info(f"New yolo file name: {self.filename_current}")
 
-        if self.filename_current is not None:
-            with open(self.filename_current, "a", encoding="utf-8") as f:
-                f.write(json_line + "\n")
-                f.flush()
+            if self.filename_current is not None:
+                with open(self.filename_current, "a", encoding="utf-8") as f:
+                    f.write(json_line + "\n")
+                    f.flush()
+        except OSError as e:
+            logging.error(f"Failed to write to file {self.filename_current}: {e}", exc_info=True)
+        except Exception as e:
+            logging.error(f"Unexpected error writing to file {self.filename_current}: {e}", exc_info=True)
 
     async def _raw_to_text(self, raw_input: Optional[List]) -> Optional[Message]:
         """

--- a/src/providers/config_provider.py
+++ b/src/providers/config_provider.py
@@ -198,6 +198,9 @@ class ConfigProvider:
             self.config_response_publisher = None
 
         if self.session:
-            self.session.close()
+            try:
+                self.session.close()
+            except Exception as e:
+                logging.error(f"Error closing Zenoh session: {e}", exc_info=True)
 
         logging.info("ConfigProvider stopped and Zenoh session closed")

--- a/src/providers/fabric_map_provider.py
+++ b/src/providers/fabric_map_provider.py
@@ -225,17 +225,26 @@ class FabricDataSubmitter:
         if not isinstance(data, dict):
             raise ValueError("Provided data must be a dictionary.")
 
-        if (
-            os.path.exists(self.filename_current)
-            and os.path.getsize(self.filename_current) > self.max_file_size_bytes
-        ):
-            self.filename_current = self.update_filename()
-            logging.info(f"new file name: {self.filename_current}")
+        if self.filename_current is None:
+            logging.warning("Cannot write to file: filename_current is None")
+            return
 
-        with open(self.filename_current, "a", encoding="utf-8") as f:
-            json_line = json.dumps(data)
-            f.write(json_line + "\n")
-            f.flush()
+        try:
+            if (
+                os.path.exists(self.filename_current)
+                and os.path.getsize(self.filename_current) > self.max_file_size_bytes
+            ):
+                self.filename_current = self.update_filename()
+                logging.info(f"new file name: {self.filename_current}")
+
+            with open(self.filename_current, "a", encoding="utf-8") as f:
+                json_line = json.dumps(data)
+                f.write(json_line + "\n")
+                f.flush()
+        except OSError as e:
+            logging.error(f"Failed to write to file {self.filename_current}: {e}", exc_info=True)
+        except Exception as e:
+            logging.error(f"Unexpected error writing to file {self.filename_current}: {e}", exc_info=True)
 
     def _share_data_worker(self, data: FabricData):
         """

--- a/src/providers/ros2_publisher_provider.py
+++ b/src/providers/ros2_publisher_provider.py
@@ -118,6 +118,10 @@ class ROS2PublisherProvider(Node):
         if self._thread:
             self._thread.join(timeout=5)
 
-        self.publisher_.Close()
+        try:
+            if hasattr(self, "publisher_") and self.publisher_ is not None:
+                self.publisher_.Close()
+        except Exception as e:
+            logging.error(f"Error closing ROS2 publisher: {e}", exc_info=True)
 
         logging.info("ROS2 Publisher Provider stopped")

--- a/src/providers/rplidar_provider.py
+++ b/src/providers/rplidar_provider.py
@@ -309,18 +309,23 @@ class RPLidarProvider:
         if not isinstance(json_line, str):
             raise ValueError("Provided json_line must be a json string.")
 
-        if (
-            self.filename_current is not None
-            and os.path.exists(self.filename_current)
-            and os.path.getsize(self.filename_current) > self.max_file_size_bytes
-        ):
-            self.filename_current = self.update_filename()
-            logging.info(f"New rpscan file name: {self.filename_current}")
+        try:
+            if (
+                self.filename_current is not None
+                and os.path.exists(self.filename_current)
+                and os.path.getsize(self.filename_current) > self.max_file_size_bytes
+            ):
+                self.filename_current = self.update_filename()
+                logging.info(f"New rpscan file name: {self.filename_current}")
 
-        if self.filename_current is not None:
-            with open(self.filename_current, "a", encoding="utf-8") as f:
-                f.write(json_line + "\n")
-                f.flush()
+            if self.filename_current is not None:
+                with open(self.filename_current, "a", encoding="utf-8") as f:
+                    f.write(json_line + "\n")
+                    f.flush()
+        except OSError as e:
+            logging.error(f"Failed to write to file {self.filename_current}: {e}", exc_info=True)
+        except Exception as e:
+            logging.error(f"Unexpected error writing to file {self.filename_current}: {e}", exc_info=True)
 
     def listen_scan(self, data: zenoh.Sample):
         """


### PR DESCRIPTION
Overview
Improves error handling for file write operations and resource cleanup methods to prevent crashes from disk errors, permission issues, or cleanup failures. This makes the system more robust in production environments.
Type of change
[x] Bug fix
[ ] New feature
[ ] Documentation improvement
[ ] Bounty issue submission
[ ] Other

Changes
File write error handling (3 files):
src/providers/rplidar_provider.py: Added try-except around file write operations in write_str_to_file() to handle OSError (disk full, permission errors) gracefully
src/inputs/plugins/vlm_local_yolo.py: Added try-except around file write operations in write_str_to_file() to handle OSError gracefully
src/providers/fabric_map_provider.py: Added try-except around file write operations in write_dict_to_file() and added null check for filename_current to prevent crashes
Resource cleanup error handling (2 files):
src/providers/ros2_publisher_provider.py: Added try-except around publisher_.Close() in stop() method to handle cleanup failures gracefully
src/providers/config_provider.py: Added try-except around session.close() in stop() method to handle Zenoh session cleanup failures gracefully
All error handlers log detailed error messages with exc_info=True for debugging while preventing crashes.

Checklist
[x] Code complies with style guidelines
[x] Self-review completed
[ ] Documentation updated (if applicable)
[ ] Local testing completed
[ ] Tests added/updated (if applicable)

Impact
Prevents crashes from file I/O errors (disk full, permission issues) and resource cleanup failures, improving system stability in production. Low risk change that only adds defensive error handling without changing core functionality.