### PR TITLE
Fix: Correct unitree_sdk2py import paths for compatibility

### DIFF
--- a/src/actions/arm_g1/connector/unitree_sdk.py
+++ b/src/actions/arm_g1/connector/unitree_sdk.py
@@ -2,7 +2,7 @@ import logging
 
 from actions.arm_g1.interface import ArmInput
 from actions.base import ActionConfig, ActionConnector
-from unitree.unitree_sdk2py.g1.arm.g1_arm_action_client import G1ArmActionClient
+from unitree_sdk2py.g1.arm.g1_arm_action_client import G1ArmActionClient
 
 
 class ARMUnitreeSDKConnector(ActionConnector[ActionConfig, ArmInput]):

--- a/src/actions/emotion/connector/unitree_sdk.py
+++ b/src/actions/emotion/connector/unitree_sdk.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 from actions.base import ActionConfig, ActionConnector
 from actions.emotion.interface import EmotionInput
-from unitree.unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
+from unitree_sdk2py.g1.audio.g1_audio_client import AudioClient
 
 
 class EmotionUnitreeConfig(ActionConfig):

--- a/src/actions/move_game_controller/connector/go2_game_controller.py
+++ b/src/actions/move_game_controller/connector/go2_game_controller.py
@@ -9,7 +9,7 @@ from actions.base import ActionConfig, ActionConnector
 from actions.move_game_controller.interface import IDLEInput
 from providers.odom_provider import OdomProvider, RobotState
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+from unitree_sdk2py.go2.sport.sport_client import SportClient
 from zenoh_msgs import AudioStatus, open_zenoh_session
 
 try:

--- a/src/actions/move_go2_action/connector/unitree_sdk.py
+++ b/src/actions/move_go2_action/connector/unitree_sdk.py
@@ -10,7 +10,7 @@ from actions.move_go2_action.interface import ActionInput
 from providers.odom_provider import OdomProvider
 from providers.rplidar_provider import RPLidarProvider
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+from unitree_sdk2py.go2.sport.sport_client import SportClient
 
 
 class ActionUnitreeSDKConfig(ActionConfig):

--- a/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk.py
+++ b/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk.py
@@ -13,7 +13,7 @@ from providers.face_presence_provider import FacePresenceProvider
 from providers.odom_provider import OdomProvider, RobotState
 from providers.simple_paths_provider import SimplePathsProvider
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+from unitree_sdk2py.go2.sport.sport_client import SportClient
 from zenoh_msgs import (
     AIStatusRequest,
     AIStatusResponse,

--- a/src/actions/move_go2_autonomy/connector/unitree_rplidar_sdk.py
+++ b/src/actions/move_go2_autonomy/connector/unitree_rplidar_sdk.py
@@ -11,7 +11,7 @@ from actions.move_go2_autonomy.interface import MoveInput
 from providers.odom_provider import OdomProvider, RobotState
 from providers.rplidar_provider import RPLidarProvider
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+from unitree_sdk2py.go2.sport.sport_client import SportClient
 
 
 class MoveUnitreeRPLidarSDKConfig(ActionConfig):

--- a/src/actions/move_go2_teleops/connector/remote.py
+++ b/src/actions/move_go2_teleops/connector/remote.py
@@ -10,7 +10,7 @@ from actions.base import ActionConfig, ActionConnector
 from actions.move_go2_teleops.interface import MoveInput
 from providers import CommandStatus
 from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
-from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+from unitree_sdk2py.go2.sport.sport_client import SportClient
 
 
 class RobotState(Enum):

--- a/src/actions/move_to_peer/connector/ros2.py
+++ b/src/actions/move_to_peer/connector/ros2.py
@@ -41,7 +41,7 @@ class MoveToPeerRos2Connector(ActionConnector[ActionConfig, MoveToPeerInput]):
         super().__init__(config)
         self.io = IOProvider()
         # defer heavy import; SportClient requires DDS initialisation
-        from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient
+        from unitree_sdk2py.go2.sport.sport_client import SportClient
 
         self.sport_client = SportClient()
         self.sport_client.SetTimeout(10.0)

--- a/src/inputs/plugins/battery_unitree_go2.py
+++ b/src/inputs/plugins/battery_unitree_go2.py
@@ -10,8 +10,8 @@ from inputs.base.loop import FuserInput
 from providers import BatteryStatus, IOProvider, TeleopsStatus, TeleopsStatusProvider
 
 try:
-    from unitree.unitree_sdk2py.core.channel import ChannelSubscriber  # type: ignore
-    from unitree.unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_  # type: ignore
+    from unitree_sdk2py.core.channel import ChannelSubscriber  # type: ignore
+    from unitree_sdk2py.idl.unitree_go.msg.dds_ import LowState_  # type: ignore
 except ImportError:
     logging.warning(
         "Unitree SDK not found. Please install the Unitree SDK to use this plugin."

--- a/src/inputs/plugins/unitree_g1_basic.py
+++ b/src/inputs/plugins/unitree_g1_basic.py
@@ -10,8 +10,8 @@ from inputs.base.loop import FuserInput
 from providers import BatteryStatus, IOProvider, TeleopsStatus, TeleopsStatusProvider
 
 try:
-    from unitree.unitree_sdk2py.core.channel import ChannelSubscriber  # type: ignore
-    from unitree.unitree_sdk2py.idl.unitree_hg.msg import dds_  # type: ignore
+    from unitree_sdk2py.core.channel import ChannelSubscriber  # type: ignore
+    from unitree_sdk2py.idl.unitree_hg.msg import dds_  # type: ignore
 except ImportError:
     logging.warning(
         "Unitree SDK not found. Please install the Unitree SDK to use this plugin."

--- a/src/providers/odom_provider.py
+++ b/src/providers/odom_provider.py
@@ -12,11 +12,11 @@ from runtime.logging import LoggingConfig, get_logging_config, setup_logging
 
 try:
     # Needed for Unitree but not TurtleBot4
-    from unitree.unitree_sdk2py.core.channel import (
+    from unitree_sdk2py.core.channel import (
         ChannelFactoryInitialize,
         ChannelSubscriber,
     )
-    from unitree.unitree_sdk2py.idl.geometry_msgs.msg.dds_ import PoseStamped_
+    from unitree_sdk2py.idl.geometry_msgs.msg.dds_ import PoseStamped_
 except ImportError:
     logging.warning(
         "Unitree SDK or CycloneDDS not found. You do not need this unless you are connecting to a Unitree robot."

--- a/src/providers/unitree_camera_vlm_provider.py
+++ b/src/providers/unitree_camera_vlm_provider.py
@@ -11,7 +11,7 @@ from om1_vlm import VideoStream
 from .singleton import singleton
 
 try:
-    from unitree.unitree_sdk2py.go2.video.video_client import VideoClient
+    from unitree_sdk2py.go2.video.video_client import VideoClient
 except ImportError:
     logging.warning(
         "Unitree SDK not found. Please install the Unitree SDK to use this plugin."

--- a/src/providers/unitree_go2_state_provider.py
+++ b/src/providers/unitree_go2_state_provider.py
@@ -8,11 +8,11 @@ from typing import Optional
 from runtime.logging import LoggingConfig, get_logging_config, setup_logging
 
 try:
-    from unitree.unitree_sdk2py.core.channel import (
+    from unitree_sdk2py.core.channel import (
         ChannelFactoryInitialize,
         ChannelSubscriber,
     )
-    from unitree.unitree_sdk2py.idl.unitree_go.msg.dds_ import SportModeState_
+    from unitree_sdk2py.idl.unitree_go.msg.dds_ import SportModeState_
 except ImportError:
     logging.error(
         "Unitree SDK or CycloneDDS not found. Please install the unitree_sdk2py package or CycloneDDS."

--- a/src/runtime/robotics.py
+++ b/src/runtime/robotics.py
@@ -29,7 +29,7 @@ def load_unitree(unitree_ethernet: str):
             f"Using {unitree_ethernet} as the Unitree Network Ethernet Adapter"
         )
 
-        from unitree.unitree_sdk2py.core.channel import ChannelFactoryInitialize
+        from unitree_sdk2py.core.channel import ChannelFactoryInitialize
 
         try:
             ChannelFactoryInitialize(0, unitree_ethernet)


### PR DESCRIPTION
## Description

This PR fixes a `ModuleNotFoundError` caused by incorrect import paths for the `unitree_sdk2py` package across multiple files.

**Problem:**
The current codebase attempts to import the SDK using a nested namespace:
```python
from unitree.unitree_sdk2py.core.channel import ChannelFactoryInitialize
```

**Root Cause:**
When `unitree_sdk2py` is installed via `uv` or `pip`, it is exposed as a **top-level module** (`unitree_sdk2py`), not nested under a `unitree` parent package.

**Solution:**
Remove the `unitree.` prefix from all affected import statements:
```python
from unitree_sdk2py.core.channel import ChannelFactoryInitialize
```

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Steps to Reproduce

1. Clone the repository
2. Install dependencies: `uv pip install -r pyproject.toml --extra dds`
3. Run: `uv run src/run.py unitree_g1_humanoid`
4. Observe error:
   ```
   ModuleNotFoundError: No module named 'unitree.unitree_sdk2py'
   ```

---

## Affected Files

The following files contain the incorrect `unitree.unitree_sdk2py` import path:

### Runtime
- `src/runtime/robotics.py`

### Inputs
- `src/inputs/plugins/unitree_g1_basic.py`
- `src/inputs/plugins/battery_unitree_go2.py`

### Actions
- `src/actions/emotion/connector/unitree_sdk.py`
- `src/actions/arm_g1/connector/unitree_sdk.py`
- `src/actions/move_go2_teleops/connector/remote.py`
- `src/actions/move_go2_autonomy/connector/unitree_rplidar_sdk.py`
- `src/actions/move_go2_autonomy/connector/unitree_om_path_sdk.py`
- `src/actions/move_game_controller/connector/go2_game_controller.py`
- `src/actions/move_to_peer/connector/ros2.py`
- `src/actions/move_go2_action/connector/unitree_sdk.py`

### Providers
- `src/providers/odom_provider.py`
- `src/providers/unitree_go2_state_provider.py`
- `src/providers/unitree_camera_vlm_provider.py`

---

## Verification

- [x] Verified `from unitree.unitree_sdk2py...` exists in `src/runtime/robotics.py` on `main` branch
- [x] Confirmed `unitree_sdk2py` package installs as a top-level module (not under `unitree/`)
- [x] Local execution succeeds after applying these fixes

---

## Related Documentation

- [Unitree G1 Humanoid Setup](https://docs.openmind.org/robotics/unitree_g1_humanoid)
- [unitree_sdk2py GitHub](https://github.com/unitreerobotics/unitree_sdk2_python)