### PR TITLE
CI: narrow ci-cd label scope to workflows only

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,8 +27,8 @@ infrastructure:
 ci-cd:
   - changed-files:
     - any-glob-to-any-file:
-      - '.github/**/*'
-      - '**/.github/**/*'
+      - '.github/workflows/**/*'
+      
 
 # Dependencies
 dependencies:


### PR DESCRIPTION
## Overview
This PR refines the labeler configuration so that the `ci-cd` label is applied only to workflow-related changes.

## Type of change
- [x] Other: CI / labeler configuration improvement

## Changes
- Scoped `ci-cd` label to `.github/workflows/**`
- Avoided overlapping labels with general configuration files

## Impact
Improves PR labeling accuracy without changing any runtime behavior.

## Additional Information
This helps reduce label noise and makes CI-related changes easier to identify.