### PR TITLE
fix(rf_mapper): add thread safety for shared scan data access

### DIFF
--- a/src/backgrounds/plugins/rf_mapper.py
+++ b/src/backgrounds/plugins/rf_mapper.py
@@ -70,6 +70,9 @@ class RFmapper(Background[RFmapperConfig]):
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._scan_task)
         self.running = False
+        # Thread synchronization lock for shared scan data
+        self._scan_lock = threading.Lock()
+
 
         self.scan_results: List[RFData] = []
         self.scan_idx = 0
@@ -113,7 +116,6 @@ class RFmapper(Background[RFmapperConfig]):
 
         self.seen_devices: Dict[str, RFData] = {}
 
-        self.seen_names: List[str] = []
 
         self.start()
 
@@ -217,7 +219,6 @@ class RFmapper(Background[RFmapperConfig]):
                 final_list.append(device)
         logging.debug(f"Scan...{final_list}")
 
-        self.scan_idx += 1
 
         return final_list
 
@@ -229,7 +230,10 @@ class RFmapper(Background[RFmapperConfig]):
         logging.info("Starting RF scan thread...")
         self.running = True
         while self.running:
-            self.scan_results = self.loop.run_until_complete(self.scan())
+            scan_result = self.loop.run_until_complete(self.scan())
+            with self._scan_lock:
+                self.scan_results = scan_result
+                self.scan_idx += 1
             logging.info(f"RF scan index: {self.scan_idx}")
             logging.info(f"RF scan last sent: {self.scan_last_sent}")
             time.sleep(0.5)
@@ -259,14 +263,16 @@ class RFmapper(Background[RFmapperConfig]):
                 logging.info(f"Sending to fabric: payload {self.payload_idx}")
 
                 # add scan results if they are new
-                logging.info(f"RF scan index: {self.scan_idx}")
-                logging.info(f"RF scan last sent: {self.scan_last_sent}")
-                fresh_scan_results = []
-                if self.scan_results and self.scan_idx > self.scan_last_sent:
-                    fresh_scan_results = self.scan_results
-                    self.scan_last_sent = self.scan_idx
-                    self.scan_results = []
-                    logging.info(f"RF scan sending new payload: {self.scan_last_sent}")
+                # Use lock to safely access shared scan data
+                with self._scan_lock:
+                    logging.info(f"RF scan index: {self.scan_idx}")
+                    logging.info(f"RF scan last sent: {self.scan_last_sent}")
+                    fresh_scan_results = []
+                    if self.scan_results and self.scan_idx > self.scan_last_sent:
+                        fresh_scan_results = self.scan_results
+                        self.scan_last_sent = self.scan_idx
+                        self.scan_results = []
+                        logging.info(f"RF scan sending new payload: {self.scan_last_sent}")
 
                 # basic gps data and occasional scan results
                 try:
@@ -285,7 +291,7 @@ class RFmapper(Background[RFmapperConfig]):
                             self.ble_scan = g["ble_scan"]
                             logging.debug(f"RF scan results {self.ble_scan}")
                         else:
-                            logging.warn("No nRF52 scan results")
+                            logging.warning("No nRF52 scan results")
 
                 except Exception as e:
                     logging.error(f"Error parsing GPS: {e}")


### PR DESCRIPTION
  ## Summary
  - Add `threading.Lock()` to synchronize access to shared scan data
  - Protect shared variable writes in `_scan_task()` with lock
  - Protect shared variable reads in `run()` with lock
  - Replace deprecated `logging.warn()` with `logging.warning()`
  - Remove unused `self.seen_names` variable

  Fixes #1771
