### PR TITLE
fix: Correct typo 'Overiew' to 'Overview' in unitree_sdk.mdx

### DIFF
--- a/docs/full_autonomy_guidelines/unitree_sdk.mdx
+++ b/docs/full_autonomy_guidelines/unitree_sdk.mdx
@@ -5,7 +5,7 @@ description: "Unitree SDK"
 
 This provides the full ROS2 system for running the Unitree Go2 and G1 SDK.
 
-### System Overiew
+### System Overview
 
 The ROS2 SDK consists of three main services:
 

--- a/mintlify/full_autonomy_guidelines/unitree_sdk.mdx
+++ b/mintlify/full_autonomy_guidelines/unitree_sdk.mdx
@@ -5,7 +5,7 @@ description: "Unitree SDK"
 
 This provides the full ROS2 system for running the Unitree Go2 and G1 SDK.
 
-### System Overiew
+### System Overview
 
 The ROS2 SDK consists of three main services:
 


### PR DESCRIPTION
## Problem
Fixed typo: `Overiew` → `Overview` in unitree_sdk.mdx documentation files.

## Changes
- Fixed typo in `docs/full_autonomy_guidelines/unitree_sdk.mdx`
- Fixed typo in `mintlify/full_autonomy_guidelines/unitree_sdk.mdx`

## Verification
- ✅ typos check passed
- ✅ pre-commit checks passed