### PR TITLE
refactor: remove duplicate IOProvider initialization in kokoro_tts.py

### DIFF
--- a/src/actions/speak/connector/kokoro_tts.py
+++ b/src/actions/speak/connector/kokoro_tts.py
@@ -102,8 +102,6 @@ class SpeakKokoroTTSConnector(ActionConnector[SpeakKokoroTTSConfig, SpeakInput])
         self.silence_rate = self.config.silence_rate
         self.silence_counter = 0
 
-        # IO Provider
-        self.io_provider = IOProvider()
 
         self.audio_topic = "robot/status/audio"
         self.tts_status_request_topic = "om/tts/request"


### PR DESCRIPTION
  ## Summary
  Remove duplicate `IOProvider()` initialization in `SpeakKokoroTTSConnector.__init__`

  ## Problem
  `IOProvider` was being instantiated twice:
  - Line 91: First initialization under "Sleep mode configuration"
  - Line 106: Duplicate initialization under "IO Provider" comment

  ## Solution
  Removed the second redundant initialization since `IOProvider` is a singleton and the first call is sufficient.

  ## Changes
  - Removed duplicate `self.io_provider = IOProvider()` (line 106)
  - Removed redundant `# IO Provider` comment (line 105)

  ## Test plan
  - [x] Code compiles without errors
  - [x] IOProvider still accessible via first initialization
