### PR TITLE
fix(unitree): prepare v4l2-ctl dependency check

### DIFF
--- a/src/providers/unitree_realsense_dev_vlm_provider.py
+++ b/src/providers/unitree_realsense_dev_vlm_provider.py
@@ -1,6 +1,7 @@
 import base64
 import glob
 import logging
+import shutil
 import subprocess
 import time
 from typing import Callable, List, Optional, Tuple
@@ -216,6 +217,16 @@ class UnitreeRealSenseDevVideoStream(VideoStream):
             video_devices = sorted(glob.glob("/dev/video*"))
         except Exception as e:
             logger.exception("Failed to list video devices: %s", e)
+            return None
+
+        # Check if v4l2-ctl is installed
+        if shutil.which("v4l2-ctl") is None:
+            logger.warning(
+                "v4l2-ctl not found. Falling back to simple device enumeration."
+            )
+            for device in video_devices:
+                if device not in skip_devices:
+                    return device
             return None
 
         for device in video_devices:


### PR DESCRIPTION
## Overview
This PR improves the robustness of the UnitreeRealSenseDevVideoStream by handling the absence of the v4l2-ctl system binary gracefully. Previously, missing this binary would cause repeated FileNotFoundError exceptions during device discovery, effectively breaking the provider.

## Changes
File: [src/providers/unitree_realsense_dev_vlm_provider.py](code-assist-path:c:\Users\asus\Music\om\OM1\src\providers\unitree_realsense_dev_vlm_provider.py)
Logic:
Added import shutil.
In _find_rgb_device, added a check using shutil.which("v4l2-ctl").
If the binary is missing, the method logs a warning once and falls back to returning the first available /dev/video* device that isn't in the skip list.

## Impact
Robustness: The provider can now function (at least partially) in minimal environments (like Docker containers) where v4l2-utils is not installed, relying on OpenCV's internal ability to open the device.
Diagnostics: Replaces confusing stack traces with a clear warning message about the missing dependency.

## Testing
[x] Verified that shutil.which correctly identifies the presence/absence of the binary.
[x] Confirmed that the fallback loop returns a device path if one exists.
[x] Confirmed that the original logic remains active when v4l2-ctl is present.

## Additional Information
This addresses the "Implicit Runtime Dependency on v4l2-ctl" finding from the runtime robustness review.