### PR TITLE
fix(unitree): prepare timeout for v4l2-ctl subprocess

### DIFF
--- a/src/providers/unitree_realsense_dev_vlm_provider.py
+++ b/src/providers/unitree_realsense_dev_vlm_provider.py
@@ -228,8 +228,12 @@ class UnitreeRealSenseDevVideoStream(VideoStream):
                     capture_output=True,
                     text=True,
                     shell=False,
+                    timeout=3.0,
                 )
                 formats = result.stdout
+            except subprocess.TimeoutExpired:
+                logger.warning("Timeout running v4l2-ctl for device '%s'", device)
+                continue
             except Exception as e:
                 logger.exception(
                     "Failed to run v4l2-ctl for device '%s': %s", device, e


### PR DESCRIPTION
## Overview
This PR improves the runtime robustness of UnitreeRealSenseDevVideoStream by enforcing a timeout on external subprocess calls used for device discovery.

## Changes
File: [src/providers/unitree_realsense_dev_vlm_provider.py]
- Logic:
Added timeout=3.0 (seconds) to the subprocess.run call invoking v4l2-ctl.
Added a specific exception handler for subprocess.TimeoutExpired to log a warning and skip the problematic device instead of hanging the thread.

## Impact
Robustness: Prevents the video capture thread from entering a "zombie" state if a connected USB device is malfunctioning and blocking I/O requests indefinitely.
Reliability: Ensures that the system can continue scanning for other valid devices even if one device hangs during the probe.

## Testing
[x] Verified that subprocess.run accepts the timeout parameter.
[x] Verified that subprocess.TimeoutExpired is correctly caught and logged (simulated by mocking subprocess.run to raise the exception).
[x] Confirmed that normal device discovery still works when no timeout occurs.

## Additional Information
This addresses the "Unbounded Subprocess Execution (Hang Risk)" finding from the runtime robustness review.