### PR TITLE
fix(zenoh_msgs): Mutable defaults in status_msgs dataclasses

### DIFF
--- a/src/zenoh_msgs/idl/status_msgs.py
+++ b/src/zenoh_msgs/idl/status_msgs.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 from pycdr2 import IdlStruct
@@ -93,7 +93,7 @@ class ModeStatusRequest(IdlStruct, typename="ModeStatusRequest"):
     header: Header
     request_id: String
     code: int8
-    mode: String = String("")  # Target mode for SWITCH_MODE, ignored for STATUS
+    mode: String = field(default_factory=lambda: String(""))
 
 
 @dataclass
@@ -194,7 +194,7 @@ class ConfigRequest(IdlStruct, typename="ConfigRequest"):
 
     header: Header
     request_id: String
-    config: String = String("")  # ignored for GET_CONFIG
+    config: String = field(default_factory=lambda: String(""))
 
 
 @dataclass


### PR DESCRIPTION
### Issue
Two dataclasses use mutable default values causing `ValueError` during import

### Error
```
ValueError: mutable default String(IdlStruct, idl_typename='String') for field mode is not allowed: use default_factory
```

### Files Changed
- `src/zenoh_msgs/idl/status_msgs.py`

### Changes Made

1. **Line 1**: Added `field` to imports
```python
   from dataclasses import dataclass, field
```

2. **Line 96**: Fixed `ModeStatusRequest.mode`
```python
   mode: String = field(default_factory=lambda: String(""))
```

3. **Line 197**: Fixed `ConfigRequest.config`
```python
   config: String = field(default_factory=lambda: String(""))
```

### Testing
```bash
pytest tests/providers/test_odom_provider.py -v
```

- **Before**: ValueError, 0 tests collected
- **After**: 8/8 tests passed ✅

### Screenshots

**_- Before:_**
<img width="1868" height="814" alt="before" src="https://github.com/user-attachments/assets/5584186a-3292-403b-aa24-bfd12e040683" />
<img width="1913" height="812" alt="before1" src="https://github.com/user-attachments/assets/fec1c226-c0c6-459d-bf1e-672e52d4b6a0" />


**_- After:_**
<img width="1917" height="810" alt="after" src="https://github.com/user-attachments/assets/5d997a63-a974-40fa-8f45-2c3e7cc5af6e" />
