### PR TITLE
fix: Prevent exception info leakage with custom hook exceptions

### DIFF
--- a/src/hooks/__init__.py
+++ b/src/hooks/__init__.py
@@ -1,0 +1,39 @@
+"""
+Hooks module for OM1 runtime.
+
+This module provides hooks for starting and stopping various services
+such as Nav2, SLAM, and person following.
+"""
+
+
+class HookError(Exception):
+    """
+    Base exception for hook-related errors.
+
+    This exception provides a safe way to propagate errors from hooks
+    without exposing internal implementation details.
+    """
+
+    pass
+
+
+class Nav2Error(HookError):
+    """
+    Exception raised when Nav2 operations fail.
+
+    This exception is used for errors related to starting, stopping,
+    or communicating with the Nav2 navigation system.
+    """
+
+    pass
+
+
+class SLAMError(HookError):
+    """
+    Exception raised when SLAM operations fail.
+
+    This exception is used for errors related to starting, stopping,
+    or communicating with the SLAM mapping system.
+    """
+
+    pass

--- a/src/hooks/nav2_hook.py
+++ b/src/hooks/nav2_hook.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 import aiohttp
 
+from hooks import Nav2Error
 from providers.elevenlabs_tts_provider import ElevenLabsTTSProvider
 
 
@@ -46,18 +47,17 @@ async def start_nav2_hook(context: Dict[str, Any]):
                 else:
                     try:
                         error_info = await response.json()
-                    except Exception as _:
+                    except Exception:
                         error_info = {"message": "Unknown error"}
+                    error_msg = error_info.get("message", "Unknown error")
                     logging.error(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
+                        f"Failed to start Nav2: {error_msg} (status: {response.status})"
                     )
-                    raise Exception(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
+                    raise Nav2Error("Failed to start Nav2 navigation system")
 
     except aiohttp.ClientError as e:
-        logging.error(f"Error calling Nav2 API: {str(e)}")
-        raise Exception(f"Error calling Nav2 API: {str(e)}")
+        logging.error(f"Error calling Nav2 API: {e}")
+        raise Nav2Error("Unable to communicate with Nav2 service") from e
 
 
 async def stop_nav2_hook(context: Dict[str, Any]):
@@ -83,25 +83,24 @@ async def stop_nav2_hook(context: Dict[str, Any]):
                 if response.status == 200:
                     result = await response.json()
                     logging.info(
-                        f"Nav2 started successfully: {result.get('message', 'Success')}"
+                        f"Nav2 stopped successfully: {result.get('message', 'Success')}"
                     )
                     return {
                         "status": "success",
-                        "message": "Nav2 process initiated",
+                        "message": "Nav2 process stopped",
                         "response": result,
                     }
                 else:
                     try:
                         error_info = await response.json()
-                    except Exception as _:
+                    except Exception:
                         error_info = {"message": "Unknown error"}
+                    error_msg = error_info.get("message", "Unknown error")
                     logging.error(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
+                        f"Failed to stop Nav2: {error_msg} (status: {response.status})"
                     )
-                    raise Exception(
-                        f"Failed to start Nav2: {error_info.get('message', 'Unknown error')}"
-                    )
+                    raise Nav2Error("Failed to stop Nav2 navigation system")
 
     except aiohttp.ClientError as e:
-        logging.error(f"Error calling Nav2 API: {str(e)}")
-        raise Exception(f"Error calling Nav2 API: {str(e)}")
+        logging.error(f"Error calling Nav2 API: {e}")
+        raise Nav2Error("Unable to communicate with Nav2 service") from e

--- a/src/hooks/slam_hook.py
+++ b/src/hooks/slam_hook.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 import aiohttp
 
+from hooks import SLAMError
 from providers.elevenlabs_tts_provider import ElevenLabsTTSProvider
 
 
@@ -39,18 +40,17 @@ async def start_slam_hook(context: Dict[str, Any]):
                 else:
                     try:
                         error_info = await response.json()
-                    except Exception as _:
+                    except Exception:
                         error_info = {"message": "Unknown error"}
+                    error_msg = error_info.get("message", "Unknown error")
                     logging.error(
-                        f"Failed to start SLAM: {error_info.get('message', 'Unknown error')}"
+                        f"Failed to start SLAM: {error_msg} (status: {response.status})"
                     )
-                    raise Exception(
-                        f"Failed to start SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
+                    raise SLAMError("Failed to start SLAM mapping system")
 
     except aiohttp.ClientError as e:
-        logging.error(f"Error calling SLAM API: {str(e)}")
-        raise Exception(f"Error calling SLAM API: {str(e)}")
+        logging.error(f"Error calling SLAM API: {e}")
+        raise SLAMError("Unable to communicate with SLAM service") from e
 
 
 async def stop_slam_hook(context: Dict[str, Any]):
@@ -92,14 +92,13 @@ async def stop_slam_hook(context: Dict[str, Any]):
                 else:
                     try:
                         error_info = await save_response.json()
-                    except Exception as _:
+                    except Exception:
                         error_info = {"message": "Unknown error"}
+                    error_msg = error_info.get("message", "Unknown error")
                     logging.error(
-                        f"Failed to save SLAM map: {error_info.get('message', 'Unknown error')}"
+                        f"Failed to save SLAM map: {error_msg} (status: {save_response.status})"
                     )
-                    raise Exception(
-                        f"Failed to save SLAM map: {error_info.get('message', 'Unknown error')}"
-                    )
+                    raise SLAMError("Failed to save SLAM map")
 
             # Stop the SLAM process
             async with session.post(
@@ -121,15 +120,14 @@ async def stop_slam_hook(context: Dict[str, Any]):
                 else:
                     try:
                         error_info = await response.json()
-                    except Exception as _:
+                    except Exception:
                         error_info = {"message": "Unknown error"}
+                    error_msg = error_info.get("message", "Unknown error")
                     logging.error(
-                        f"Failed to stop SLAM: {error_info.get('message', 'Unknown error')}"
+                        f"Failed to stop SLAM: {error_msg} (status: {response.status})"
                     )
-                    raise Exception(
-                        f"Failed to stop SLAM: {error_info.get('message', 'Unknown error')}"
-                    )
+                    raise SLAMError("Failed to stop SLAM mapping system")
 
     except aiohttp.ClientError as e:
-        logging.error(f"Error calling SLAM API: {str(e)}")
-        raise Exception(f"Error calling SLAM API: {str(e)}")
+        logging.error(f"Error calling SLAM API: {e}")
+        raise SLAMError("Unable to communicate with SLAM service") from e


### PR DESCRIPTION
- Add custom exception classes (HookError, Nav2Error, SLAMError) in hooks/__init__.py
- Replace generic Exception raises with specific custom exceptions
- Log detailed error information internally but expose only safe messages in exceptions
- Use exception chaining (from e) to preserve debugging context
- Fix inconsistent log messages in stop_nav2_hook (was saying "started" instead of "stopped")

This prevents internal implementation details from leaking through exception messages while still maintaining full error context in logs.
