### PR TITLE
fix(tests): implement test_poll_returns_none_if_requests_is_none_and_mock_disabled

### DIFF
--- a/tests/inputs/plugins/test_fabric_closest_peer.py
+++ b/tests/inputs/plugins/test_fabric_closest_peer.py
@@ -72,7 +72,22 @@ async def test_poll_returns_mocked_peer_when_mock_mode_enabled(
 
 @pytest.mark.asyncio
 async def test_poll_returns_none_if_requests_is_none_and_mock_disabled(caplog):
-    pass
+    """Test that poll returns None when requests is unavailable and mock is disabled."""
+    config = FabricClosestPeerConfig(mock_mode=False)
+
+    mock_io = Mock()
+    mock_io.get_dynamic_variable.side_effect = lambda x: {
+        "latitude": -33.868820,
+        "longitude": 151.209295,
+    }.get(x)
+
+    with (
+        patch("inputs.plugins.fabric_closest_peer.requests", None),
+        patch("inputs.plugins.fabric_closest_peer.IOProvider", return_value=mock_io),
+    ):
+        instance = FabricClosestPeer(config=config)
+        result = await instance._poll()
+        assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The test `test_poll_returns_none_if_requests_is_none_and_mock_disabled` only contained `pass` - it was not implemented and didn't test anything.

## Solution

Implemented the test to verify that `_poll()` returns `None` when:
- `requests` module is unavailable (set to `None`)
- Mock mode is disabled

## Changes

- `tests/inputs/plugins/test_fabric_closest_peer.py`: Implemented the empty test with actual test logic

## Testing

- Pre-commit checks pass
- Test follows existing patterns in the file