### PR TITLE
docs: clarify Getting Started example intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## Getting Started
 
 To get started with OM1, let's run the Spot agent. Spot uses your webcam to capture and label objects. These text captions are then sent to the LLM, which returns `movement`, `speech` and `face` action commands. These commands are displayed on WebSim along with basic timing and other debugging information.
+This example is intended as a minimal end-to-end demo to help new users understand how inputs, LLM reasoning, and action outputs are connected in OM1.
 
 ### Package Management and VENV
 


### PR DESCRIPTION
## Summary
Adds a short clarification to the Getting Started section to help new users
understand the purpose of the Spot agent example.

## Changes
- Documentation-only change in README.md

No functional or code changes.

