### PR TITLE
fix: Standardize timestamp types to float across TeleOps dataclasses

### DIFF
--- a/src/providers/teleops_status_provider.py
+++ b/src/providers/teleops_status_provider.py
@@ -19,7 +19,7 @@ class BatteryStatus:
     battery_level: float
     temperature: float
     voltage: float
-    timestamp: str
+    timestamp: float
     charging_status: bool = False
 
     def to_dict(self) -> dict:
@@ -54,7 +54,7 @@ class BatteryStatus:
             charging_status=data.get("charging_status", False),
             temperature=data.get("temperature", 0.0),
             voltage=data.get("voltage", 0.0),
-            timestamp=data.get("timestamp", str(time.time())),
+            timestamp=data.get("timestamp", time.time()),
         )
 
 
@@ -67,7 +67,7 @@ class CommandStatus:
     vx: float
     vy: float
     vyaw: float
-    timestamp: str
+    timestamp: float
 
     def to_dict(self) -> dict:
         """
@@ -158,7 +158,7 @@ class TeleopsStatus:
     Data class to represent the status of the teleops system.
     """
 
-    update_time: str
+    update_time: float
     battery_status: BatteryStatus
     action_status: ActionStatus = field(
         default_factory=lambda: ActionStatus(ActionType.AI, time.time())


### PR DESCRIPTION
## Description

Fixes inconsistent timestamp type annotations in `src/providers/teleops_status_provider.py` where fields were declared as `str` but assigned `time.time()` float values, causing type mismatches.

## Problem

The TeleOps dataclasses had timestamp fields with inconsistent type annotations:

- `BatteryStatus.timestamp: str` but default was `time.time()` (float)
- `CommandStatus.timestamp: str` but default was `time.time()` (float)  
- `TeleopsStatus.update_time: str` but default was `time.time()` (float)
- `ActionStatus.timestamp: float` ✅ (correct)

This mismatch between declared types and actual values could cause:
- Type checker warnings/errors
- Runtime confusion for consumers
- Inconsistent behavior across the provider system

## Changes

- ✅ `BatteryStatus.timestamp: str` → `float`
- ✅ `CommandStatus.timestamp: str` → `float`
- ✅ `TeleopsStatus.update_time: str` → `float`
- ✅ Updated `from_dict` methods to maintain consistency

## Impact

All timestamp fields now consistently use `float` (Unix time) across the TeleOps provider system, ensuring type safety and predictable behavior.

## Testing

- [x] Code review
- [x] Verified type consistency across all dataclasses
- [x] Confirmed `from_dict` methods align with type annotations

Fixes #1895