### PR TITLE
Community: add good first issue auto-labeling rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,3 +60,15 @@ config:
       - '**/*.toml'
       - '**/*.ini'
       - '**/*.conf'
+
+# Good first issues (low-risk changes)
+good first issue:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**/*'
+      - '*.md'
+      - '*.mdx'
+      - 'tests/**/*'
+      - '**/test_*.py'
+      - '**/*_test.py'
+      - '.github/*.yml'


### PR DESCRIPTION
## Overview
This PR adds automatic labeling rules for `good first issue` to help new contributors discover low-risk entry points.

## Type of change
- [x] Other: community / labeling improvement

## Changes
- Added labeler rules for documentation, test-only, and simple config changes

## Impact
Improves contributor onboarding and makes beginner-friendly issues easier to identify.

## Additional Information
This follows common open source practices for community growth and contributor experience.
