### PR TITLE
CI: remove hourly cron trigger from nightly integration tests

### DIFF
--- a/.github/workflows/nightly-integration-tests.yml
+++ b/.github/workflows/nightly-integration-tests.yml
@@ -4,8 +4,6 @@ env:
   OM1_API_KEY: ${{ secrets.OM1_API_KEY }}
 
 on:
-  schedule:
-    - cron: '0 * * * *'
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
## Overview
This PR removes the hourly cron trigger from the nightly integration test workflow to prevent unnecessary CI executions.

## Type of change
- [x] Other: CI / workflow optimization

## Changes
- Removed the hourly scheduled cron trigger
- Kept push, pull_request, and manual triggers intact

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Local testing completed
- [ ] Tests added/updated (not applicable)

## Impact
Reduces CI noise and resource usage while preserving full test coverage on relevant events such as pushes and pull requests.

## Additional Information
This workflow uses secrets and external integrations, so avoiding frequent scheduled runs helps reduce risk and overhead.
