### PR TITLE
chore(single-mode): stop orchestrators during reload and cleanup

### DIFF
--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -288,6 +288,17 @@ class CortexRuntime:
 
         self.sleep_ticker_provider.skip_sleep = True
 
+        if self.background_orchestrator:
+            self.background_orchestrator.stop()
+
+        if self.simulator_orchestrator:
+            logging.debug("Stopping simulator orchestrator")
+            self.simulator_orchestrator.stop()
+
+        if self.action_orchestrator:
+            logging.debug("Stopping action orchestrator")
+            self.action_orchestrator.stop()
+
         tasks_to_cancel = {}
 
         if self.cortex_loop_task and not self.cortex_loop_task.done():
@@ -412,6 +423,15 @@ class CortexRuntime:
                 await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
             except Exception as e:
                 logging.warning(f"Error during final cleanup: {e}")
+
+        if self.background_orchestrator:
+            self.background_orchestrator.stop()
+
+        if self.simulator_orchestrator:
+            self.simulator_orchestrator.stop()
+
+        if self.action_orchestrator:
+            self.action_orchestrator.stop()
 
         # Stop ConfigProvider
         self.config_provider.stop()


### PR DESCRIPTION
**# Overview**
- Ensure single-mode runtime shuts down orchestrator thread pools during reload/cleanup to match multi-mode behavior.

**# Changes**
- Add `.stop()` calls for background, simulator, and action orchestrators in reload and final cleanup paths (`src/runtime/single_mode/cortex.py:283`).

**# Impact**
- Reduces lingering thread pools and improves shutdown reliability without changing runtime behavior.

**# Testing**
- Not run (not requested).

**# Additional Information**
- Aligns single-mode lifecycle handling with existing multi-mode shutdown flow.