### PR TITLE
test: fix assertion in test_greeting_conversation_state_provider

### DIFF
--- a/tests/providers/test_greeting_conversation_state_provider.py
+++ b/tests/providers/test_greeting_conversation_state_provider.py
@@ -339,7 +339,7 @@ class TestGreetingConversationStateMachineProvider:
         assert "command" in result
         assert "time_in_state" in result
         assert "confidence_trend" in result
-        assert result["current_state"] == ConversationState.CONCLUDING.value
+        assert result["current_state"] == ConversationState.CONVERSING.value
 
     def test_process_conversation_with_voice_input(self, state_machine_with_mock_io):
         """Test processing conversation with voice input."""


### PR DESCRIPTION
Fixed incorrect assertion in `test_greeting_conversation_state_provider`

**Issue:** 
The test sets `ConversationState.CONVERSING` in the LLM output, but line 342 asserts the result should be `CONCLUDING`

**Fix:**
Updated assertion to expect `CONVERSING` state consistent with the LLM output configuration

## Before Fix
<img width="1856" height="802" alt="before" src="https://github.com/user-attachments/assets/b2380321-65ff-4dab-b053-9b2173581efe" />


## After Fix
<img width="1919" height="849" alt="after" src="https://github.com/user-attachments/assets/edd86608-5516-4a97-b404-318c1b51828e" />
