### PR TITLE
docs: fix service count in Full Autonomy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Stay tuned!
 
 ## Full Autonomy Guidance
 
-We're excited to introduce **full autonomy** for Unitree Go2 and G1 with the BrainPack. Full autonomy has five services that work together in a loop without manual intervention:
+We're excited to introduce **full autonomy** for Unitree Go2 and G1 with the BrainPack. Full autonomy has four services that work together in a loop without manual intervention:
 
 - **om1**
 - **unitree_sdk** – A ROS 2 package that provides SLAM (Simultaneous Localization and Mapping) capabilities for the Unitree Go2 robot using an RPLiDAR sensor, the SLAM Toolbox and the Nav2 stack.


### PR DESCRIPTION
Changed "five services" to "four services" to match the actual number of services listed in the Full Autonomy section.

## Overview
Corrected an inconsistency in the README where the text claimed "five services" but only four services are actually listed (om1, unitree_sdk, om1-avatar, om1-video-processor).

## Type of change
- [x] Documentation improvement

## Changes
- Line 112: Changed "five services" to "four services" in the Full Autonomy Guidance section

## Impact
This prevents confusion for users reading the Full Autonomy documentation. The text now accurately reflects the number of services described.