### PR TITLE
Warn when action_execution_mode/action_dependencies are defined but unused

### DIFF
--- a/src/runtime/multi_mode/config.py
+++ b/src/runtime/multi_mode/config.py
@@ -394,6 +394,17 @@ def load_mode_config(
     verify_runtime_version(config_version, config_name)
     validate_config_schema(raw_config)
 
+    # Warn if config fields are defined but not yet consumed by the runtime.
+    if raw_config.get("action_execution_mode"):
+        logging.warning(
+            "action_execution_mode is defined but not yet consumed by the runtime (config-only for now)."
+        )
+    if raw_config.get("action_dependencies"):
+        logging.warning(
+            "action_dependencies are defined but not yet consumed by the runtime (config-only for now)."
+        )
+
+
     g_robot_ip = raw_config.get("robot_ip", None)
     if g_robot_ip is None or g_robot_ip == "" or g_robot_ip == "192.168.0.241":
         logging.warning("No robot ip found in mode config. Checking .env file.")

--- a/src/runtime/single_mode/config.py
+++ b/src/runtime/single_mode/config.py
@@ -146,6 +146,18 @@ def load_config(
     verify_runtime_version(config_version, config_name)
     validate_config_schema(raw_config)
 
+    # Warn if config fields are defined but not yet consumed by the runtime.
+    # This avoids silently ignoring user configuration.
+    if raw_config.get("action_execution_mode"):
+        logging.warning(
+            "action_execution_mode is defined but not yet consumed by the runtime (config-only for now)."
+        )
+    if raw_config.get("action_dependencies"):
+        logging.warning(
+            "action_dependencies are defined but not yet consumed by the runtime (config-only for now)."
+        )
+
+
     g_robot_ip = raw_config.get("robot_ip", None)
     if g_robot_ip is None or g_robot_ip == "" or g_robot_ip == "192.168.0.241":
         logging.warning(


### PR DESCRIPTION
### What
- Emit warnings when `action_execution_mode` and/or `action_dependencies` are set in config but not yet consumed by the runtime.

### Why
These fields are currently accepted by config validation but silently ignored at runtime, which can mislead users into thinking they are effective.

### Tested
- `uv run src/cli.py validate-config config/spot_actiondeps_test.json5`
- `PYTHONPATH=src uv run python3 -c "from runtime.single_mode.config import load_config; load_config('spot_actiondeps_test')"`
