### PR TITLE
docs: fix Set up Development Environment step grammar and phrasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,7 @@ Before contributing, please take a moment to read through the following guidelin
     ```
     (Replace `<your-username>` with your GitHub username.)
 
-3. **Setup Development Environment**
-    Refer [documentation](https://docs.openmind.org/developing/1_get-started) to setup your development environment.
+3. **Set up Development Environment:** Refer to the [documentation](https://docs.openmind.org/developing/1_get-started) to set up your development environment.
 
 4.  **Create a Branch:**  Create a new branch for your work.  Use a descriptive name that reflects the purpose of your changes (e.g., `fix-bug-xyz`, `add-feature-abc`, `docs-improve-readme`).
     ```bash


### PR DESCRIPTION
## Overview
Fixes the "Set up Development Environment" step in the Contribution Workflow: corrects grammar and phrasing so it's clearer for new contributors.

(If applicable, linked issue: [ ])

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
- **Step 3 title:** "Setup" → "Set up" (correct phrasal verb).
- **Description:** "Refer [documentation] to setup" → "Refer to the [documentation] to set up" (grammar and verb form).
- Combined the step title and description into one clear sentence with a colon.

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [ ] Local testing completed (N/A – markdown only)
- [ ] Tests added/updated (if applicable) (N/A)

## Impact
Documentation-only change. No effect on code or tooling. Makes the contribution workflow easier to follow.

## Additional Information
Addresses feedback that the original wording ("Refer documentation to setup") was unclear and ungrammatical.