### PR TITLE
fix(test): Resolve NameError in unitree_g1_basic import

### DIFF
--- a/src/inputs/plugins/unitree_g1_basic.py
+++ b/src/inputs/plugins/unitree_g1_basic.py
@@ -136,7 +136,7 @@ class UnitreeG1Basic(FuserInput[UnitreeG1BasicConfig, List[float]]):
         self.g1_lowbatt_percent = 20.0  # percent
         self.descriptor_for_LLM = "Energy Level"
 
-    def BMSStateHandler(self, msg: dds_.BmsState_):  # type: ignore
+    def BMSStateHandler(self, msg: BmsState_):  # type: ignore
         """
         Handle incoming BmsState messages from the Unitree robot.
 
@@ -153,7 +153,7 @@ class UnitreeG1Basic(FuserInput[UnitreeG1BasicConfig, List[float]]):
         self.battery_percentage = float(msg.soc)  # type: ignore
         self.battery_temperature = float(msg.temperature[0])  # type: ignore
 
-    def LowStateHandler(self, msg: dds_.LowState_):  # type: ignore
+    def LowStateHandler(self, msg: LowState_):  # type: ignore
         """
         Handle incoming LowState messages from the Unitree robot.
 


### PR DESCRIPTION
## Problem
Test fails with `NameError: name 'dds_' is not defined` when importing `unitree_g1_basic`

## Root Cause
Type hints used `dds_.BmsState_` and `dds_.LowState_` but `dds_` is not defined in both cases

## Solution
Changed type hints to use `BmsState_` and `LowState_` directly

```python
def BMSStateHandler(self, msg: BmsState_):
def LowStateHandler(self, msg: LowState_):
```

### Before:
<img width="1915" height="814" alt="before" src="https://github.com/user-attachments/assets/f193dafd-f9dd-4b76-b0ef-2613e22ad92a" />


### After:
<img width="1920" height="808" alt="after" src="https://github.com/user-attachments/assets/f782b301-ad28-4dbf-9132-15e000415173" />



✅ All tests now pass