### PR TITLE
fix(nav): avoid misleading warning when stopping provider

### DIFF
--- a/src/providers/unitree_go2_navigation_provider.py
+++ b/src/providers/unitree_go2_navigation_provider.py
@@ -270,6 +270,7 @@ class UnitreeGo2NavigationProvider:
         """
         Stop the navigation provider by unsubscribing from topics and cleaning up resources.
         """
+        was_running = self.running
         self.running = False
 
         if self.session:
@@ -280,7 +281,10 @@ class UnitreeGo2NavigationProvider:
             self.ai_status_pub.undeclare()
             logging.info("AI status publisher closed")
 
-        logging.warning("Navigation Provider is not running")
+        if was_running:
+            logging.info("Navigation Provider stopped")
+        else:
+            logging.warning("Navigation Provider was not running")
 
     @property
     def navigation_state(self) -> str:


### PR DESCRIPTION
# Overview
This PR fixes a misleading shutdown log message in the Unitree Go2 navigation provider. Previously, calling `stop()` always emitted a warning stating the provider was not running, even when it was shutting down normally.

# Changes
- Update `src/providers/unitree_go2_navigation_provider.py` `stop()` to:
  - Log `info` when a running provider is stopped.
  - Log `warning` only when `stop()` is called while already not running.

# Impact
- Reduces log noise and prevents false warnings during normal shutdown.
- Improves operator trust in logs and makes real warnings easier to spot.
- No behavioral change beyond log messaging.

# Testing
- `ruff check src\providers\unitree_go2_navigation_provider.py`

# Additional Information
- `pyright` was not available in this environment to run locally.