### PR TITLE
fix(io): use os.replace for atomic file writes

### DIFF
--- a/src/providers/config_provider.py
+++ b/src/providers/config_provider.py
@@ -108,7 +108,7 @@ class ConfigProvider:
             with open(temp_path, "w") as f:
                 json.dump(new_config, f, indent=2)
 
-            os.rename(temp_path, self.config_path)
+            os.replace(temp_path, self.config_path)
 
             logging.info(f"Updated runtime config file: {self.config_path}")
 

--- a/src/runtime/multi_mode/manager.py
+++ b/src/runtime/multi_mode/manager.py
@@ -148,7 +148,7 @@ class ModeManager:
             with open(temp_file, "w") as f:
                 json5.dump(runtime_config, f, indent=2)
 
-            os.rename(temp_file, runtime_config_path)
+            os.replace(temp_file, runtime_config_path)
             logging.debug(f"Runtime config file created/updated: {runtime_config_path}")
 
         except Exception as e:
@@ -942,7 +942,7 @@ class ModeManager:
             with open(temp_file, "w") as f:
                 json.dump(state_data, f, indent=2)
 
-            os.rename(temp_file, state_file)
+            os.replace(temp_file, state_file)
             logging.debug(f"Mode state saved to {state_file}")
 
         except Exception as e:


### PR DESCRIPTION
# Overview
This PR hardens “atomic write” file replacement by switching from `os.rename(...)` to `os.replace(...)` in runtime/config persistence paths.

# Changes
- Use `os.replace(...)` for temp-file replacement in:
  - `src/runtime/multi_mode/manager.py` (runtime config write and mode state save)
  - `src/providers/config_provider.py` (runtime config update)

# Impact
- Improves cross-platform reliability when overwriting an existing destination file.
- Reduces risk of silently continuing with stale `.runtime.json5` or mode state/config after a failed rename.
- No change to higher-level runtime logic or config semantics.

# Testing
- `ruff check src\runtime\multi_mode\manager.py src\providers\config_provider.py`

# Additional Information
- `pytest` is not available in this environment to run the full test suite locally.