### PR TITLE
fix: correct GitHub organization name in bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/🌟-bounty.md
+++ b/.github/ISSUE_TEMPLATE/🌟-bounty.md
@@ -14,7 +14,7 @@ assignees: ''
 **Guidelines**
 
 **License**
-This project is licensed under the MIT License. See the [LICENSE](https://github.com/OpenmindAGI/OM1/blob/main/LICENSE) file for more details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/OpenMind/OM1/blob/main/LICENSE) file for more details.
 
 **Contact**
 For questions or further assistance, reach out via the issue tracker or contact the maintainers directly.


### PR DESCRIPTION
## Summary

Fixes broken LICENSE link in the bounty issue template.

## Problem

The LICENSE link in `.github/ISSUE_TEMPLATE/🌟-bounty.md` points to incorrect GitHub organization:
- **Before:** `https://github.com/OpenmindAGI/OM1/blob/main/LICENSE`
- **After:** `https://github.com/OpenMind/OM1/blob/main/LICENSE`

## Changes

- Fix organization name: `OpenmindAGI` → `OpenMind`

## Impact

The broken link now correctly points to the LICENSE file.