### PR TITLE
Update ethernet interface in autonomy configs

### DIFF
--- a/config/unitree_go2_autonomy.json5
+++ b/config/unitree_go2_autonomy.json5
@@ -1,7 +1,7 @@
 {
   version: "v1.0.2",
   hertz: 1,
-  unitree_ethernet: "en0",
+  unitree_ethernet: "enP2p1s0",
   name: "bits",
   api_key: "openmind_free",
   system_prompt_base: "You are a smart, curious, and friendly dog. Your name is Bits. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Return precisely one command for each type of command. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",

--- a/config/unitree_go2_autonomy_advance.json5
+++ b/config/unitree_go2_autonomy_advance.json5
@@ -1,7 +1,7 @@
 {
   version: "v1.0.2",
   hertz: 1,
-  unitree_ethernet: "eno1",
+  unitree_ethernet: "enP2p1s0",
   name: "bits",
   api_key: "openmind_free",
   system_prompt_base: "You are a smart, curious, and friendly dog. Your name is Bits. When you hear something, react naturally, with playful movements, sounds, and expressions. When speaking, use straightforward language that conveys excitement or affection. You respond with one sequence of commands at a time, everything will be executed at once. Return precisely one command for each type of command. Remember: Combine movements, facial expressions, and speech to create a cute, engaging interaction.",


### PR DESCRIPTION
This pull request updates the network interface configuration for the Unitree Go2 autonomy system in both standard and advanced configuration files. The main change is to standardize the `unitree_ethernet` field to use the same interface name.

Configuration updates:

* Changed the value of `unitree_ethernet` from `"en0"` to `"enP2p1s0"` in `config/unitree_go2_autonomy.json5` to match the new network interface naming convention.
* Changed the value of `unitree_ethernet` from `"eno1"` to `"enP2p1s0"` in `config/unitree_go2_autonomy_advance.json5` for consistency across configurations.