### PR TITLE
fix(docs): correct parameter type in zenoh

### DIFF
--- a/src/inputs/plugins/zenoh.py
+++ b/src/inputs/plugins/zenoh.py
@@ -75,7 +75,7 @@ class ZenohListener(FuserInput[ZenohListenerConfig, Optional[str]]):
 
         Parameters
         ----------
-        zenoh_input : object
+        zenoh_input : zenoh.Sample
             The Zenoh sample received, which should have a 'payload' attribute.
         """
         try:


### PR DESCRIPTION
Fixed incorrect parameter type documentation in `_handle_zenoh_message`

Changed `zenoh_input : object` to `zenoh_input : zenoh.Sample` to match the actual type hint