### PR TITLE
Fix: set running flag after successful start in ASR providers

### DIFF
--- a/src/providers/asr_provider.py
+++ b/src/providers/asr_provider.py
@@ -90,7 +90,7 @@ class ASRProvider:
             logging.warning("ASR provider is already running")
             return
 
-        self.running = True
+        # Start clients and streams first; only mark as running on success
         self.ws_client.start()
         self.audio_stream.start()
 
@@ -105,6 +105,7 @@ class ASRProvider:
                     self.audio_stream.fill_buffer_remote
                 )
 
+        self.running = True
         logging.info("ASR provider started")
 
     def stop(self):

--- a/src/providers/asr_rtsp_provider.py
+++ b/src/providers/asr_rtsp_provider.py
@@ -78,10 +78,11 @@ class ASRRTSPProvider:
             logging.warning("ASR RTSP provider is already running")
             return
 
-        self.running = True
+        # Start clients/streams first; mark running only after successful start
         self.ws_client.start()
         self.audio_stream.start()
 
+        self.running = True
         logging.info("ASR RTSP provider started")
 
     def stop(self):


### PR DESCRIPTION
## Overview
Fix state corruption in `ASRProvider` and `ASRRTSPProvider` by setting `self.running = True` only after successful initialization of websocket client and audio stream.

## Type of change
- [x] Bug fix

## Changes
- Moved `self.running = True` to after `self.ws_client.start()` and `self.audio_stream.start()` calls in both providers
- Prevents providers from being stuck in `running=True` state if initialization fails

**Files changed:**
- `src/providers/asr_provider.py`
- `src/providers/asr_rtsp_provider.py`

**Diff (same pattern in both files):**
```diff
-        self.running = True
         self.ws_client.start()
         self.audio_stream.start()
+        self.running = True
         logging.info("ASR provider started")
```
## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Local testing completed

## Impact
Ensures proper state handling; providers won't remain stuck in running state if initialization fails.