### PR TITLE
Fix mintlify.sh shebang placement

### DIFF
--- a/scripts/mintlify.sh
+++ b/scripts/mintlify.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # chmod +x mintlify.sh
 # invoke with ./mintlify.sh
 
-#!/bin/bash
 set -e
 
 # Step 1: Copy docs to mintlify/


### PR DESCRIPTION
## Overview
Moved the `#!/bin/bash` shebang to the very first line in `scripts/mintlify.sh` to ensure proper script execution across all environments.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Bounty issue submission
- [x] Other: Code quality / Best practice

## Changes
- Relocated the shebang (`#!/bin/bash`) from the 4th line to the 1st line.
- Kept the usage comments below the shebang to maintain documentation without breaking the interpreter directive.

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact
This change ensures that the script is correctly recognized as a Bash script by the operating system. It eliminates the risk of the script failing or running with the wrong shell in environments that strictly require the shebang on the first line. There are no risks or side effects as the logic remains identical.

## Additional Information
According to POSIX standards, for a script to be portable and reliably executed, the shebang must be the very first characters of the file.