### PR TITLE
fix: use dynamic WebSocket protocol in WebSim dashboard

### DIFF
--- a/src/simulators/plugins/WebSim.py
+++ b/src/simulators/plugins/WebSim.py
@@ -270,7 +270,7 @@ class WebSim(Simulator):
                             }, [isResizing]);
 
                             React.useEffect(() => {
-                                const ws = new WebSocket(`ws://${window.location.host}/ws`);
+                                const ws = new WebSocket(`${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`);
 
                                 ws.onopen = () => {
                                     console.log('Connected to WebSocket');


### PR DESCRIPTION
## Summary

Fixes WebSocket connection failure when WebSim dashboard is accessed via HTTPS.

## Problem

**File:** `src/simulators/plugins/WebSim.py:273`

```javascript
// Before (hardcoded ws://)
const ws = new WebSocket(`ws://${window.location.host}/ws`);
```

When the page is served over HTTPS, browsers block this as "mixed content" (secure page trying to connect to insecure WebSocket).

**Impact:**
- WebSim dashboard non-functional when accessed via HTTPS
- No WebSocket connection = no real-time updates

## Fix

```javascript
// After (dynamic protocol)
const ws = new WebSocket(`${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`);
```

Now automatically uses:
- `wss://` when page is served over HTTPS
- `ws://` when page is served over HTTP

## Testing

- HTTP access: Works as before (ws://)
- HTTPS access: Now works correctly (wss://)