### PR TITLE
fix(io): read config files with explicit UTF-8 encoding

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -199,7 +199,7 @@ def validate_config(
 
         # Load and parse JSON5
         try:
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 raw_config = json5.load(f)
         except ValueError as e:
             print("Error: Invalid JSON5 syntax")
@@ -224,7 +224,7 @@ def validate_config(
             os.path.dirname(__file__), "../config/schema", schema_file
         )
 
-        with open(schema_path, "r") as f:
+        with open(schema_path, "r", encoding="utf-8") as f:
             schema = json.load(f)
 
         validate(instance=raw_config, schema=schema)

--- a/src/run.py
+++ b/src/run.py
@@ -98,7 +98,7 @@ def start(
     setup_logging(config_name, log_level, log_to_file)
 
     try:
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             raw_config = json5.load(f)
 
         if "modes" in raw_config and "default_mode" in raw_config:

--- a/src/runtime/config.py
+++ b/src/runtime/config.py
@@ -31,7 +31,7 @@ def _load_schema(schema_file: str) -> dict:
             f"Schema file not found: {schema_path}. Cannot validate configuration."
         )
 
-    with open(schema_path, "r") as f:
+    with open(schema_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/src/runtime/multi_mode/config.py
+++ b/src/runtime/multi_mode/config.py
@@ -385,7 +385,7 @@ def load_mode_config(
         else mode_source_path
     )
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         try:
             raw_config = json5.load(f)
         except Exception as e:

--- a/src/runtime/single_mode/config.py
+++ b/src/runtime/single_mode/config.py
@@ -134,7 +134,7 @@ def load_config(
         else config_source_path
     )
 
-    with open(config_path, "r") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         try:
             raw_config = json5.load(f)
         except Exception as e:


### PR DESCRIPTION
**# Overview**
- Standardize UTF‑8 decoding for config and schema reads to avoid platform‑dependent parsing issues.

**# Changes**
- Add `encoding="utf-8"` to JSON/JSON5 file opens in `src/runtime/config.py`, `src/runtime/single_mode/config.py`, `src/runtime/multi_mode/config.py`, `src/cli.py`, and `src/run.py`.

**# Impact**
- Prevents Windows/default‑encoding surprises while preserving behavior for valid UTF‑8 configs.

**# Testing**
- Not run (not requested).

**# Additional Information**
- No schema or runtime behavior changes; this is a read‑time safeguard only.