### PR TITLE
docs(TeleopsStatusProvider): clarify __init__ parameters and initialization behavior

### DIFF
--- a/src/providers/teleops_status_provider.py
+++ b/src/providers/teleops_status_provider.py
@@ -218,11 +218,20 @@ class TeleopsStatusProvider:
 
         Parameters
         ----------
-        api_key : str
-            API key for authentication. Default is None.
+        api_key : Optional[str]
+            API key for authentication with the teleops status API.
+            If None or empty string, status retrieval and sharing operations
+            will fail with an error log. Default is None.
         base_url : str
-            Base URL for the teleops status API. Default is
-            "https://api.openmind.org/api/core/teleops/status".
+            Base URL for the teleops status API endpoint. This URL is used
+            for both retrieving and sharing teleops status information.
+            Default is "https://api.openmind.org/api/core/teleops/status".
+
+        Notes
+        -----
+        This provider uses a singleton pattern and creates a ThreadPoolExecutor
+        with a single worker thread for asynchronous status sharing operations.
+        The executor is automatically cleaned up when `stop()` is called.
         """
         self.api_key = api_key
         self.base_url = base_url


### PR DESCRIPTION
Documented the `__init__` parameters for `TeleopsStatusProvider` class.

- Corrected `api_key` parameter type from `str` to `Optional[str]` in docstring
- Added detailed description for `api_key` parameter, including behavior when None or empty
- Enhanced `base_url` parameter documentation with usage context
- Added Notes section explaining singleton pattern and ThreadPoolExecutor initialization