### PR TITLE
Add Home Assistant smart device control action (bounty #366)

### DIFF
--- a/docs/examples/home_assistant.mdx
+++ b/docs/examples/home_assistant.mdx
@@ -1,0 +1,49 @@
+---
+title: "Home Assistant (Smart Devices)"
+---
+
+# Home Assistant (Smart Devices)
+
+This guide shows how to control basic IoT devices (lights/switches/thermostats) through **Home Assistant**.
+
+## 1) Create a Home Assistant Long-Lived Access Token
+
+In Home Assistant:
+- Profile → **Long-Lived Access Tokens** → create a token
+- Store it in your environment as `HOME_ASSISTANT_TOKEN`
+
+## 2) Add the action to your OM1 config
+
+Add an action entry like this (example):
+
+```json5
+{
+  name: "home_assistant",
+  llm_label: "home_assistant",
+  connector: "rest_api",
+  config: {
+    base_url: "http://homeassistant.local:8123",
+    token_env: "HOME_ASSISTANT_TOKEN",
+    verify_ssl: true,
+    devices: {
+      living_room_light: "light.living_room",
+      bedroom_switch: "switch.bedroom"
+    }
+  }
+}
+```
+
+## 3) Example commands
+
+- Turn on a light:
+  - `device=living_room_light, command=on`
+- Turn off a switch:
+  - `device=bedroom_switch, command=off`
+- Set brightness (percentage) for lights:
+  - `device=living_room_light, command=set, value=50`
+
+## Notes
+
+- The connector uses Home Assistant REST API:
+  `POST /api/services/<domain>/<service>`
+- Device aliases are required (mapped to `entity_id` in config). This avoids the LLM guessing entity IDs.

--- a/src/actions/home_assistant/connector/rest_api.py
+++ b/src/actions/home_assistant/connector/rest_api.py
@@ -1,0 +1,120 @@
+import os
+from typing import Any, Dict, Optional, Tuple
+
+import aiohttp
+
+from actions.base import ActionConfig, ActionConnector
+from actions.home_assistant.interface import HomeAssistantControlInput
+
+
+class HomeAssistantConfig(ActionConfig):
+    """Configuration for Home Assistant control."""
+
+    base_url: str = "http://homeassistant.local:8123"
+
+    # Prefer env var so configs can be committed safely
+    token_env: str = "HOME_ASSISTANT_TOKEN"
+    token: str = ""
+
+    # Map friendly device names to entity_ids.
+    # Example: {"living_room_light": "light.living_room"}
+    devices: Dict[str, str] = {}
+
+    timeout_seconds: float = 10.0
+    verify_ssl: bool = True
+
+
+class HomeAssistantRESTConnector(ActionConnector[HomeAssistantConfig, HomeAssistantControlInput]):
+    """Calls Home Assistant REST API to control entities."""
+
+    def _get_token(self) -> str:
+        token = (self.config.token or "").strip()
+        if token:
+            return token
+        env_key = (self.config.token_env or "").strip()
+        if env_key:
+            return (os.environ.get(env_key) or "").strip()
+        return ""
+
+    def _resolve_entity(self, device: str) -> str:
+        entity_id = (self.config.devices or {}).get(device)
+        if not entity_id:
+            raise ValueError(
+                f"Unknown Home Assistant device alias '{device}'. "
+                f"Add it to actions.home_assistant.config.devices."
+            )
+        return entity_id
+
+    @staticmethod
+    def _split_domain_entity(entity_id: str) -> Tuple[str, str]:
+        if "." not in entity_id:
+            raise ValueError(
+                f"Invalid entity_id '{entity_id}'. Expected format '<domain>.<entity>'."
+            )
+        domain, _ = entity_id.split(".", 1)
+        return domain, entity_id
+
+    def _command_to_service(
+        self, domain: str, command: str, value: Optional[float]
+    ) -> Tuple[str, Dict[str, Any]]:
+        c = command.strip().lower()
+
+        if c in {"on", "off", "toggle"}:
+            return (
+                {"on": "turn_on", "off": "turn_off", "toggle": "toggle"}[c],
+                {},
+            )
+
+        if c == "set":
+            if value is None:
+                raise ValueError("'set' command requires a numeric value")
+
+            # Small opinionated defaults that work well in practice.
+            if domain == "light":
+                # Interpret value as brightness percentage.
+                return "turn_on", {"brightness_pct": float(value)}
+
+            if domain == "climate":
+                return "set_temperature", {"temperature": float(value)}
+
+            if domain in {"input_number", "number"}:
+                return "set_value", {"value": float(value)}
+
+            # Fallback: try a generic 'set_value'
+            return "set_value", {"value": float(value)}
+
+        raise ValueError(f"Unsupported command '{command}'. Use on/off/toggle/set")
+
+    async def connect(self, output_interface: HomeAssistantControlInput) -> None:
+        token = self._get_token()
+        if not token:
+            raise ValueError(
+                "Missing Home Assistant token. Set config.token or env var HOME_ASSISTANT_TOKEN."
+            )
+
+        entity_id = self._resolve_entity(output_interface.device)
+        domain, entity_id = self._split_domain_entity(entity_id)
+        service, extra = self._command_to_service(
+            domain, output_interface.command, output_interface.value
+        )
+
+        url = f"{self.config.base_url.rstrip('/')}/api/services/{domain}/{service}"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        payload: Dict[str, Any] = {"entity_id": entity_id, **extra}
+
+        timeout = aiohttp.ClientTimeout(total=float(self.config.timeout_seconds))
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                ssl=bool(self.config.verify_ssl),
+            ) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    raise RuntimeError(
+                        f"Home Assistant call failed: {resp.status} {resp.reason}: {text[:500]}"
+                    )

--- a/src/actions/home_assistant/interface.py
+++ b/src/actions/home_assistant/interface.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from actions.base import Interface
+
+
+@dataclass
+class HomeAssistantControlInput:
+    """Control a Home Assistant entity (smart device).
+
+    This action is designed for simple, reliable device control via Home Assistant.
+
+    Parameters
+    ----------
+    device : str
+        A friendly device name/alias. Must exist in the action config mapping.
+        Example: "living_room_light".
+    command : str
+        Command to execute. Supported: "on", "off", "toggle", "set".
+    value : Optional[float]
+        Optional numeric value for "set" (e.g. brightness %, temperature).
+    """
+
+    device: str
+    command: str
+    value: Optional[float] = None
+
+
+@dataclass
+class HomeAssistantControl(Interface[HomeAssistantControlInput, HomeAssistantControlInput]):
+    """Controls smart devices via Home Assistant service calls."""
+
+    input: HomeAssistantControlInput
+    output: HomeAssistantControlInput

--- a/tests/test_home_assistant_rest_connector.py
+++ b/tests/test_home_assistant_rest_connector.py
@@ -1,0 +1,96 @@
+import pytest
+
+from actions.home_assistant.connector.rest_api import (
+    HomeAssistantConfig,
+    HomeAssistantRESTConnector,
+)
+from actions.home_assistant.interface import HomeAssistantControlInput
+
+
+class _FakeResponse:
+    def __init__(self, status=200, reason="OK", text="[]"):
+        self.status = status
+        self.reason = reason
+        self._text = text
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None, ssl=None):
+        self.calls.append({"url": url, "json": json, "headers": headers, "ssl": ssl})
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_home_assistant_turn_on_builds_expected_call(monkeypatch):
+    cfg = HomeAssistantConfig(
+        base_url="http://localhost:8123",
+        token="abc",
+        devices={"lamp": "light.living_room"},
+        verify_ssl=False,
+    )
+    c = HomeAssistantRESTConnector(cfg)
+
+    fake = _FakeSession()
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout=None: fake)
+
+    await c.connect(HomeAssistantControlInput(device="lamp", command="on"))
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["url"].endswith("/api/services/light/turn_on")
+    assert call["json"] == {"entity_id": "light.living_room"}
+    assert call["headers"]["Authorization"] == "Bearer abc"
+    assert call["ssl"] is False
+
+
+@pytest.mark.asyncio
+async def test_home_assistant_set_brightness(monkeypatch):
+    cfg = HomeAssistantConfig(
+        base_url="http://localhost:8123",
+        token="abc",
+        devices={"lamp": "light.living_room"},
+        verify_ssl=False,
+    )
+    c = HomeAssistantRESTConnector(cfg)
+
+    fake = _FakeSession()
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout=None: fake)
+
+    await c.connect(HomeAssistantControlInput(device="lamp", command="set", value=50))
+
+    call = fake.calls[0]
+    assert call["url"].endswith("/api/services/light/turn_on")
+    assert call["json"] == {"entity_id": "light.living_room", "brightness_pct": 50.0}
+
+
+@pytest.mark.asyncio
+async def test_home_assistant_unknown_device():
+    cfg = HomeAssistantConfig(base_url="http://localhost:8123", token="abc", devices={})
+    c = HomeAssistantRESTConnector(cfg)
+
+    with pytest.raises(ValueError):
+        await c.connect(HomeAssistantControlInput(device="missing", command="on"))


### PR DESCRIPTION
Implements a minimal, testable Home Assistant REST action for basic smart device control.

What’s included:
- New action: `actions/home_assistant`
- Connector: `rest_api` (calls `POST /api/services/<domain>/<service>`)
- Safe config: token via env var (`HOME_ASSISTANT_TOKEN`) + alias->entity_id mapping
- Unit tests for request construction: `tests/test_home_assistant_rest_connector.py`
- Docs: `docs/examples/home_assistant.mdx`

Notes / lessons learned from previous closed PRs:
- Kept scope tight to the bounty (no unrelated features)
- No root-level files added

Closes #366.
