### PR TITLE
Add Home Assistant smart device control action (bounty #366)

### DIFF
--- a/docs/examples/home_assistant.mdx
+++ b/docs/examples/home_assistant.mdx
@@ -1,0 +1,66 @@
+---
+title: "Home Assistant (Smart Devices)"
+---
+
+# Home Assistant (Smart Devices)
+
+This guide shows how to control basic IoT devices (lights/switches/thermostats) through **Home Assistant**.
+
+## 1) Create a Home Assistant Long-Lived Access Token
+
+In Home Assistant:
+- Profile → **Long-Lived Access Tokens** → create a token
+- Export it as an environment variable:
+
+```bash
+export HOME_ASSISTANT_TOKEN="<your_token>"
+```
+
+## 2) Add the action to your OM1 config
+
+Add an action entry like this (example):
+
+```json5
+{
+  name: "home_assistant",
+  llm_label: "home_assistant",
+  connector: "homeAssistantAPI",
+  config: {
+    base_url: "http://homeassistant.local:8123",
+    token_env: "HOME_ASSISTANT_TOKEN",
+    verify_ssl: true,
+    devices: {
+      lamp: "light.living_room",
+      bedroom_switch: "switch.bedroom"
+    }
+  }
+}
+```
+
+## 3) How to call it (JSON action value)
+
+OM1 actions pass a single string value. For structured arguments, provide JSON:
+
+- Turn on a light:
+
+```json
+{"device": "lamp", "command": "on"}
+```
+
+- Turn off a switch:
+
+```json
+{"device": "bedroom_switch", "command": "off"}
+```
+
+- Set brightness (percentage) for lights:
+
+```json
+{"device": "lamp", "command": "set", "value": 50}
+```
+
+## Notes
+
+- The connector uses Home Assistant REST API:
+  `POST /api/services/<domain>/<service>`
+- Device aliases are required (mapped to `entity_id` in config). This avoids the LLM guessing entity IDs.

--- a/src/actions/home_assistant/connector/homeAssistantAPI.py
+++ b/src/actions/home_assistant/connector/homeAssistantAPI.py
@@ -1,0 +1,142 @@
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import aiohttp
+from pydantic import Field
+
+from actions.base import ActionConfig, ActionConnector
+from actions.home_assistant.interface import HomeAssistantInput
+
+
+class HomeAssistantAPIConfig(ActionConfig):
+    """Configuration for HomeAssistantAPIConnector."""
+
+    base_url: str = Field(
+        default="http://homeassistant.local:8123",
+        description="Home Assistant base URL, e.g. http://<ip>:8123",
+    )
+    token: str = Field(
+        default="",
+        description="Home Assistant long-lived access token (recommended to use env var)",
+    )
+    token_env: str = Field(
+        default="HOME_ASSISTANT_TOKEN",
+        description="Environment variable name to read token from if token is empty",
+    )
+
+    # Friendly alias -> entity_id mapping (avoids the LLM guessing entity_ids)
+    devices: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of device alias to Home Assistant entity_id",
+    )
+
+    timeout_seconds: float = Field(default=10.0, description="HTTP timeout seconds")
+    verify_ssl: bool = Field(default=True, description="Verify TLS certs")
+
+
+class HomeAssistantAPIConnector(ActionConnector[HomeAssistantAPIConfig, HomeAssistantInput]):
+    """Connector for Home Assistant REST API service calls."""
+
+    def _get_token(self) -> str:
+        token = (self.config.token or "").strip()
+        if token:
+            return token
+
+        env_key = (self.config.token_env or "").strip()
+        if not env_key:
+            return ""
+
+        import os
+
+        return (os.environ.get(env_key) or "").strip()
+
+    def _resolve_entity_id(self, device_alias: str) -> str:
+        entity_id = (self.config.devices or {}).get(device_alias)
+        if not entity_id:
+            raise ValueError(
+                f"Unknown Home Assistant device alias '{device_alias}'. "
+                f"Add it to config.devices (alias -> entity_id)."
+            )
+        return entity_id
+
+    @staticmethod
+    def _split_domain(entity_id: str) -> Tuple[str, str]:
+        if "." not in entity_id:
+            raise ValueError(
+                f"Invalid entity_id '{entity_id}'. Expected '<domain>.<entity>'."
+            )
+        domain, _ = entity_id.split(".", 1)
+        return domain, entity_id
+
+    @staticmethod
+    def _command_to_service(domain: str, command: str, value: Optional[float]) -> Tuple[str, Dict[str, Any]]:
+        c = (command or "").strip().lower()
+
+        if c in {"on", "off", "toggle"}:
+            return {"on": "turn_on", "off": "turn_off", "toggle": "toggle"}[c], {}
+
+        if c == "set":
+            if value is None:
+                raise ValueError("'set' requires a numeric value")
+
+            if domain == "light":
+                return "turn_on", {"brightness_pct": float(value)}
+            if domain == "climate":
+                return "set_temperature", {"temperature": float(value)}
+            if domain in {"input_number", "number"}:
+                return "set_value", {"value": float(value)}
+
+            # fallback
+            return "set_value", {"value": float(value)}
+
+        raise ValueError("Unsupported command. Use on/off/toggle/set")
+
+    async def connect(self, output_interface: HomeAssistantInput) -> None:
+        token = self._get_token()
+        if not token:
+            logging.error(
+                "Home Assistant token missing. Set config.token or env var HOME_ASSISTANT_TOKEN."
+            )
+            return
+
+        # The orchestrator passes action.value to this connector as output_interface.action.
+        # We expect it to be JSON for structured arguments.
+        try:
+            payload_in = json.loads(output_interface.action or "{}")
+        except Exception as e:
+            raise ValueError(
+                "HomeAssistant action expects JSON string in `action`, e.g. "
+                "{\"device\":\"living_room_light\",\"command\":\"on\"}"
+            ) from e
+
+        if not isinstance(payload_in, dict):
+            raise ValueError("HomeAssistant action JSON must be an object")
+
+        device = payload_in.get("device")
+        command = payload_in.get("command")
+        value = payload_in.get("value", None)
+
+        if not device or not command:
+            raise ValueError("Missing required keys: device, command")
+
+        entity_id = self._resolve_entity_id(str(device))
+        domain, entity_id = self._split_domain(entity_id)
+        service, extra = self._command_to_service(domain, str(command), None if value is None else float(value))
+
+        url = f"{self.config.base_url.rstrip('/')}/api/services/{domain}/{service}"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+        payload_out: Dict[str, Any] = {"entity_id": entity_id, **extra}
+
+        timeout = aiohttp.ClientTimeout(total=float(self.config.timeout_seconds))
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json=payload_out, headers=headers, ssl=bool(self.config.verify_ssl)) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    raise RuntimeError(
+                        f"Home Assistant call failed: {resp.status} {resp.reason}: {text[:500]}"
+                    )

--- a/src/actions/home_assistant/interface.py
+++ b/src/actions/home_assistant/interface.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from actions.base import Interface
+
+
+@dataclass
+class HomeAssistantInput:
+    """Input interface for Home Assistant smart device control.
+
+    OM1 action inputs typically accept a single `action` string. This action expects
+    `action` to be JSON so the orchestrator can pass structured arguments.
+
+    Expected JSON shape (examples):
+
+    - Turn on a light:
+      {"device": "living_room_light", "command": "on"}
+
+    - Set brightness (percent):
+      {"device": "living_room_light", "command": "set", "value": 50}
+
+    Parameters
+    ----------
+    action : str
+        JSON string containing {device, command, value?}.
+    """
+
+    action: str = ""
+
+
+@dataclass
+class HomeAssistant(Interface[HomeAssistantInput, HomeAssistantInput]):
+    """Control smart devices via Home Assistant."""
+
+    input: HomeAssistantInput
+    output: HomeAssistantInput

--- a/tests/test_home_assistant_api_connector.py
+++ b/tests/test_home_assistant_api_connector.py
@@ -1,0 +1,101 @@
+import json
+
+import pytest
+
+from actions.home_assistant.connector.homeAssistantAPI import (
+    HomeAssistantAPIConfig,
+    HomeAssistantAPIConnector,
+)
+from actions.home_assistant.interface import HomeAssistantInput
+
+
+class _FakeResponse:
+    def __init__(self, status=200, reason="OK", text="[]"):
+        self.status = status
+        self.reason = reason
+        self._text = text
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, json=None, headers=None, ssl=None):
+        self.calls.append({"url": url, "json": json, "headers": headers, "ssl": ssl})
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_turn_on_light_builds_expected_call(monkeypatch):
+    cfg = HomeAssistantAPIConfig(
+        base_url="http://localhost:8123",
+        token="abc",
+        devices={"lamp": "light.living_room"},
+        verify_ssl=False,
+    )
+    c = HomeAssistantAPIConnector(cfg)
+
+    fake = _FakeSession()
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout=None: fake)
+
+    action = json.dumps({"device": "lamp", "command": "on"})
+    await c.connect(HomeAssistantInput(action=action))
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["url"].endswith("/api/services/light/turn_on")
+    assert call["json"] == {"entity_id": "light.living_room"}
+    assert call["headers"]["Authorization"] == "Bearer abc"
+    assert call["ssl"] is False
+
+
+@pytest.mark.asyncio
+async def test_set_brightness_uses_brightness_pct(monkeypatch):
+    cfg = HomeAssistantAPIConfig(
+        base_url="http://localhost:8123",
+        token="abc",
+        devices={"lamp": "light.living_room"},
+        verify_ssl=False,
+    )
+    c = HomeAssistantAPIConnector(cfg)
+
+    fake = _FakeSession()
+
+    import aiohttp
+
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda timeout=None: fake)
+
+    action = json.dumps({"device": "lamp", "command": "set", "value": 50})
+    await c.connect(HomeAssistantInput(action=action))
+
+    call = fake.calls[0]
+    assert call["url"].endswith("/api/services/light/turn_on")
+    assert call["json"] == {"entity_id": "light.living_room", "brightness_pct": 50.0}
+
+
+@pytest.mark.asyncio
+async def test_unknown_device_alias_raises(monkeypatch):
+    cfg = HomeAssistantAPIConfig(base_url="http://localhost:8123", token="abc", devices={})
+    c = HomeAssistantAPIConnector(cfg)
+
+    action = json.dumps({"device": "missing", "command": "on"})
+    with pytest.raises(ValueError):
+        await c.connect(HomeAssistantInput(action=action))


### PR DESCRIPTION
Implements Home Assistant smart device control for bounty #366, aligned with OM1’s existing action patterns.

What’s included:
- Action: `home_assistant`
- Connector: `homeAssistantAPI` (pattern similar to `telegramAPI`)
- Uses Home Assistant REST API service calls: `POST /api/services/<domain>/<service>`
- Uses env var token (`HOME_ASSISTANT_TOKEN`) by default (no secrets in repo)
- Uses alias→entity_id mapping in config to avoid the LLM guessing entity IDs
- Unit tests for request construction: `tests/test_home_assistant_api_connector.py`
- Docs: `docs/examples/home_assistant.mdx`

How to call it:
OM1 passes a single string value; for structured args, send JSON in the action value, e.g.
`{"device":"lamp","command":"on"}` or `{"device":"lamp","command":"set","value":50}`.

Closes #366.
