### PR TITLE
fix(security): Add read_only, tmpfs, and no-new-privileges to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,13 @@ services:
       - NET_ADMIN
     security_opt:
       - apparmor:unconfined
+      - no-new-privileges:true
     group_add:
       - audio
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/log
+      - /run
+      - /var/run
     command: ["unitree_go2_modes"]


### PR DESCRIPTION
## Summary

This PR addresses security findings from Semgrep related to the Docker Compose configuration (`yaml.docker-compose.security.no-new-privileges.no-new-privileges` and `yaml.docker-compose.security.writable-filesystem-service.writable-filesystem-service`). It modifies `docker-compose.yml` to enhance the security posture of the `om1` service by making the root filesystem read-only and adding security options.

## Changes

- **`docker-compose.yml`:**
  - Added `read_only: true` to the `om1` service to make the root filesystem read-only.
  - Added `tmpfs` mounts for `/tmp`, `/var/log`, `/run`, and `/var/run` to provide writeable areas for temporary files and logs within the container, which is necessary when the root filesystem is read-only.
  - Added `no-new-privileges:true` to `security_opt` to prevent processes within the container from gaining additional privileges via setuid/setgid binaries.

## Notes

- These changes aim to reduce the potential impact if the application process running inside the container is compromised.
- Testing confirms that the container can be built and started successfully with these options enabled, and the initial `entrypoint.sh` script executes without encountering read-only filesystem errors for essential operations. (Note: Container may still fail to fully start due to external configuration like PulseAudio access, but this is unrelated to the `read_only` changes).
- The `version` key in `docker-compose.yml` has been flagged as obsolete by newer versions of Docker Compose, but removing it is outside the scope of this PR.