### PR TITLE
Docs: add CI status badge for nightly integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![OM_Banner_X2 (1)](https://github.com/user-attachments/assets/853153b7-351a-433d-9e1a-d257b781f93c)
 
+[![Nightly Integration Tests](https://github.com/OpenMind/OM1/actions/workflows/nightly-integration-tests.yml/badge.svg)](https://github.com/OpenMind/OM1/actions/workflows/nightly-integration-tests.yml)
+
 <p align="center">
 <a href="https://arxiv.org/abs/2412.18588">Technical Paper</a> |
 <a href="https://docs.openmind.org/">Documentation</a> |


### PR DESCRIPTION
## Overview
Adds a GitHub Actions CI status badge to the README to make the current state of the Nightly Integration Tests visible at a glance.

## Type of change
- [x] Documentation improvement

## Changes
- Added a CI status badge linked to the Nightly Integration Tests workflow.

## Impact
- No impact on runtime behavior.
- Improves developer experience and project transparency.

## Additional Information
The badge updates automatically based on the workflow status.
