### PR TITLE
Make app command configurable in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,4 @@ services:
       - apparmor:unconfined
     group_add:
       - audio
-    command: ["unitree_go2_modes"]
+    command: ["${OM1_COMMAND:-unitree_go2_modes}"]


### PR DESCRIPTION
This pull request introduces a small change to the `docker-compose.yml` file, making the `command` for the service configurable via the `OM1_COMMAND` environment variable, with a default fallback to `unitree_go2_modes`.