### PR TITLE
Remove unused finished_promises parmeter from Fuser.fuse

### DIFF
--- a/src/fuser/__init__.py
+++ b/src/fuser/__init__.py
@@ -40,7 +40,7 @@ class Fuser:
         self.config = config
         self.io_provider = IOProvider()
 
-    def fuse(self, inputs: list[Sensor], finished_promises: list[T.Any]) -> str:
+    def fuse(self, inputs: list[Sensor]) -> str:
         """
         Combine all inputs into a single formatted prompt string.
 
@@ -51,8 +51,6 @@ class Fuser:
         ----------
         inputs : list[Sensor]
             List of agent input objects containing latest input buffers.
-        finished_promises : list[Any]
-            List of completed promises from previous actions.
 
         Returns
         -------


### PR DESCRIPTION
## Summary

This PR removes the unused finished_promises parameter from the Fuser.fuse method.

The parameter was not referenced anywhere in the implementation, so keeping it added unnecessary complexity to the method signature and its callers.

## Changes

- Removed finished_promises parameter from Fuser.fuse

## Benefits

- Improves code clarity and maintainability
- Avoids confusion for future contributors
