### PR TITLE
fix(robotics): align load_unitree logs and docstring on init failure

### DIFF
--- a/src/runtime/robotics.py
+++ b/src/runtime/robotics.py
@@ -1,7 +1,8 @@
 import logging
+from typing import Optional
 
 
-def load_unitree(unitree_ethernet: str):
+def load_unitree(unitree_ethernet: Optional[str]) -> None:
     """
     Initialize the Unitree robot's network communication channel.
 
@@ -11,29 +12,28 @@ def load_unitree(unitree_ethernet: str):
 
     Parameters
     ----------
-    unitree_ethernet : str
-        Configuration object containing the Unitree Ethernet adapter string, such as "eth0"
+    unitree_ethernet : Optional[str]
+        The Unitree Ethernet adapter string, such as "eth0".
 
     Returns
     -------
     None
-
-    Raises
-    ------
-    Exception
-        If initialization of the Unitree Ethernet channel fails.
-
     """
-    if unitree_ethernet is not None:
-        logging.info(
-            f"Using {unitree_ethernet} as the Unitree Network Ethernet Adapter"
+    if not unitree_ethernet:
+        return
+
+    logging.info("Using %s as the Unitree Network Ethernet Adapter", unitree_ethernet)
+
+    from unitree.unitree_sdk2py.core.channel import ChannelFactoryInitialize
+
+    try:
+        ChannelFactoryInitialize(0, unitree_ethernet)
+    except Exception:
+        logging.exception(
+            "Failed to initialize Unitree Ethernet channel for adapter %s",
+            unitree_ethernet,
         )
+        logging.warning("Continuing without Unitree DDS initialization")
+        return
 
-        from unitree.unitree_sdk2py.core.channel import ChannelFactoryInitialize
-
-        try:
-            ChannelFactoryInitialize(0, unitree_ethernet)
-        except Exception as e:
-            logging.error(f"Failed to initialize Unitree Ethernet channel: {e}")
-            # raise e
-        logging.info("Booting Unitree and CycloneDDS")
+    logging.info("Booting Unitree and CycloneDDS")

--- a/tests/runtime/test_robotics.py
+++ b/tests/runtime/test_robotics.py
@@ -1,0 +1,68 @@
+import logging
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from runtime.robotics import load_unitree
+
+
+def _install_fake_unitree_channel(
+    monkeypatch: Any, channel_factory_initialize: Any
+) -> None:
+    unitree = ModuleType("unitree")
+    unitree.__path__ = []  # type: ignore
+    unitree_sdk2py = ModuleType("unitree.unitree_sdk2py")
+    unitree_sdk2py.__path__ = []  # type: ignore
+    core = ModuleType("unitree.unitree_sdk2py.core")
+    core.__path__ = []  # type: ignore
+    channel = ModuleType("unitree.unitree_sdk2py.core.channel")
+    channel.ChannelFactoryInitialize = channel_factory_initialize
+
+    monkeypatch.setitem(sys.modules, "unitree", unitree)
+    monkeypatch.setitem(sys.modules, "unitree.unitree_sdk2py", unitree_sdk2py)
+    monkeypatch.setitem(sys.modules, "unitree.unitree_sdk2py.core", core)
+    monkeypatch.setitem(sys.modules, "unitree.unitree_sdk2py.core.channel", channel)
+
+
+def test_load_unitree_returns_early_when_none() -> None:
+    load_unitree(None)
+
+
+def test_load_unitree_logs_boot_message_on_success(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    called = {"value": False}
+
+    def channel_factory_initialize(_domain_id: int, adapter: str) -> None:
+        assert adapter == "eth0"
+        called["value"] = True
+
+    _install_fake_unitree_channel(monkeypatch, channel_factory_initialize)
+
+    with caplog.at_level(logging.INFO):
+        load_unitree("eth0")
+
+    assert called["value"] is True
+    assert "Using eth0 as the Unitree Network Ethernet Adapter" in caplog.text
+    assert "Booting Unitree and CycloneDDS" in caplog.text
+    assert "Continuing without Unitree DDS initialization" not in caplog.text
+
+
+def test_load_unitree_does_not_log_boot_message_on_failure(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    def channel_factory_initialize(_domain_id: int, _adapter: str) -> None:
+        raise RuntimeError("boom")
+
+    _install_fake_unitree_channel(monkeypatch, channel_factory_initialize)
+
+    with caplog.at_level(logging.INFO):
+        load_unitree("eth0")
+
+    assert (
+        "Failed to initialize Unitree Ethernet channel for adapter eth0" in caplog.text
+    )
+    assert "Continuing without Unitree DDS initialization" in caplog.text
+    assert "Booting Unitree and CycloneDDS" not in caplog.text


### PR DESCRIPTION
# Overview
Clarifies `load_unitree` failure behavior and prevents misleading “system is up” logs when Unitree DDS initialization fails.

# Changes
- Updated `load_unitree` to:
  - Return early on `None`/empty adapter values.
  - Log initialization failures with full traceback (`logging.exception`) and an explicit warning that the runtime will continue without Unitree DDS init.
  - Only log “Booting Unitree and CycloneDDS” on successful initialization.
- Updated the docstring to match actual behavior (no longer claims it raises on init failure).
- Added unit tests that stub `unitree.unitree_sdk2py.core.channel` via `sys.modules` to validate success/failure logging paths (`tests/runtime/test_robotics.py`).

# Impact
- Removes misleading logs after failed Unitree initialization, improving operator/developer diagnostics.
- Preserves existing non-raising behavior (runtime continues), but makes the degraded state explicit and avoids implying success.

# Testing
- Added `tests/runtime/test_robotics.py` covering:
  - Early return when adapter is `None`
  - Boot log emitted only on success
  - Boot log suppressed on failure with explicit warning emitted

# Additional Information
This PR is intentionally scoped to logging/doc accuracy and a small regression test; it does not change higher-level runtime control flow or configuration schemas.