### PR TITLE
fix(providers): harden elevenlabs tts provider concurrency

### DIFF
--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,4 +1,3 @@
-from .context_provider import ContextProvider
 from .io_provider import IOProvider
 from .teleops_status_provider import (
     BatteryStatus,
@@ -8,7 +7,6 @@ from .teleops_status_provider import (
 )
 
 __all__ = [
-    "ContextProvider",
     "IOProvider",
     "TeleopsStatusProvider",
     "CommandStatus",


### PR DESCRIPTION
Changes:
- Added an RLock to ElevenLabsTTSProvider to protect shared state across configure/start/stop/add_pending_message.
- Updated configure() to recreate the AudioOutputStream and only restart the stream when the provider was already running.
- Improved error observability by logging enqueue failures with full stack traces (exc_info=True) and re-raising.
- Reduced import-time side effects by removing ContextProvider from providers/__init__.py (prevents heavy zenoh_msgs import during test collection).

Tests:
- tests/providers/test_elevenlabs_tts_provider.py