### PR TITLE
fix(security): Add non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN git submodule update --init --recursive
 
 RUN cp -r config config_defaults
 
+ENV UV_HTTP_TIMEOUT=120
 RUN uv venv /app/OM1/.venv && \
     uv pip install -r pyproject.toml --extra dds
 
@@ -85,6 +86,15 @@ RUN echo '#!/bin/bash' > /entrypoint.sh && \
     echo '  exec python src/run.py "$@"' >> /entrypoint.sh && \
     echo 'fi' >> /entrypoint.sh && \
     chmod +x /entrypoint.sh
+
+# Create a non-root user and change ownership of the necessary files.
+RUN groupadd -r openmind && useradd -r -g openmind openmind
+# Change ownership of the config and entrypoint.sh directories to the openmind user.
+RUN chown -R openmind:openmind /app/OM1/config /entrypoint.sh
+# Change ownership of WORKDIR OM1 so that openmind users can read the main files
+RUN chown openmind:openmind /app/OM1
+
+USER openmind
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["spot"]


### PR DESCRIPTION
## Summary

This PR addresses a security finding from Semgrep (`dockerfile.security.missing-user`) by adding a non-root user (`openmind`) to the Dockerfile and switching to it before running the main application command. This reduces the potential impact if the application process is compromised within the container.

## Changes

- Added commands to create a new system user `openmind` and group `openmind`.
- Changed ownership of the `/app/OM1/config` directory and `/entrypoint.sh` script to the `openmind` user.
- Changed ownership of the `/app/OM1` working directory to the `openmind` user.
- Added the `USER openmind` instruction before the `ENTRYPOINT` and `CMD`.

## Notes

- This change ensures that the primary process running inside the container does not have root privileges.
- The specific directories/files given ownership of the `openmind` user are based on common access patterns during startup (`entrypoint.sh`) and potential runtime configuration (`config/`).
- The Docker image was rebuilt successfully after increasing `UV_HTTP_TIMEOUT` to handle network timeouts during dependency installation.
- Testing confirmed that the `entrypoint.sh` script can run under the `openmind` user without permission errors.