### PR TITLE
refactor: Use self.language instead of language_code parameter in __init__

### DIFF
--- a/src/providers/ubtech_asr_provider.py
+++ b/src/providers/ubtech_asr_provider.py
@@ -38,7 +38,7 @@ class UbtechASRProvider:
         self.just_resumed = False  # Add new flag
         self._thread: Optional[threading.Thread] = None
         self._message_callback: Optional[Callable] = None
-        self._set_robot_language(language_code)
+        self._set_robot_language(self.language)
 
     def register_message_callback(self, cb: Optional[Callable]):
         """


### PR DESCRIPTION
## Problem
After assigning `self.language = language_code`, the code still uses the `language_code` parameter instead of the instance variable `self.language`

## Solution
Use `self.language` consistently after it's assigned

## Changes
Line 41: `self._set_robot_language(language_code)` → `self._set_robot_language(self.language)`