### PR TITLE
fix(config): make runtime config updates Windows-safe and explicit on…

### DIFF
--- a/src/providers/config_provider.py
+++ b/src/providers/config_provider.py
@@ -108,7 +108,7 @@ class ConfigProvider:
             with open(temp_path, "w") as f:
                 json.dump(new_config, f, indent=2)
 
-            os.rename(temp_path, self.config_path)
+            os.replace(temp_path, self.config_path)
 
             logging.info(f"Updated runtime config file: {self.config_path}")
 
@@ -165,19 +165,17 @@ class ConfigProvider:
         """
         Get a snapshot of the current runtime configuration.
         """
-        try:
-            if not os.path.exists(self.config_path):
-                logging.warning(
-                    f"ConfigProvider: Config file not found: {self.config_path}"
-                )
-                return {}
+        if not os.path.exists(self.config_path):
+            raise FileNotFoundError(
+                f"ConfigProvider: Config file not found: {self.config_path}"
+            )
 
+        try:
             with open(self.config_path, "r") as f:
                 return json5.load(f)
-
         except Exception as e:
             logging.error(f"Failed to read config file {self.config_path}: {e}")
-            return {}
+            raise
 
     def stop(self):
         """


### PR DESCRIPTION
# Overview
Fixes `ConfigProvider` runtime config updates on Windows and prevents silent “empty config” responses when the runtime config file is missing or unreadable.

# Changes
- Switch from `os.rename()` to `os.replace()` for atomic overwrites of `config/memory/.runtime.json5` on Windows (`src/providers/config_provider.py:111`).
- Remove `{}` fallback in `_get_config_snapshot()` so missing/unreadable configs trigger the existing error-response path instead of returning an empty snapshot (`src/providers/config_provider.py:164`).
- Add targeted unit tests for overwrite behavior and missing-config error response (`tests/providers/test_config_provider.py:35`, `tests/providers/test_config_provider.py:56`).

# Impact
- Windows: “set config” updates work even when the destination file already exists.
- “get config” no longer returns `{}` with a success message on missing/corrupt config; it returns an error response with a clear message.
- No schema or CI workflow changes.

# Testing
- Added `tests/providers/test_config_provider.py`.
- Local test run was blocked on Windows because `uv run pytest` fails to resolve/install `tensorflow-io-gcs-filesystem==0.37.1` (no compatible Windows wheel in current resolution).

# Additional Information
This change preserves runtime behavior for valid configs and only improves correctness and diagnostics in failure modes.