### PR TITLE
fix: resolve thread safety issues, remove unused variable, and fix deprecated logging in rf_mapper.py

### DIFF
--- a/src/backgrounds/plugins/rf_mapper.py
+++ b/src/backgrounds/plugins/rf_mapper.py
@@ -74,6 +74,7 @@ class RFmapper(Background[RFmapperConfig]):
         self.scan_results: List[RFData] = []
         self.scan_idx = 0
         self.scan_last_sent = 0
+        self.scan_lock = threading.Lock()
 
         self.payload_idx = 0
 
@@ -112,8 +113,6 @@ class RFmapper(Background[RFmapperConfig]):
         self.fds = FabricDataSubmitter(api_key=self.api_key, write_to_local_file=True)
 
         self.seen_devices: Dict[str, RFData] = {}
-
-        self.seen_names: List[str] = []
 
         self.start()
 
@@ -182,7 +181,6 @@ class RFmapper(Background[RFmapperConfig]):
                         f"Updated BLE mfgval: {self.seen_devices[addr].mfgval}"
                     )
             else:
-
                 # this is a new device
                 self.seen_devices[addr] = RFData(
                     unix_ts=time.time(),
@@ -217,8 +215,6 @@ class RFmapper(Background[RFmapperConfig]):
                 final_list.append(device)
         logging.debug(f"Scan...{final_list}")
 
-        self.scan_idx += 1
-
         return final_list
 
     def _scan_task(self):
@@ -229,7 +225,10 @@ class RFmapper(Background[RFmapperConfig]):
         logging.info("Starting RF scan thread...")
         self.running = True
         while self.running:
-            self.scan_results = self.loop.run_until_complete(self.scan())
+            scan_results = self.loop.run_until_complete(self.scan())
+            with self.scan_lock:
+                self.scan_results = scan_results
+                self.scan_idx += 1
             logging.info(f"RF scan index: {self.scan_idx}")
             logging.info(f"RF scan last sent: {self.scan_last_sent}")
             time.sleep(0.5)
@@ -255,17 +254,18 @@ class RFmapper(Background[RFmapperConfig]):
         """
         try:
             while self.running:
-
                 logging.info(f"Sending to fabric: payload {self.payload_idx}")
 
                 # add scan results if they are new
                 logging.info(f"RF scan index: {self.scan_idx}")
                 logging.info(f"RF scan last sent: {self.scan_last_sent}")
                 fresh_scan_results = []
-                if self.scan_results and self.scan_idx > self.scan_last_sent:
-                    fresh_scan_results = self.scan_results
-                    self.scan_last_sent = self.scan_idx
-                    self.scan_results = []
+                with self.scan_lock:
+                    if self.scan_results and self.scan_idx > self.scan_last_sent:
+                        fresh_scan_results = self.scan_results
+                        self.scan_results = []
+                        self.scan_last_sent = self.scan_idx
+                if fresh_scan_results:
                     logging.info(f"RF scan sending new payload: {self.scan_last_sent}")
 
                 # basic gps data and occasional scan results
@@ -285,7 +285,7 @@ class RFmapper(Background[RFmapperConfig]):
                             self.ble_scan = g["ble_scan"]
                             logging.debug(f"RF scan results {self.ble_scan}")
                         else:
-                            logging.warn("No nRF52 scan results")
+                            logging.warning("No nRF52 scan results")
 
                 except Exception as e:
                     logging.error(f"Error parsing GPS: {e}")


### PR DESCRIPTION
## Summary

- Add `threading.Lock` to protect shared variables (`scan_results`, `scan_idx`, `scan_last_sent`) between `_scan_task` and `run` threads, preventing race conditions
- Remove unused `self.seen_names` variable to reduce code clutter
- Replace deprecated `logging.warn()` with `logging.warning()` for Python 3.10+ compatibility

## Test Plan

- [x] Ruff linter passes
- [x] Ruff format passes  
- [x] Pyright type check passes (0 errors)
- [x] Module imports successfully
- [x] All related pytest tests pass

Closes #1771