### PR TITLE
fix(tests): add mock_zenoh fixture to test_singleton_pattern

### DIFF
--- a/tests/providers/test_config_provider.py
+++ b/tests/providers/test_config_provider.py
@@ -47,7 +47,8 @@ def test_initialization(mock_zenoh):
     mock_session_instance.declare_subscriber.assert_called_once()
 
 
-def test_singleton_pattern():
+def test_singleton_pattern(mock_zenoh):
+    """Test that ConfigProvider follows singleton pattern."""
     provider1 = ConfigProvider()
     provider2 = ConfigProvider()
     assert provider1 is provider2


### PR DESCRIPTION
## Problem

The `test_singleton_pattern` test in `tests/providers/test_config_provider.py` was missing the `mock_zenoh` fixture, causing it to attempt real Zenoh connections during test execution.

This violates test isolation principles and can cause unpredictable failures in CI environments where Zenoh is not available.

## Solution

- Added `mock_zenoh` fixture to `test_singleton_pattern` to match the pattern used by other tests in the same file
- Added docstring for test clarity

## Changes

- `tests/providers/test_config_provider.py`: Added `mock_zenoh` fixture parameter and docstring to `test_singleton_pattern`

## Testing

- Pre-commit checks pass
- Change follows existing test patterns in the file