### PR TITLE
feat(inputs): add EnvironmentOCRInput for scene text recognition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "typer==0.15.1",
     "opencv-python==4.11.0.86",
     "deepface==0.0.93",
+    "easyocr==1.7.2",
     "web3==7.6.0",
     "numpy==2.0.2",
     "cdp-sdk==0.21.0",

--- a/src/inputs/plugins/environment_ocr_input.py
+++ b/src/inputs/plugins/environment_ocr_input.py
@@ -1,0 +1,184 @@
+import asyncio
+import logging
+import time
+from typing import Optional, Sequence
+
+import cv2
+import easyocr
+import numpy as np
+from pydantic import Field
+
+from inputs.base import Message, SensorConfig
+from inputs.base.loop import FuserInput
+from providers.io_provider import IOProvider
+
+
+class EnvironmentOCRInputConfig(SensorConfig):
+    """
+    Configuration for Environment OCR Input.
+
+    Parameters
+    ----------
+    camera_index : int
+        Index of the camera device.
+    languages : Sequence[str]
+        EasyOCR language codes to load. Defaults to English ("en").
+    min_confidence : float
+        Minimum confidence threshold for including detections (0.0 - 1.0).
+    max_detections : int
+        Maximum number of text detections to report per frame.
+    poll_interval_s : float
+        Poll interval in seconds.
+    gpu : bool
+        Whether to enable GPU usage for OCR.
+    """
+
+    camera_index: int = Field(default=0, description="Index of the camera device")
+    languages: Sequence[str] = Field(
+        default_factory=lambda: ("en",),
+        description="OCR languages (EasyOCR language codes)",
+    )
+    min_confidence: float = Field(
+        default=0.5, description="Minimum OCR confidence threshold"
+    )
+    max_detections: int = Field(
+        default=5, description="Maximum number of text detections per poll"
+    )
+    poll_interval_s: float = Field(
+        default=0.5, description="Polling interval (seconds)"
+    )
+    gpu: bool = Field(default=False, description="Enable GPU for OCR")
+
+
+def _check_webcam(index_to_check: int) -> bool:
+    cap = cv2.VideoCapture(index_to_check)
+    if not cap.isOpened():
+        logging.info("OCR did not find cam: %s", index_to_check)
+        return False
+    logging.info("OCR found cam: %s", index_to_check)
+    return True
+
+
+class EnvironmentOCRInput(FuserInput[EnvironmentOCRInputConfig, Optional[np.ndarray]]):
+    """
+    Reads text in the robot's environment using OCR over camera frames.
+    """
+
+    def __init__(self, config: EnvironmentOCRInputConfig):
+        super().__init__(config)
+
+        self.io_provider = IOProvider()
+        self.messages: list[Message] = []
+
+        self.descriptor_for_LLM = "Text Reader"
+
+        self.have_cam = _check_webcam(self.config.camera_index)
+        self.cap: Optional[cv2.VideoCapture] = None
+        self.width = 0
+        self.height = 0
+        self.cam_third = 0
+        if self.have_cam:
+            self.cap = cv2.VideoCapture(self.config.camera_index)
+            self.width = int(self.cap.get(3))
+            self.height = int(self.cap.get(4))
+            self.cam_third = int(self.width / 3) if self.width > 0 else 0
+            logging.info("OCR webcam dimensions: %s, %s", self.width, self.height)
+
+        self._reader = easyocr.Reader(list(self.config.languages), gpu=self.config.gpu)
+
+    async def _poll(self) -> Optional[np.ndarray]:
+        await asyncio.sleep(self.config.poll_interval_s)
+
+        if self.have_cam and self.cap is not None:
+            _ret, frame = self.cap.read()
+            return frame
+        return None
+
+    @staticmethod
+    def _direction_for_bbox_center_x(center_x: float, cam_third: int) -> str:
+        if cam_third <= 0:
+            return "in front of you"
+        if center_x < cam_third:
+            return "on your left"
+        if center_x > 2 * cam_third:
+            return "on your right"
+        return "in front of you"
+
+    def _ocr_frame(self, frame_bgr: np.ndarray) -> list[tuple[str, str, float]]:
+        frame_rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        results = self._reader.readtext(frame_rgb, detail=1)
+
+        filtered: list[tuple[str, str, float]] = []
+        for bbox, text, confidence in results:
+            if not isinstance(text, str) or text.strip() == "":
+                continue
+            try:
+                conf = float(confidence)
+            except Exception:
+                continue
+            if conf < float(self.config.min_confidence):
+                continue
+
+            try:
+                xs = [float(p[0]) for p in bbox]
+            except Exception:
+                continue
+            if not xs:
+                continue
+            center_x = (min(xs) + max(xs)) / 2.0
+            direction = self._direction_for_bbox_center_x(center_x, self.cam_third)
+
+            filtered.append((text.strip(), direction, conf))
+
+        filtered.sort(key=lambda x: x[2], reverse=True)
+        return filtered[: max(0, int(self.config.max_detections))]
+
+    def _format_detections(
+        self, detections: list[tuple[str, str, float]]
+    ) -> Optional[str]:
+        if not detections:
+            return None
+
+        sentences: list[str] = []
+        for i, (text, direction, _confidence) in enumerate(detections):
+            prefix = "You see text" if i == 0 else "You also see text"
+            sentences.append(f'{prefix} "{text}" {direction}.')
+
+        return " ".join(sentences)
+
+    async def _raw_to_text(self, raw_input: Optional[np.ndarray]) -> Optional[Message]:
+        if raw_input is None:
+            return None
+
+        try:
+            detections = self._ocr_frame(raw_input)
+            sentence = self._format_detections(detections)
+        except Exception:
+            logging.exception("Error running OCR on camera frame")
+            return None
+
+        if sentence is None:
+            return None
+        return Message(timestamp=time.time(), message=sentence)
+
+    async def raw_to_text(self, raw_input: Optional[np.ndarray]):
+        pending_message = await self._raw_to_text(raw_input)
+        if pending_message is not None:
+            self.messages.append(pending_message)
+
+    def formatted_latest_buffer(self) -> Optional[str]:
+        if len(self.messages) == 0:
+            return None
+
+        latest_message = self.messages[-1]
+        self.io_provider.add_input(
+            self.descriptor_for_LLM, latest_message.message, latest_message.timestamp
+        )
+        self.messages = []
+
+        return f"""
+{self.descriptor_for_LLM} INPUT
+// START
+{latest_message.message}
+// END
+"""

--- a/tests/inputs/plugins/test_environment_ocr_input.py
+++ b/tests/inputs/plugins/test_environment_ocr_input.py
@@ -1,0 +1,122 @@
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from inputs.base import Message
+from inputs.plugins.environment_ocr_input import (
+    EnvironmentOCRInput,
+    EnvironmentOCRInputConfig,
+)
+
+
+@pytest.fixture
+def mock_check_webcam():
+    with patch("inputs.plugins.environment_ocr_input._check_webcam", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_cv2_video_capture():
+    with patch("inputs.plugins.environment_ocr_input.cv2.VideoCapture") as mock:
+        mock_instance = Mock()
+        dummy_frame = np.zeros((200, 300, 3), dtype=np.uint8)
+        mock_instance.read.return_value = (True, dummy_frame)
+        mock_instance.get.side_effect = lambda x: {3: 300, 4: 200}[x]
+        mock.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def mock_easyocr_reader():
+    with patch("inputs.plugins.environment_ocr_input.easyocr.Reader") as mock:
+        mock_instance = Mock()
+        mock.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def mock_io_provider():
+    with patch("inputs.plugins.environment_ocr_input.IOProvider") as mock_class:
+        mock_instance = Mock()
+        mock_class.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def ocr_input(
+    mock_check_webcam, mock_cv2_video_capture, mock_easyocr_reader, mock_io_provider
+):
+    config = EnvironmentOCRInputConfig(
+        camera_index=0,
+        languages=("en",),
+        min_confidence=0.5,
+        max_detections=5,
+        poll_interval_s=0.0,
+        gpu=False,
+    )
+    return EnvironmentOCRInput(config=config)
+
+
+def test_format_detections_single(ocr_input):
+    result = ocr_input._format_detections([("EXIT", "on your left", 0.9)])
+    assert result == 'You see text "EXIT" on your left.'
+
+
+def test_format_detections_multiple(ocr_input):
+    result = ocr_input._format_detections(
+        [("EXIT", "on your left", 0.9), ("Room 101", "in front of you", 0.8)]
+    )
+    assert result == (
+        'You see text "EXIT" on your left. You also see text "Room 101" in front of you.'
+    )
+
+
+def test_ocr_frame_filters_and_adds_direction(ocr_input, mock_easyocr_reader):
+    # width=300 => cam_third=100
+    ocr_input.cam_third = 100
+    mock_easyocr_reader.readtext.return_value = [
+        # Left side
+        ([[0, 0], [10, 0], [10, 10], [0, 10]], "EXIT", 0.91),
+        # Center
+        ([[140, 0], [160, 0], [160, 10], [140, 10]], "Room 101", 0.80),
+        # Below threshold
+        ([[250, 0], [290, 0], [290, 10], [250, 10]], "LOW", 0.10),
+    ]
+
+    frame = np.zeros((200, 300, 3), dtype=np.uint8)
+    detections = ocr_input._ocr_frame(frame)
+
+    assert detections == [
+        ("EXIT", "on your left", 0.91),
+        ("Room 101", "in front of you", 0.8),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_returns_message(ocr_input, mock_easyocr_reader):
+    mock_easyocr_reader.readtext.return_value = [
+        ([[0, 0], [10, 0], [10, 10], [0, 10]], "EXIT", 0.91),
+    ]
+    frame = np.zeros((200, 300, 3), dtype=np.uint8)
+    msg = await ocr_input._raw_to_text(frame)
+    assert msg is not None
+    assert msg.message == 'You see text "EXIT" on your left.'
+
+
+def test_formatted_latest_buffer_records_input(ocr_input, mock_io_provider):
+    ocr_input.messages = []
+    ocr_input.messages.append(
+        Message(timestamp=1.0, message='You see text "EXIT" on your left.')
+    )
+
+    buf = ocr_input.formatted_latest_buffer()
+    assert buf is not None
+    assert 'You see text "EXIT" on your left.' in buf
+    mock_io_provider.add_input.assert_called_once()
+    assert ocr_input.messages == []
+
+
+def test_formatted_latest_buffer_empty(ocr_input):
+    ocr_input.messages = []
+    assert ocr_input.formatted_latest_buffer() is None


### PR DESCRIPTION
# Overview
Adds `EnvironmentOCRInput`, a new input plugin that performs OCR on the robot’s camera feed and emits natural-language text observations (including left/center/right spatial context) for LLM consumption. Related to #1994


# Changes
- Added new plugin `EnvironmentOCRInput` and config model `EnvironmentOCRInputConfig` in `src/inputs/plugins/environment_ocr_input.py`.
  - OCR via `easyocr.Reader`
  - Configurable `languages`, `min_confidence`, `max_detections`, `poll_interval_s`, and `gpu`
  - Formats detections like: `You see text "EXIT" on your left. You also see text "Room 101" in front of you.`
- Added unit tests with full mocking (camera, IOProvider, EasyOCR) in `tests/inputs/plugins/test_environment_ocr_input.py`.
- Added `easyocr==1.7.2` to `pyproject.toml` dependencies.

# Impact
- Enables OM1 to read and report environmental text (signs/labels/displays) as an input stream for downstream reasoning/navigation.
- Keeps runtime behavior unchanged unless the plugin is enabled in configuration.

# Testing
- Added new test suite `tests/inputs/plugins/test_environment_ocr_input.py` validating formatting, confidence filtering, spatial direction mapping, and buffer output (all without requiring real hardware or OCR runtime).

# Additional Information
- This introduces a new third-party dependency (`easyocr==1.7.2`). Lockfile updates may be required in the main CI environment where dependencies are resolved.
