### PR TITLE
feat: Add conversation history persistence to disk (Issue #985)

### DIFF
--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -57,6 +57,7 @@ class LLMConfig(BaseModel):
     )
     auto_save_interval: int = Field(
         default=1,
+        ge=1,
         description="Number of interactions before auto-save triggers. 1 = save every interaction.",
     )
     extra_params: T.Dict[str, T.Any] = Field(default_factory=dict)

--- a/src/providers/llm_history_manager.py
+++ b/src/providers/llm_history_manager.py
@@ -5,6 +5,7 @@ import logging
 import os
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar, Union
 
@@ -112,10 +113,36 @@ class LLMHistoryManager:
         self.io_provider = IOProvider()
 
         # Persistence settings (Issue #985)
-        self._history_file_path: Optional[str] = getattr(
+        raw_history_file_path: Optional[str] = getattr(
             config, "history_file_path", None
         )
-        self._auto_save_interval: int = getattr(config, "auto_save_interval", 1)
+
+        # Validate and sanitize history file path to prevent directory traversal
+        self._history_file_path: Optional[str] = None
+        if raw_history_file_path:
+            try:
+                base_dir = os.getcwd()
+                abs_path = os.path.abspath(raw_history_file_path)
+
+                # Reject paths with directory traversal
+                normalized = os.path.normpath(raw_history_file_path)
+                if ".." in normalized.split(os.sep):
+                    raise ValueError("history_file_path contains directory traversal")
+
+                # Ensure path is within base directory
+                common = os.path.commonpath([base_dir, abs_path])
+                if common != base_dir:
+                    raise ValueError("history_file_path is outside allowed directory")
+
+                self._history_file_path = abs_path
+            except (ValueError, OSError) as exc:
+                logging.warning(
+                    "Ignoring unsafe history_file_path %r: %s",
+                    raw_history_file_path,
+                    exc,
+                )
+
+        self._auto_save_interval: int = max(1, getattr(config, "auto_save_interval", 1))
         self._save_counter: int = 0
         self._file_lock = threading.RLock()
         self._last_save_hash: Optional[int] = None
@@ -143,7 +170,11 @@ class LLMHistoryManager:
         # Ensure parent directory exists
         history_dir = os.path.dirname(self._history_file_path)
         if history_dir and not os.path.exists(history_dir):
-            os.makedirs(history_dir, mode=0o755, exist_ok=True)
+            try:
+                os.makedirs(history_dir, mode=0o755, exist_ok=True)
+            except OSError as e:
+                logging.warning(f"Failed to create history directory {history_dir}: {e}")
+                return None
 
         return self._history_file_path
 
@@ -180,14 +211,19 @@ class LLMHistoryManager:
                     logging.warning("Invalid messages format: expected list")
                     return False
 
-                self.history = [
-                    ChatMessage.from_dict(msg)
-                    for msg in messages
-                    if isinstance(msg, dict) and "role" in msg and "content" in msg
-                ]
+                loaded_messages: List[ChatMessage] = []
+                for msg in messages:
+                    if isinstance(msg, dict) and "role" in msg and "content" in msg:
+                        loaded_messages.append(ChatMessage.from_dict(msg))
+                    else:
+                        logging.warning("Skipping malformed history message: %r", msg)
+                self.history = loaded_messages
 
                 # Load frame index
                 self.frame_index = data.get("frame_index", 0)
+
+                # Reset save counter for predictable auto-save behavior
+                self._save_counter = 0
 
                 # Update save hash to avoid unnecessary saves
                 self._last_save_hash = self._compute_history_hash()
@@ -218,8 +254,6 @@ class LLMHistoryManager:
         """
         try:
             if os.path.exists(file_path):
-                import time
-
                 backup_path = f"{file_path}.corrupted.{int(time.time())}"
                 os.rename(file_path, backup_path)
                 logging.info(f"Backed up corrupted file to {backup_path}")
@@ -303,13 +337,19 @@ class LLMHistoryManager:
     def _maybe_auto_save(self) -> None:
         """
         Perform auto-save if the save interval has been reached.
+        Thread-safe counter management.
         """
         if not self._history_file_path:
             return
 
-        self._save_counter += 1
-        if self._save_counter >= self._auto_save_interval:
-            self._save_counter = 0
+        should_save = False
+        with self._file_lock:
+            self._save_counter += 1
+            if self._save_counter >= self._auto_save_interval:
+                self._save_counter = 0
+                should_save = True
+
+        if should_save:
             self._save_history()
 
     def save(self) -> bool:

--- a/tests/providers/test_llm_history_persistence.py
+++ b/tests/providers/test_llm_history_persistence.py
@@ -1,7 +1,8 @@
 """
 Unit Tests for LLM History Persistence (Issue #985)
 
-Tests for: Save conversation history to disk and reload on restart
+These tests verify the actual LLMHistoryManager persistence implementation,
+not just basic file I/O operations.
 
 Run with: pytest tests/providers/test_llm_history_persistence.py -v
 """
@@ -11,29 +12,59 @@ import os
 import tempfile
 import threading
 from dataclasses import dataclass
-from typing import Optional
-from unittest.mock import MagicMock, patch
 
 import pytest
 
+# Import the actual classes from the implementation
+from providers.llm_history_manager import ChatMessage, LLMHistoryManager
+
 
 @dataclass
-class ChatMessage:
-    """ChatMessage for testing."""
+class MockLLMConfig:
+    """Mock LLMConfig for testing without full dependencies."""
 
-    role: str
-    content: str
-
-    def to_dict(self):
-        return {"role": self.role, "content": self.content}
-
-    @classmethod
-    def from_dict(cls, data):
-        return cls(role=data["role"], content=data["content"])
+    model: str = "gpt-4o-mini"
+    agent_name: str = "TestBot"
+    history_length: int = 10
+    history_file_path: str = None
+    auto_save_interval: int = 1
 
 
-class TestHistoryPersistence:
-    """Test suite for conversation history persistence."""
+class MockOpenAIClient:
+    """Mock OpenAI client for testing."""
+
+    pass
+
+
+class TestChatMessageSerialization:
+    """Tests for ChatMessage serialization methods."""
+
+    def test_to_dict(self):
+        """Test ChatMessage.to_dict() returns correct format."""
+        msg = ChatMessage(role="user", content="Hello, world!")
+        result = msg.to_dict()
+
+        assert result == {"role": "user", "content": "Hello, world!"}
+
+    def test_from_dict(self):
+        """Test ChatMessage.from_dict() creates correct object."""
+        data = {"role": "assistant", "content": "Hi there!"}
+        msg = ChatMessage.from_dict(data)
+
+        assert msg.role == "assistant"
+        assert msg.content == "Hi there!"
+
+    def test_roundtrip(self):
+        """Test to_dict/from_dict preserves data."""
+        original = ChatMessage(role="user", content="Test message 🚀")
+        restored = ChatMessage.from_dict(original.to_dict())
+
+        assert original.role == restored.role
+        assert original.content == restored.content
+
+
+class TestLLMHistoryManagerPersistence:
+    """Test suite for LLMHistoryManager persistence functionality."""
 
     @pytest.fixture
     def temp_dir(self):
@@ -46,226 +77,274 @@ class TestHistoryPersistence:
         """Create a path for the history file."""
         return os.path.join(temp_dir, "memory", "history.json")
 
+    @pytest.fixture
+    def config_with_persistence(self, history_file):
+        """Create a config with persistence enabled."""
+        return MockLLMConfig(
+            history_file_path=history_file,
+            auto_save_interval=1,
+        )
+
+    @pytest.fixture
+    def config_without_persistence(self):
+        """Create a config without persistence."""
+        return MockLLMConfig(history_file_path=None)
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock OpenAI client."""
+        return MockOpenAIClient()
+
     # =========================================================================
-    # Test 1: Basic Save Functionality
+    # Test: save() method
     # =========================================================================
 
-    def test_save_history_creates_file(self, temp_dir):
-        """Test that save_history creates the history file."""
-        history_file = os.path.join(temp_dir, "history.json")
+    def test_save_creates_file(self, config_with_persistence, mock_client, history_file):
+        """Test that save() creates the history file."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
 
-        history = [
-            ChatMessage(role="user", content="Hello"),
-            ChatMessage(role="assistant", content="Hi there!"),
-        ]
+        # Add some history
+        manager.history.append(ChatMessage(role="user", content="Hello"))
+        manager.history.append(ChatMessage(role="assistant", content="Hi!"))
 
-        data = {
-            "version": "1.0",
-            "agent_name": "TestBot",
-            "frame_index": 0,
-            "message_count": len(history),
-            "messages": [msg.to_dict() for msg in history],
-        }
+        # Save
+        result = manager.save()
 
-        with open(history_file, "w") as f:
-            json.dump(data, f)
-
+        assert result is True
         assert os.path.exists(history_file)
 
+        # Verify file contents
         with open(history_file) as f:
-            loaded = json.load(f)
+            data = json.load(f)
 
-        assert loaded["message_count"] == 2
-        assert loaded["messages"][0]["content"] == "Hello"
+        assert data["message_count"] == 2
+        assert data["messages"][0]["content"] == "Hello"
 
-    def test_save_history_creates_directory(self, temp_dir):
-        """Test that save_history creates parent directories."""
-        history_file = os.path.join(temp_dir, "nested", "deep", "history.json")
+    def test_save_creates_directory(self, temp_dir, mock_client):
+        """Test that save() creates nested directories."""
+        history_file = os.path.join(temp_dir, "deep", "nested", "history.json")
+        config = MockLLMConfig(history_file_path=history_file)
 
-        os.makedirs(os.path.dirname(history_file), exist_ok=True)
+        manager = LLMHistoryManager(config, mock_client)
+        manager.history.append(ChatMessage(role="user", content="Test"))
 
-        with open(history_file, "w") as f:
-            json.dump({"messages": []}, f)
+        result = manager.save()
 
+        assert result is True
         assert os.path.exists(history_file)
 
+    def test_save_without_persistence_returns_false(
+        self, config_without_persistence, mock_client
+    ):
+        """Test that save() returns False when persistence is disabled."""
+        manager = LLMHistoryManager(config_without_persistence, mock_client)
+        manager.history.append(ChatMessage(role="user", content="Test"))
+
+        result = manager.save()
+
+        assert result is False
+
     # =========================================================================
-    # Test 2: Basic Load Functionality
+    # Test: load() method
     # =========================================================================
 
-    def test_load_history_restores_messages(self, temp_dir):
-        """Test that load_history restores saved messages."""
-        history_file = os.path.join(temp_dir, "history.json")
+    def test_load_restores_history(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that load() restores saved history."""
+        # First, save some history
+        manager1 = LLMHistoryManager(config_with_persistence, mock_client)
+        manager1.history = [
+            ChatMessage(role="user", content="First"),
+            ChatMessage(role="assistant", content="Second"),
+        ]
+        manager1.frame_index = 42
+        manager1.save()
 
+        # Create new manager and load
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+
+        # Should auto-load on init, but we can also call load()
+        assert len(manager2.history) == 2
+        assert manager2.history[0].content == "First"
+        assert manager2.frame_index == 42
+
+    def test_load_handles_missing_file(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that load() handles missing file gracefully."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+
+        # File doesn't exist yet
+        assert len(manager.history) == 0
+
+    def test_load_handles_corrupted_file(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that load() handles corrupted JSON gracefully."""
+        # Create corrupted file
+        os.makedirs(os.path.dirname(history_file), exist_ok=True)
+        with open(history_file, "w") as f:
+            f.write('{"messages": [{"role": "user" invalid json')
+
+        # Should not crash, and should backup corrupted file
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+
+        assert len(manager.history) == 0
+        # Check that backup was created
+        backup_files = [f for f in os.listdir(os.path.dirname(history_file)) if ".corrupted." in f]
+        assert len(backup_files) == 1
+
+    def test_load_logs_malformed_messages(
+        self, config_with_persistence, mock_client, history_file, caplog
+    ):
+        """Test that load() logs warnings for malformed messages."""
+        # Create file with some malformed messages
+        os.makedirs(os.path.dirname(history_file), exist_ok=True)
         data = {
             "version": "1.0",
-            "agent_name": "TestBot",
-            "frame_index": 5,
-            "message_count": 3,
             "messages": [
-                {"role": "user", "content": "First message"},
-                {"role": "assistant", "content": "First response"},
-                {"role": "user", "content": "Second message"},
+                {"role": "user", "content": "Good message"},
+                {"role": "user"},  # Missing content
+                {"content": "Missing role"},  # Missing role
+                "not a dict",  # Not a dict
             ],
         }
-
         with open(history_file, "w") as f:
             json.dump(data, f)
 
-        with open(history_file) as f:
-            loaded = json.load(f)
+        import logging
+        with caplog.at_level(logging.WARNING):
+            manager = LLMHistoryManager(config_with_persistence, mock_client)
 
-        messages = [ChatMessage.from_dict(m) for m in loaded["messages"]]
-
-        assert len(messages) == 3
-        assert messages[0].role == "user"
-        assert messages[0].content == "First message"
-        assert loaded["frame_index"] == 5
-
-    def test_load_history_missing_file(self, temp_dir):
-        """Test that load_history handles missing files gracefully."""
-        history_file = os.path.join(temp_dir, "nonexistent.json")
-        assert not os.path.exists(history_file)
+        # Only the good message should be loaded
+        assert len(manager.history) == 1
+        assert manager.history[0].content == "Good message"
 
     # =========================================================================
-    # Test 3: Atomic Write Safety
+    # Test: clear() method
     # =========================================================================
 
-    def test_atomic_write_uses_temp_file(self, temp_dir):
-        """Test that atomic writes use temporary files."""
-        history_file = os.path.join(temp_dir, "history.json")
+    def test_clear_removes_history(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that clear() removes history from memory and disk."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.history = [
+            ChatMessage(role="user", content="Test"),
+        ]
+        manager.frame_index = 10
+        manager.save()
 
-        data = {"messages": [{"role": "user", "content": "test"}]}
+        # Clear
+        manager.clear()
 
-        fd, temp_path = tempfile.mkstemp(suffix=".tmp", prefix=".history_", dir=temp_dir)
+        assert len(manager.history) == 0
+        assert manager.frame_index == 0
 
-        try:
-            with os.fdopen(fd, "w") as f:
-                json.dump(data, f)
-                f.flush()
-                os.fsync(f.fileno())
-
-            os.replace(temp_path, history_file)
-
-            assert os.path.exists(history_file)
-            assert not os.path.exists(temp_path)
-
-        except Exception:
-            if os.path.exists(temp_path):
-                os.unlink(temp_path)
-            raise
-
-    def test_atomic_write_survives_crash(self, temp_dir):
-        """Test that atomic writes don't corrupt data on simulated crash."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        initial_data = {"messages": [{"role": "user", "content": "original"}]}
-        with open(history_file, "w") as f:
-            json.dump(initial_data, f)
-
-        # Simulate crash: temp file exists but rename didn't complete
-        temp_path = history_file + ".tmp"
-        partial_data = '{"messages": [{"role": "user", "content": "partial'
-
-        with open(temp_path, "w") as f:
-            f.write(partial_data)
-
-        # Original file should still be valid
-        with open(history_file) as f:
-            loaded = json.load(f)
-
-        assert loaded["messages"][0]["content"] == "original"
-
-        os.unlink(temp_path)
-
-    # =========================================================================
-    # Test 4: Corruption Handling
-    # =========================================================================
-
-    def test_corrupted_json_handling(self, temp_dir):
-        """Test that corrupted JSON files are handled gracefully."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        with open(history_file, "w") as f:
-            f.write('{"messages": [{"role": "user", invalid json here')
-
-        try:
-            with open(history_file) as f:
-                json.load(f)
-            loaded = True
-        except json.JSONDecodeError:
-            loaded = False
-
-        assert not loaded
-
-    def test_corrupted_file_backup(self, temp_dir):
-        """Test that corrupted files are backed up."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        with open(history_file, "w") as f:
-            f.write("not valid json at all {{{")
-
-        backup_path = history_file + ".corrupted.123456"
-        os.rename(history_file, backup_path)
-
-        assert os.path.exists(backup_path)
-        assert not os.path.exists(history_file)
-
-    def test_invalid_structure_handling(self, temp_dir):
-        """Test handling of valid JSON but invalid structure."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        with open(history_file, "w") as f:
-            json.dump(["not", "a", "dict"], f)
-
+        # File should exist but be empty
         with open(history_file) as f:
             data = json.load(f)
+        assert data["messages"] == []
 
-        assert not isinstance(data, dict)
+    # =========================================================================
+    # Test: Auto-save functionality
+    # =========================================================================
 
-    def test_missing_fields_handling(self, temp_dir):
-        """Test handling of missing required fields."""
+    def test_auto_save_triggers_at_interval(self, temp_dir, mock_client):
+        """Test that auto-save triggers after configured interval."""
         history_file = os.path.join(temp_dir, "history.json")
+        config = MockLLMConfig(history_file_path=history_file, auto_save_interval=3)
 
-        with open(history_file, "w") as f:
-            json.dump({"version": "1.0"}, f)
+        manager = LLMHistoryManager(config, mock_client)
 
-        with open(history_file) as f:
-            data = json.load(f)
+        # Simulate interactions
+        for i in range(5):
+            manager.history.append(ChatMessage(role="user", content=f"Message {i}"))
+            manager._maybe_auto_save()
 
-        messages = data.get("messages", [])
-        assert messages == []
+        # After 5 calls with interval=3, should have saved once (at call 3)
+        # File should exist
+        assert os.path.exists(history_file)
+
+    def test_auto_save_resets_counter_on_load(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that load() resets the auto-save counter."""
+        # Create and save
+        manager1 = LLMHistoryManager(config_with_persistence, mock_client)
+        manager1.history.append(ChatMessage(role="user", content="Test"))
+        manager1._save_counter = 5
+        manager1.save()
+
+        # Load in new manager
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+
+        # Counter should be reset
+        assert manager2._save_counter == 0
 
     # =========================================================================
-    # Test 5: Thread Safety
+    # Test: Hash-based change detection
     # =========================================================================
 
-    def test_concurrent_saves(self, temp_dir):
+    def test_skip_save_when_unchanged(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that save() skips when history hasn't changed."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.history.append(ChatMessage(role="user", content="Test"))
+        manager.save()
+
+        # Get file modification time
+        mtime1 = os.path.getmtime(history_file)
+
+        # Save again without changes
+        import time
+        time.sleep(0.1)  # Small delay to ensure mtime would change
+        manager.save()
+
+        # File should not have been modified
+        mtime2 = os.path.getmtime(history_file)
+        assert mtime1 == mtime2
+
+    def test_save_when_changed(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that save() writes when history has changed."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.history.append(ChatMessage(role="user", content="Test"))
+        manager.save()
+
+        mtime1 = os.path.getmtime(history_file)
+
+        # Add new message
+        import time
+        time.sleep(0.1)
+        manager.history.append(ChatMessage(role="assistant", content="Response"))
+        manager.save()
+
+        mtime2 = os.path.getmtime(history_file)
+        assert mtime2 > mtime1
+
+    # =========================================================================
+    # Test: Thread safety
+    # =========================================================================
+
+    def test_concurrent_saves_are_safe(self, temp_dir, mock_client):
         """Test that concurrent saves don't corrupt data."""
         history_file = os.path.join(temp_dir, "history.json")
-        lock = threading.RLock()
+        config = MockLLMConfig(history_file_path=history_file)
+
+        manager = LLMHistoryManager(config, mock_client)
         errors = []
 
         def save_worker(worker_id, iterations):
             for i in range(iterations):
                 try:
-                    with lock:
-                        data = {
-                            "worker": worker_id,
-                            "iteration": i,
-                            "messages": [{"role": "user", "content": f"msg-{worker_id}-{i}"}],
-                        }
-
-                        fd, temp_path = tempfile.mkstemp(suffix=".tmp", dir=temp_dir)
-                        try:
-                            with os.fdopen(fd, "w") as f:
-                                json.dump(data, f)
-                            os.replace(temp_path, history_file)
-                        except Exception:
-                            if os.path.exists(temp_path):
-                                os.unlink(temp_path)
-                            raise
-
+                    manager.history.append(
+                        ChatMessage(role="user", content=f"msg-{worker_id}-{i}")
+                    )
+                    manager.save()
                 except Exception as e:
                     errors.append(str(e))
 
@@ -280,204 +359,80 @@ class TestHistoryPersistence:
 
         assert len(errors) == 0
 
+        # File should be valid JSON
         with open(history_file) as f:
             data = json.load(f)
-
         assert "messages" in data
 
-    def test_concurrent_reads(self, temp_dir):
-        """Test that concurrent reads work correctly."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        data = {"messages": [{"role": "user", "content": "test"}]}
-        with open(history_file, "w") as f:
-            json.dump(data, f)
-
-        results = []
-        errors = []
-
-        def read_worker():
-            try:
-                with open(history_file) as f:
-                    data = json.load(f)
-                results.append(len(data.get("messages", [])))
-            except Exception as e:
-                errors.append(str(e))
-
-        threads = [threading.Thread(target=read_worker) for _ in range(10)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-
-        assert len(errors) == 0
-        assert all(r == 1 for r in results)
-
     # =========================================================================
-    # Test 6: Edge Cases
+    # Test: Security - Path validation
     # =========================================================================
 
-    def test_empty_history_save_load(self, temp_dir):
+    def test_rejects_directory_traversal(self, temp_dir, mock_client, caplog):
+        """Test that directory traversal paths are rejected."""
+        import logging
+
+        malicious_path = os.path.join(temp_dir, "..", "..", "etc", "passwd")
+        config = MockLLMConfig(history_file_path=malicious_path)
+
+        with caplog.at_level(logging.WARNING):
+            manager = LLMHistoryManager(config, mock_client)
+
+        # Path should be rejected
+        assert manager._history_file_path is None
+
+    # =========================================================================
+    # Test: Edge cases
+    # =========================================================================
+
+    def test_empty_history(self, config_with_persistence, mock_client, history_file):
         """Test saving and loading empty history."""
-        history_file = os.path.join(temp_dir, "history.json")
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.save()
 
-        data = {
-            "version": "1.0",
-            "messages": [],
-            "frame_index": 0,
-        }
+        # Reload
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+        assert len(manager2.history) == 0
 
-        with open(history_file, "w") as f:
-            json.dump(data, f)
-
-        with open(history_file) as f:
-            loaded = json.load(f)
-
-        assert loaded["messages"] == []
-
-    def test_large_history_handling(self, temp_dir):
-        """Test handling of large conversation history."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        messages = [
-            {"role": "user" if i % 2 == 0 else "assistant", "content": f"Message {i}" * 100}
-            for i in range(1000)
+    def test_unicode_content(self, config_with_persistence, mock_client, history_file):
+        """Test saving and loading unicode content."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.history = [
+            ChatMessage(role="user", content="Hello 👋 World 🌍"),
+            ChatMessage(role="assistant", content="你好世界 مرحبا"),
         ]
+        manager.save()
 
-        data = {"version": "1.0", "messages": messages}
+        # Reload
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+        assert "👋" in manager2.history[0].content
+        assert "你好" in manager2.history[1].content
 
-        with open(history_file, "w") as f:
-            json.dump(data, f)
+    def test_large_history(self, config_with_persistence, mock_client, history_file):
+        """Test handling large conversation history."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        for i in range(1000):
+            manager.history.append(
+                ChatMessage(role="user", content=f"Message {i}" * 50)
+            )
+        manager.save()
 
-        with open(history_file) as f:
-            loaded = json.load(f)
+        # Reload
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+        assert len(manager2.history) == 1000
 
-        assert len(loaded["messages"]) == 1000
+    def test_frame_index_persisted(
+        self, config_with_persistence, mock_client, history_file
+    ):
+        """Test that frame_index is persisted."""
+        manager = LLMHistoryManager(config_with_persistence, mock_client)
+        manager.history.append(ChatMessage(role="user", content="Test"))
+        manager.frame_index = 42
+        manager.save()
 
-    def test_unicode_content_handling(self, temp_dir):
-        """Test handling of unicode content in messages."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        data = {
-            "messages": [
-                {"role": "user", "content": "Hello 👋 World 🌍"},
-                {"role": "assistant", "content": "你好世界 مرحبا بالعالم"},
-                {"role": "user", "content": "Émoji: 🚀🎉✨"},
-            ]
-        }
-
-        with open(history_file, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False)
-
-        with open(history_file, encoding="utf-8") as f:
-            loaded = json.load(f)
-
-        assert "👋" in loaded["messages"][0]["content"]
-        assert "你好" in loaded["messages"][1]["content"]
-
-    def test_special_characters_in_path(self, temp_dir):
-        """Test handling of special characters in file path."""
-        history_file = os.path.join(temp_dir, "agent name with spaces", "history.json")
-        os.makedirs(os.path.dirname(history_file), exist_ok=True)
-
-        data = {"messages": [{"role": "user", "content": "test"}]}
-
-        with open(history_file, "w") as f:
-            json.dump(data, f)
-
-        assert os.path.exists(history_file)
-
-    # =========================================================================
-    # Test 7: Frame Index Persistence
-    # =========================================================================
-
-    def test_frame_index_persisted(self, temp_dir):
-        """Test that frame_index is persisted with history."""
-        history_file = os.path.join(temp_dir, "history.json")
-
-        data = {
-            "version": "1.0",
-            "frame_index": 42,
-            "messages": [{"role": "user", "content": "test"}],
-        }
-
-        with open(history_file, "w") as f:
-            json.dump(data, f)
-
-        with open(history_file) as f:
-            loaded = json.load(f)
-
-        assert loaded["frame_index"] == 42
-
-    # =========================================================================
-    # Test 8: Hash-based Change Detection
-    # =========================================================================
-
-    def test_skip_save_when_unchanged(self, temp_dir):
-        """Test that saves are skipped when history hasn't changed."""
-        history = [
-            ChatMessage(role="user", content="Hello"),
-            ChatMessage(role="assistant", content="Hi"),
-        ]
-
-        def compute_hash(messages, frame_index):
-            return hash((frame_index, tuple((m.role, m.content) for m in messages)))
-
-        hash1 = compute_hash(history, 0)
-        hash2 = compute_hash(history, 0)
-
-        assert hash1 == hash2  # Same history = same hash
-
-        history.append(ChatMessage(role="user", content="New message"))
-        hash3 = compute_hash(history, 0)
-
-        assert hash1 != hash3  # Changed history = different hash
-
-    # =========================================================================
-    # Test 9: Auto-save Interval
-    # =========================================================================
-
-    def test_auto_save_interval(self, temp_dir):
-        """Test that auto-save respects the interval setting."""
-        save_counter = 0
-        auto_save_interval = 3
-        saves_performed = 0
-
-        for i in range(10):
-            save_counter += 1
-            if save_counter >= auto_save_interval:
-                save_counter = 0
-                saves_performed += 1
-
-        # Should have saved 3 times (at iterations 3, 6, 9)
-        assert saves_performed == 3
-
-
-class TestChatMessage:
-    """Tests for ChatMessage dataclass."""
-
-    def test_to_dict(self):
-        """Test ChatMessage.to_dict() method."""
-        msg = ChatMessage(role="user", content="Hello")
-        d = msg.to_dict()
-
-        assert d == {"role": "user", "content": "Hello"}
-
-    def test_from_dict(self):
-        """Test ChatMessage.from_dict() class method."""
-        d = {"role": "assistant", "content": "Hi there"}
-        msg = ChatMessage.from_dict(d)
-
-        assert msg.role == "assistant"
-        assert msg.content == "Hi there"
-
-    def test_roundtrip(self):
-        """Test to_dict/from_dict roundtrip."""
-        original = ChatMessage(role="user", content="Test message")
-        restored = ChatMessage.from_dict(original.to_dict())
-
-        assert original.role == restored.role
-        assert original.content == restored.content
+        # Reload
+        manager2 = LLMHistoryManager(config_with_persistence, mock_client)
+        assert manager2.frame_index == 42
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Implements conversation history persistence to disk with automatic save/reload on restart.

## Changes
- Add `history_file_path` and `auto_save_interval` config options to `LLMConfig`
- Atomic writes using temp file + `os.replace` pattern (matches `ModeManager` style)
- Auto-load history on `LLMHistoryManager` initialization
- Auto-save after interactions with configurable interval
- Hash-based change detection to skip unnecessary writes
- Thread-safe disk operations using `RLock`
- Graceful corruption handling with automatic backups
- 21 comprehensive unit tests

## Usage
```yaml
llm:
  history_file_path: config/memory/conversation_history.json
  auto_save_interval: 1