### PR TITLE
docs: improve VLMGeminiProvider __init__ docstring for better readability! 

### DIFF
--- a/src/providers/vlm_gemini_provider.py
+++ b/src/providers/vlm_gemini_provider.py
@@ -33,14 +33,15 @@ class VLMGeminiProvider:
         Parameters
         ----------
         base_url : str
-            The base URL for the OM API.
+            The base URL for the OM API endpoint used for Gemini API communication.
         api_key : str
-            The API key for the OM API.
-        fps : int
-            The frames per second for the video stream.
+            The API key for authenticating with the OM API.
+        fps : int, optional
+            The frames per second for the video stream. Defaults to 10.
         stream_url : str, optional
-            The URL for the video stream. If not provided, defaults to None.
-        camera_index : int
+            The URL for the WebSocket video stream. If not provided (None),
+            WebSocket streaming is disabled. Defaults to None.
+        camera_index : int, optional
             The camera index for the video stream device. Defaults to 0.
         """
         self.running: bool = False


### PR DESCRIPTION
Hi!  I noticed that `VLMGeminiProvider`'s `__init__` method was missing some important parameter documentation details, so I added them! 

**What I improved:**
- Added default value clarification for `fps` parameter (defaults to 10)
- Added default value clarification for `camera_index` parameter (defaults to 0)  
- Enhanced description for `stream_url` parameter to clarify that when it's None, WebSocket streaming is disabled
- Improved descriptions for `base_url` and `api_key` to be more specific about their purpose

The docstring now follows the same comprehensive format as `VLMOpenAIProvider`! Hope this helps make the codebase more readable! 