### PR TITLE
fix: Remove debug code that randomly inflates ETH balance

### DIFF
--- a/src/inputs/plugins/wallet_ethereum.py
+++ b/src/inputs/plugins/wallet_ethereum.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import random
 import time
 from typing import List, Optional
 
@@ -85,15 +84,7 @@ class WalletEthereum(FuserInput[SensorConfig, List[float]]):
                 f"Block: {self.eth_info['block_number']}, Account Balance: {self.eth_info['balance']:.3f} ETH"
             )
 
-            # randomly simulate ETH inbound transfers for debugging purposes
-            random_add_for_debugging = 0
-            dice = random.randint(0, 10)
-            logging.debug(f"WalletEthereum: dice {dice}")
-            if dice > 7:
-                logging.info("WalletEthereum: randomly adding 1.0 ETH")
-                random_add_for_debugging = 1.0
-
-            self.ETH_balance = self.balance_eth + random_add_for_debugging
+            self.ETH_balance = self.balance_eth
             self.balance_change = self.ETH_balance - self.ETH_balance_previous
             self.ETH_balance_previous = self.ETH_balance
 


### PR DESCRIPTION
## Description

Removes debug code from `src/inputs/plugins/wallet_ethereum.py` that randomly adds 1.0 ETH to the wallet balance with ~30% probability on every poll cycle.

## Changes

- ❌ Removed debug code block (lines 96-102) that randomly inflates ETH balance
- ❌ Removed unused `import random`
- ✅ Assigned `self.ETH_balance = self.balance_eth` directly

## Impact

**Before:** LLM received incorrect balance data with random +1.0 ETH additions, triggering false notifications and wrong decisions.

**After:** Balance reflects actual blockchain state without phantom transfers.

## Testing

- [x] Code review
- [x] Verified removal of debug logic
- [x] Confirmed clean import list

Fixes #2040