### PR TITLE
fix: Add context manager support and prevent resource leaks in orchestrators

### DIFF
--- a/src/actions/orchestrator.py
+++ b/src/actions/orchestrator.py
@@ -20,6 +20,11 @@ class ActionOrchestrator:
     - dependencies: Actions wait for their dependencies to complete before executing
 
     Note: It is very important that the actions do not block the event loop.
+
+    This class supports the context manager protocol for proper resource cleanup:
+        with ActionOrchestrator(config) as orchestrator:
+            orchestrator.start()
+            # ... use orchestrator ...
     """
 
     promise_queue: T.List[asyncio.Task[T.Any]]
@@ -31,6 +36,7 @@ class ActionOrchestrator:
     _execution_mode: str
     _action_dependencies: T.Dict[str, T.List[str]]
     _completed_actions: T.Dict[str, asyncio.Event]
+    _stopped: bool
 
     def __init__(self, config: RuntimeConfig):
         """
@@ -56,6 +62,7 @@ class ActionOrchestrator:
         self._execution_mode = config.action_execution_mode or "concurrent"
         self._action_dependencies = config.action_dependencies or {}
         self._completed_actions = {}
+        self._stopped = False
 
     def start(self) -> asyncio.Future:
         """
@@ -338,15 +345,58 @@ class ActionOrchestrator:
         await agent_action.connector.connect(input_interface)
         return input_interface
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stop the action executor and wait for all tasks to complete.
+
+        This method is idempotent - calling it multiple times is safe.
         """
+        if self._stopped:
+            return
+        self._stopped = True
         self._stop_event.set()
         self._connector_executor.shutdown(wait=True)
 
-    def __del__(self):
+    def __enter__(self) -> "ActionOrchestrator":
         """
-        Clean up the ActionOrchestrator by stopping the executor.
+        Enter the context manager.
+
+        Returns
+        -------
+        ActionOrchestrator
+            The orchestrator instance.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: T.Optional[type],
+        exc_val: T.Optional[BaseException],
+        exc_tb: T.Optional[T.Any],
+    ) -> None:
+        """
+        Exit the context manager and ensure resources are cleaned up.
+
+        Parameters
+        ----------
+        exc_type : Optional[type]
+            The exception type if an exception was raised.
+        exc_val : Optional[BaseException]
+            The exception value if an exception was raised.
+        exc_tb : Optional[Any]
+            The traceback if an exception was raised.
         """
         self.stop()
+
+    def __del__(self) -> None:
+        """
+        Clean up the ActionOrchestrator by stopping the executor.
+
+        Note: This is a fallback cleanup mechanism. Prefer using the context
+        manager protocol or explicitly calling stop() for reliable cleanup.
+        """
+        try:
+            self.stop()
+        except Exception:
+            # Suppress exceptions during garbage collection
+            pass

--- a/src/backgrounds/orchestrator.py
+++ b/src/backgrounds/orchestrator.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import threading
 import time
+import typing as T
 from concurrent.futures import ThreadPoolExecutor
 
 from backgrounds.base import Background
@@ -15,6 +16,11 @@ class BackgroundOrchestrator:
     Handles concurrent execution of multiple background tasks in separate
     threads, ensuring they run independently without blocking the main event loop.
     Supports graceful shutdown and error handling for individual background tasks.
+
+    This class supports the context manager protocol for proper resource cleanup:
+        with BackgroundOrchestrator(config) as orchestrator:
+            orchestrator.start()
+            # ... use orchestrator ...
     """
 
     _config: RuntimeConfig
@@ -22,6 +28,7 @@ class BackgroundOrchestrator:
     _background_executor: ThreadPoolExecutor
     _submitted_backgrounds: set[str]
     _stop_event: threading.Event
+    _stopped: bool
 
     def __init__(self, config: RuntimeConfig):
         """
@@ -41,6 +48,7 @@ class BackgroundOrchestrator:
         )
         self._submitted_backgrounds = set()
         self._stop_event = threading.Event()
+        self._stopped = False
 
     def start(self) -> asyncio.Future:
         """
@@ -82,19 +90,62 @@ class BackgroundOrchestrator:
                 logging.error(f"Error in background {background.name}: {e}")
                 time.sleep(0.1)
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stop the background executor and wait for all tasks to complete.
 
         Sets the stop event to signal all background loops to terminate,
         then shuts down the thread pool executor and waits for all running
         tasks to finish gracefully.
+
+        This method is idempotent - calling it multiple times is safe.
         """
+        if self._stopped:
+            return
+        self._stopped = True
         self._stop_event.set()
         self._background_executor.shutdown(wait=True)
 
-    def __del__(self):
+    def __enter__(self) -> "BackgroundOrchestrator":
         """
-        Clean up the BackgroundOrchestrator by stopping the executor.
+        Enter the context manager.
+
+        Returns
+        -------
+        BackgroundOrchestrator
+            The orchestrator instance.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: T.Optional[type],
+        exc_val: T.Optional[BaseException],
+        exc_tb: T.Optional[T.Any],
+    ) -> None:
+        """
+        Exit the context manager and ensure resources are cleaned up.
+
+        Parameters
+        ----------
+        exc_type : Optional[type]
+            The exception type if an exception was raised.
+        exc_val : Optional[BaseException]
+            The exception value if an exception was raised.
+        exc_tb : Optional[Any]
+            The traceback if an exception was raised.
         """
         self.stop()
+
+    def __del__(self) -> None:
+        """
+        Clean up the BackgroundOrchestrator by stopping the executor.
+
+        Note: This is a fallback cleanup mechanism. Prefer using the context
+        manager protocol or explicitly calling stop() for reliable cleanup.
+        """
+        try:
+            self.stop()
+        except Exception:
+            # Suppress exceptions during garbage collection
+            pass

--- a/src/simulators/orchestrator.py
+++ b/src/simulators/orchestrator.py
@@ -14,6 +14,11 @@ class SimulatorOrchestrator:
     Manages data flow to one or more simulators.
 
     Note: It is important that the simulators do not block the event loop.
+
+    This class supports the context manager protocol for proper resource cleanup:
+        with SimulatorOrchestrator(config) as orchestrator:
+            orchestrator.start()
+            # ... use orchestrator ...
     """
 
     promise_queue: T.List[asyncio.Task[T.Any]]
@@ -22,6 +27,7 @@ class SimulatorOrchestrator:
     _simulator_executor: ThreadPoolExecutor
     _submitted_simulators: T.Set[str]
     _stop_event: threading.Event
+    _stopped: bool
 
     def __init__(self, config: RuntimeConfig):
         self._config = config
@@ -34,6 +40,7 @@ class SimulatorOrchestrator:
         )
         self._submitted_simulators = set()
         self._stop_event = threading.Event()
+        self._stopped = False
 
     def start(self):
         """
@@ -119,15 +126,58 @@ class SimulatorOrchestrator:
         simulator.sim(actions)
         return None
 
-    def stop(self):
+    def stop(self) -> None:
         """
         Stop the simulator executor and wait for all tasks to complete.
+
+        This method is idempotent - calling it multiple times is safe.
         """
+        if self._stopped:
+            return
+        self._stopped = True
         self._stop_event.set()
         self._simulator_executor.shutdown(wait=True)
 
-    def __del__(self):
+    def __enter__(self) -> "SimulatorOrchestrator":
         """
-        Clean up the SimulatorOrchestrator by stopping the executor.
+        Enter the context manager.
+
+        Returns
+        -------
+        SimulatorOrchestrator
+            The orchestrator instance.
+        """
+        return self
+
+    def __exit__(
+        self,
+        exc_type: T.Optional[type],
+        exc_val: T.Optional[BaseException],
+        exc_tb: T.Optional[T.Any],
+    ) -> None:
+        """
+        Exit the context manager and ensure resources are cleaned up.
+
+        Parameters
+        ----------
+        exc_type : Optional[type]
+            The exception type if an exception was raised.
+        exc_val : Optional[BaseException]
+            The exception value if an exception was raised.
+        exc_tb : Optional[Any]
+            The traceback if an exception was raised.
         """
         self.stop()
+
+    def __del__(self) -> None:
+        """
+        Clean up the SimulatorOrchestrator by stopping the executor.
+
+        Note: This is a fallback cleanup mechanism. Prefer using the context
+        manager protocol or explicitly calling stop() for reliable cleanup.
+        """
+        try:
+            self.stop()
+        except Exception:
+            # Suppress exceptions during garbage collection
+            pass


### PR DESCRIPTION


- Add _stopped flag to prevent double-shutdown of ThreadPoolExecutor
- Implement __enter__/__exit__ methods for context manager protocol
- Make stop() method idempotent for safe multiple calls
- Improve __del__ to suppress exceptions during garbage collection

This ensures ThreadPoolExecutor resources are properly cleaned up even when the orchestrator is not explicitly stopped.

Affected files:
- ActionOrchestrator
- SimulatorOrchestrator
- BackgroundOrchestrator

