### PR TITLE
docs(providers): improve TeleopsStatusProvider __init__ docstring 

### DIFF
--- a/src/inputs/plugins/webcam_to_face_emotion.py
+++ b/src/inputs/plugins/webcam_to_face_emotion.py
@@ -40,7 +40,15 @@ class FaceEmotionCapture(FuserInput[SensorConfig, Optional[cv2.typing.MatLike]])
 
     def __init__(self, config: SensorConfig):
         """
-        Initialize FaceEmotionCapture instance.
+        Initialize the FaceEmotionCapture input handler.
+
+        Sets up the required providers and resources for handling facial emotion recognition.
+        Initializes OpenCV face cascade classifier and webcam capture if available.
+
+        Parameters
+        ----------
+        config : SensorConfig
+            Configuration for the sensor input.
         """
         super().__init__(config)
 

--- a/src/providers/teleops_status_provider.py
+++ b/src/providers/teleops_status_provider.py
@@ -216,9 +216,12 @@ class TeleopsStatusProvider:
         """
         Initialize the TeleopsStatusProvider.
 
+        Sets up the teleops status provider with API authentication and base URL.
+        Initializes a thread pool executor for asynchronous status sharing operations.
+
         Parameters
         ----------
-        api_key : str
+        api_key : Optional[str]
             API key for authentication. Default is None.
         base_url : str
             Base URL for the teleops status API. Default is


### PR DESCRIPTION
I noticed that the `TeleopsStatusProvider.__init__` method had a type mismatch in its docstring. The `api_key` parameter was documented as `str`, but the actual code uses `Optional[str] = None`. 

I've updated the docstring to:
- Fix the type annotation for `api_key` parameter (changed from `str` to `Optional[str]`)
- Add more detailed initialization description explaining the setup of API authentication and base URL
- Document the ThreadPoolExecutor initialization for asynchronous status sharing operations

This should make it clearer for developers using the `TeleopsStatusProvider` class! Hope this helps! 