### PR TITLE
fix: Remove debug code that randomly inflates ETH balance

### DIFF
--- a/src/inputs/plugins/wallet_ethereum.py
+++ b/src/inputs/plugins/wallet_ethereum.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import random
 import time
 from typing import List, Optional
 
@@ -85,15 +84,7 @@ class WalletEthereum(FuserInput[SensorConfig, List[float]]):
                 f"Block: {self.eth_info['block_number']}, Account Balance: {self.eth_info['balance']:.3f} ETH"
             )
 
-            # randomly simulate ETH inbound transfers for debugging purposes
-            random_add_for_debugging = 0
-            dice = random.randint(0, 10)
-            logging.debug(f"WalletEthereum: dice {dice}")
-            if dice > 7:
-                logging.info("WalletEthereum: randomly adding 1.0 ETH")
-                random_add_for_debugging = 1.0
-
-            self.ETH_balance = self.balance_eth + random_add_for_debugging
+            self.ETH_balance = self.balance_eth
             self.balance_change = self.ETH_balance - self.ETH_balance_previous
             self.ETH_balance_previous = self.ETH_balance
 


### PR DESCRIPTION
## Problem

`src/inputs/plugins/wallet_ethereum.py` contains debug code that randomly adds **1.0 ETH** to the reported wallet balance with ~30% probability on every poll cycle.

```python
# randomly simulate ETH inbound transfers for debugging purposes
random_add_for_debugging = 0
dice = random.randint(0, 10)
if dice > 7:
    random_add_for_debugging = 1.0

self.ETH_balance = self.balance_eth + random_add_for_debugging
```

## Impact

- ❌ The LLM receives incorrect balance data and may make wrong decisions based on it
- ❌ Any downstream logic reacting to `balance_change` (e.g. notifications, governance) can trigger on phantom transfers
- ❌ Data integrity compromised for all blockchain-related decision making

## Solution

This PR removes the debug block and assigns the real balance directly:

```python
self.ETH_balance = self.balance_eth
```

## Changes

- ✅ Removed random ETH addition logic (lines 93-99)
- ✅ Removed unused `import random` statement
- ✅ Direct assignment of real balance to `self.ETH_balance`
- ✅ No functional changes to balance tracking logic
- ✅ Maintains all existing error handling

## Testing

- Balance reporting now reflects actual on-chain values
- No spurious balance change notifications
- LLM receives accurate financial data

Fixes #2040