### PR TITLE
fix(fabric): ensure mock lat/lon defaults are numeric

### DIFF
--- a/src/inputs/plugins/fabric_closest_peer.py
+++ b/src/inputs/plugins/fabric_closest_peer.py
@@ -32,8 +32,8 @@ class FabricClosestPeerConfig(SensorConfig):
         default="http://localhost:8545", description="Fabric Endpoint"
     )
     mock_mode: bool = Field(default=True, description="Mock Mode")
-    mock_lat: Optional[float] = Field(default=None, description="Mock Latitude")
-    mock_lon: Optional[float] = Field(default=None, description="Mock Longitude")
+    mock_lat: float = Field(default=0.0, description="Mock Latitude")
+    mock_lon: float = Field(default=0.0, description="Mock Longitude")
 
 
 class FabricClosestPeer(FuserInput[FabricClosestPeerConfig, Optional[str]]):

--- a/tests/inputs/plugins/test_fabric_closest_peer.py
+++ b/tests/inputs/plugins/test_fabric_closest_peer.py
@@ -71,6 +71,21 @@ async def test_poll_returns_mocked_peer_when_mock_mode_enabled(
 
 
 @pytest.mark.asyncio
+async def test_poll_does_not_crash_with_default_mock_coords(
+    fabric_closest_peer_instance, mock_io_provider
+):
+    # Default config has mock_mode=True and numeric mock_lat/mock_lon.
+    fabric_closest_peer_instance.config = FabricClosestPeerConfig()
+    fabric_closest_peer_instance.mock_mode = True
+
+    result = await fabric_closest_peer_instance._poll()
+
+    assert result == "Closest peer at 0.00000, 0.00000"
+    mock_io_provider.add_dynamic_variable.assert_any_call("closest_peer_lat", 0.0)
+    mock_io_provider.add_dynamic_variable.assert_any_call("closest_peer_lon", 0.0)
+
+
+@pytest.mark.asyncio
 async def test_poll_returns_none_if_requests_is_none_and_mock_disabled(caplog):
     pass
 


### PR DESCRIPTION
**Overview**
Fixes a startup crash in `FabricClosestPeer` when running in default `mock_mode=True` by ensuring mock coordinates are always numeric.

**Changes**
- Updated `FabricClosestPeerConfig` so `mock_lat`/`mock_lon` default to `0.0` (non-optional) instead of `None` (`src/inputs/plugins/fabric_closest_peer.py:27`).
- Added a regression test to confirm `_poll()` works with default mock settings (`tests/inputs/plugins/test_fabric_closest_peer.py:75`).

**Impact**
- Prevents a `TypeError` from formatting `None` with `:.6f` in the mock path.
- No behavior change for explicitly configured mock coordinates; default behavior now produces deterministic `"Closest peer at 0.00000, 0.00000"` instead of crashing.

**Testing**
- Added unit test coverage for the default mock path.
- Test execution was not run in this environment due to missing `pytest` in the local venv and `uv run` dependency resolution failing on Windows (wheel availability for `tensorflow-io-gcs-filesystem==0.37.1`).

**Additional Information**
This is a localized, low-risk change confined to one plugin config and its tests, intended to reduce silent startup failures and improve reliability for default configurations.