### PR TITLE
docs: clarify agent modes and common pitfalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,21 @@ Please make sure to read the [Contributing Guide](./CONTRIBUTING.md) before maki
 ## License
 
 This project is licensed under the terms of the MIT License, which is a permissive free software license that allows users to freely use, modify, and distribute the software. The MIT License is a widely used and well-established license that is known for its simplicity and flexibility. By using the MIT License, this project aims to encourage collaboration, modification, and distribution of the software.
+## Agent Modes
+
+This project supports multiple agent execution modes. The two most commonly used
+during local testing are `conversation` and `spot`.
+
+### conversation
+
+Starts a local interactive agent loop. This mode is suitable for quick validation
+and development.
+
+- Runs locally
+- Does not consume credits unless a remote machine is created
+- Safe to stop with `Ctrl+C`
+
+Example:
+
+```bash
+uv run src/run.py conversation


### PR DESCRIPTION
### Summary

This PR clarifies the differences between the `conversation` and `spot` agent modes
and documents common pitfalls encountered during local testing.

### Motivation

While testing both modes locally, the expected behavior of these modes was not
immediately clear. This update aims to reduce confusion for new contributors.