### PR TITLE
feat: Add type hints to D435Provider attributes

### DIFF
--- a/src/providers/d435_provider.py
+++ b/src/providers/d435_provider.py
@@ -20,8 +20,8 @@ class D435Provider:
 
         Sets up the Zenoh subscriber for obstacle point cloud data and starts the provider.
         """
-        self.obstacle = []
-        self.running = False
+        self.obstacle: list[dict[str, float]] = []
+        self.running: bool = False
         self.session = None
 
         try:


### PR DESCRIPTION
## 📝 Description
Add type annotations to `D435Provider` class attributes to improve code readability and type safety.

## 🔧 Changes
- Add type hint `list[dict[str, float]]` to `self.obstacle`
- Add type hint `bool` to `self.running`

## ✨ Benefits
- Improved IDE autocomplete and type checking
- Better code documentation
- Enhanced maintainability
- Follows modern Python 3.10+ type hinting standards

## 📍 Files Changed
- `src/providers/d435_provider.py`

## 📸 Code Snippet
```python
def __init__(self):
    self.obstacle: list[dict[str, float]] = []
    self.running: bool = False
```