### PR TITLE
docs: fix article usage in llm plugin docstrings

### DIFF
--- a/src/llm/plugins/deepseek_llm.py
+++ b/src/llm/plugins/deepseek_llm.py
@@ -16,7 +16,7 @@ R = T.TypeVar("R", bound=BaseModel)
 
 class DeepSeekLLM(LLM[R]):
     """
-    An DeepSeek-based Language Learning Model implementation.
+    A DeepSeek-based Language Learning Model implementation.
 
     This class implements the LLM interface for DeepSeek's conversation models, handling
     configuration, authentication, and async API communication.

--- a/src/llm/plugins/near_ai_llm.py
+++ b/src/llm/plugins/near_ai_llm.py
@@ -16,7 +16,7 @@ R = T.TypeVar("R", bound=BaseModel)
 
 class NearAILLM(LLM[R]):
     """
-    An NearAI-based Language Learning Model implementation.
+    A NearAI-based Language Learning Model implementation.
 
     This class implements the LLM interface for Near AI's open-source models, handling
     configuration, authentication, and async API communication.


### PR DESCRIPTION
## Summary
- Fix article usage in LLM plugin docstrings
- near_ai_llm: “An NearAI-based …” -> “A NearAI-based …”
- deepseek_llm: “An DeepSeek-based …” -> “A DeepSeek-based …”

## Testing
- Not applicable (docstring-only change)