### PR TITLE
feat: Add Home Assistant smart device integration (Issue #366)

### DIFF
--- a/config/home_assistant.json5
+++ b/config/home_assistant.json5
@@ -85,7 +85,9 @@
         base_url: "http://homeassistant.local:8123",
         // Replace with your long-lived access token
         access_token: "",
-        verify_ssl: false,
+        // WARNING: Only set verify_ssl to false in trusted local networks.
+        // Disabling SSL verification exposes traffic to MITM attacks.
+        verify_ssl: true,
         timeout: 10
       }
     },

--- a/docs/smart_devices/HOME_ASSISTANT_SETUP.md
+++ b/docs/smart_devices/HOME_ASSISTANT_SETUP.md
@@ -264,4 +264,4 @@ class HomeAssistantOutput:
 
 ## License
 
-MIT License - see [LICENSE](../LICENSE) for details.
+MIT License - see [LICENSE](../../LICENSE) for details.

--- a/src/actions/home_assistant/connector/mqtt.py
+++ b/src/actions/home_assistant/connector/mqtt.py
@@ -6,7 +6,6 @@ MQTT protocol. It supports lights, switches, and other smart home devices
 that are exposed via MQTT in Home Assistant.
 """
 
-import asyncio
 import json
 import logging
 import time
@@ -111,6 +110,7 @@ class HomeAssistantMQTTConnector(
         self.mqtt_password = config.mqtt_password
         self.topic_prefix = config.topic_prefix
         self._last_result: Optional[HomeAssistantOutput] = None
+        self._client: Optional[aiomqtt.Client] = None
 
         logging.info(
             f"HomeAssistant MQTT connector initialized for {self.mqtt_host}:{self.mqtt_port}"
@@ -119,6 +119,12 @@ class HomeAssistantMQTTConnector(
     def _get_entity_topic(self, entity_id: str, action_type: str = "set") -> str:
         """
         Generate MQTT topic for an entity.
+
+        Uses the Home Assistant MQTT discovery topic format:
+        ``{topic_prefix}/{domain}/{object_id}/{action_type}``
+
+        For example, entity_id ``light.living_room`` with action_type ``set``
+        becomes ``homeassistant/light/living_room/set``.
 
         Parameters
         ----------
@@ -136,13 +142,36 @@ class HomeAssistantMQTTConnector(
         domain, name = entity_id.split(".", 1)
         return f"{self.topic_prefix}/{domain}/{name}/{action_type}"
 
+    async def _get_client(self) -> aiomqtt.Client:
+        """
+        Get or create a persistent MQTT client connection.
+
+        Returns
+        -------
+        aiomqtt.Client
+            Connected MQTT client.
+        """
+        if self._client is None:
+            self._client = aiomqtt.Client(
+                hostname=self.mqtt_host,
+                port=self.mqtt_port,
+                username=self.mqtt_username,
+                password=self.mqtt_password,
+            )
+            await self._client.__aenter__()
+            logging.info(
+                f"MQTT persistent connection established to "
+                f"{self.mqtt_host}:{self.mqtt_port}"
+            )
+        return self._client
+
     async def _publish_message(
         self,
         topic: str,
         payload: Dict[str, Any],
     ) -> bool:
         """
-        Publish a message to MQTT broker.
+        Publish a message to MQTT broker using a persistent connection.
 
         Parameters
         ----------
@@ -157,21 +186,18 @@ class HomeAssistantMQTTConnector(
             True if publish was successful.
         """
         try:
-            async with aiomqtt.Client(
-                hostname=self.mqtt_host,
-                port=self.mqtt_port,
-                username=self.mqtt_username,
-                password=self.mqtt_password,
-            ) as client:
-                await client.publish(
-                    topic,
-                    payload=json.dumps(payload),
-                    qos=1,
-                )
-                logging.info(f"Published to {topic}: {payload}")
-                return True
+            client = await self._get_client()
+            await client.publish(
+                topic,
+                payload=json.dumps(payload),
+                qos=1,
+            )
+            logging.info(f"Published to {topic}: {payload}")
+            return True
         except Exception as e:
             logging.error(f"MQTT publish error: {e}")
+            # Reset client on error so next call reconnects
+            self._client = None
             return False
 
     async def _control_light(
@@ -193,7 +219,12 @@ class HomeAssistantMQTTConnector(
                 try:
                     rgb = [int(x.strip()) for x in color_rgb.split(",")]
                     if len(rgb) == 3:
-                        payload["color"] = {"r": rgb[0], "g": rgb[1], "b": rgb[2]}
+                        if all(0 <= v <= 255 for v in rgb):
+                            payload["color"] = {"r": rgb[0], "g": rgb[1], "b": rgb[2]}
+                        else:
+                            logging.warning(
+                                f"RGB values out of range (0-255): {color_rgb}"
+                            )
                 except ValueError:
                     logging.warning(f"Invalid RGB color format: {color_rgb}")
         elif action in ("turn_off", "off"):
@@ -206,7 +237,14 @@ class HomeAssistantMQTTConnector(
             try:
                 rgb = [int(x.strip()) for x in color_rgb.split(",")]
                 if len(rgb) == 3:
-                    payload["color"] = {"r": rgb[0], "g": rgb[1], "b": rgb[2]}
+                    if all(0 <= v <= 255 for v in rgb):
+                        payload["color"] = {"r": rgb[0], "g": rgb[1], "b": rgb[2]}
+                    else:
+                        return HomeAssistantOutput(
+                            success=False,
+                            message=f"RGB values out of range (0-255): {color_rgb}",
+                            entity_id=entity_id,
+                        )
             except ValueError:
                 return HomeAssistantOutput(
                     success=False,
@@ -347,3 +385,14 @@ class HomeAssistantMQTTConnector(
         Tick method for periodic updates.
         """
         time.sleep(60)
+
+    async def close(self) -> None:
+        """Close the persistent MQTT client connection."""
+        if self._client is not None:
+            try:
+                await self._client.__aexit__(None, None, None)
+                logging.info("MQTT persistent connection closed")
+            except Exception as e:
+                logging.error(f"Error closing MQTT connection: {e}")
+            finally:
+                self._client = None

--- a/src/actions/home_assistant/connector/rest_api.py
+++ b/src/actions/home_assistant/connector/rest_api.py
@@ -6,7 +6,6 @@ the REST API. It supports lights, switches, thermostats, and other smart
 home devices.
 """
 
-import asyncio
 import logging
 import time
 from typing import Any, Dict, Optional
@@ -67,7 +66,6 @@ class HomeAssistantRESTConnector(
     - Thermostats: temperature setting, HVAC mode
     - Covers: open/close
     - Fans: on/off, speed
-    - Media players: play/pause/stop
     """
 
     def __init__(self, config: HomeAssistantConfig):
@@ -86,6 +84,13 @@ class HomeAssistantRESTConnector(
         self.timeout = config.timeout
         self._session: Optional[aiohttp.ClientSession] = None
         self._last_result: Optional[HomeAssistantOutput] = None
+
+        if not self.access_token:
+            logging.warning(
+                "HomeAssistant REST connector: access_token is empty. "
+                "API requests will fail. Set a long-lived access token "
+                "from your Home Assistant instance."
+            )
 
         logging.info(
             f"HomeAssistant REST connector initialized for {self.base_url}"
@@ -203,7 +208,12 @@ class HomeAssistantRESTConnector(
                 try:
                     rgb = [int(x.strip()) for x in color_rgb.split(",")]
                     if len(rgb) == 3:
-                        service_data["rgb_color"] = rgb
+                        if all(0 <= v <= 255 for v in rgb):
+                            service_data["rgb_color"] = rgb
+                        else:
+                            logging.warning(
+                                f"RGB values out of range (0-255): {color_rgb}"
+                            )
                 except ValueError:
                     logging.warning(f"Invalid RGB color format: {color_rgb}")
         elif action in ("turn_off", "off"):
@@ -218,7 +228,14 @@ class HomeAssistantRESTConnector(
             try:
                 rgb = [int(x.strip()) for x in color_rgb.split(",")]
                 if len(rgb) == 3:
-                    service_data["rgb_color"] = rgb
+                    if all(0 <= v <= 255 for v in rgb):
+                        service_data["rgb_color"] = rgb
+                    else:
+                        return HomeAssistantOutput(
+                            success=False,
+                            message=f"RGB values out of range (0-255): {color_rgb}",
+                            entity_id=entity_id,
+                        )
             except ValueError:
                 return HomeAssistantOutput(
                     success=False,

--- a/src/actions/home_assistant/interface.py
+++ b/src/actions/home_assistant/interface.py
@@ -20,7 +20,6 @@ class DeviceType(Enum):
     THERMOSTAT = "climate"
     COVER = "cover"
     FAN = "fan"
-    MEDIA_PLAYER = "media_player"
 
 
 class LightAction(Enum):

--- a/src/inputs/plugins/home_assistant_state.py
+++ b/src/inputs/plugins/home_assistant_state.py
@@ -16,6 +16,7 @@ from pydantic import Field
 
 from inputs.base import Message, SensorConfig
 from inputs.base.loop import FuserInput
+from providers.io_provider import IOProvider
 
 
 class HomeAssistantInputConfig(SensorConfig):
@@ -124,10 +125,18 @@ class HomeAssistantStateInput(FuserInput[HomeAssistantInputConfig, Optional[str]
         self.report_all_states = config.report_all_states
         self.descriptor_for_LLM = config.input_name
 
+        self.io_provider = IOProvider()
         self._session: Optional[aiohttp.ClientSession] = None
         self._previous_states: Dict[str, str] = {}
         self._last_poll_time: float = 0
         self.messages: List[Message] = []
+
+        if not self.access_token:
+            logging.warning(
+                "HomeAssistant state input: access_token is empty. "
+                "API requests will fail. Set a long-lived access token "
+                "from your Home Assistant instance."
+            )
 
         logging.info(
             f"HomeAssistant state input initialized for {self.base_url} "
@@ -303,6 +312,11 @@ class HomeAssistantStateInput(FuserInput[HomeAssistantInputConfig, Optional[str]
         """
         Filter states to only include those that have changed.
 
+        Note: This compares only the primary state string (e.g., 'on'/'off'),
+        not device attributes (brightness, temperature, etc.). Attribute-only
+        changes (e.g., brightness change while state remains 'on') will not
+        be detected as changes.
+
         Parameters
         ----------
         current_states : List[DeviceState]
@@ -334,7 +348,8 @@ class HomeAssistantStateInput(FuserInput[HomeAssistantInputConfig, Optional[str]
 
         # Respect poll interval
         if current_time - self._last_poll_time < self.poll_interval:
-            await asyncio.sleep(self.poll_interval / 2)
+            remaining = self.poll_interval - (current_time - self._last_poll_time)
+            await asyncio.sleep(remaining)
             return None
 
         self._last_poll_time = current_time
@@ -383,39 +398,47 @@ class HomeAssistantStateInput(FuserInput[HomeAssistantInputConfig, Optional[str]
             message=raw_input,
         )
 
-    async def raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
+    async def raw_to_text(self, raw_input: Optional[str]):
         """
-        Convert raw input to a Message object.
+        Update message buffer.
 
         Parameters
         ----------
         raw_input : Optional[str]
             Raw state information.
-
-        Returns
-        -------
-        Optional[Message]
-            Message object or None.
         """
         message = await self._raw_to_text(raw_input)
-        if message:
+        if message is not None:
             self.messages.append(message)
-        return message
 
     def formatted_latest_buffer(self) -> Optional[str]:
         """
-        Get the most recent device state as a formatted prompt string.
+        Format and clear the latest buffer contents.
+
+        Formats the most recent message with the standard OM1 input format,
+        adds it to the IO provider, then clears the buffer.
 
         Returns
         -------
         Optional[str]
-            The formatted buffer string if available, None otherwise.
+            Formatted string of buffer contents or None if buffer is empty.
         """
         if not self.messages:
             return None
 
         latest = self.messages[-1]
-        return f"[{self.descriptor_for_LLM}]: {latest.message}"
+
+        result = (
+            f"\nINPUT: {self.descriptor_for_LLM}\n// START\n"
+            f"{latest.message}\n// END\n"
+        )
+
+        self.io_provider.add_input(
+            self.__class__.__name__, latest.message, latest.timestamp
+        )
+        self.messages = []
+
+        return result
 
     async def close(self) -> None:
         """Close the aiohttp session."""

--- a/tests/actions/test_home_assistant.py
+++ b/tests/actions/test_home_assistant.py
@@ -6,14 +6,15 @@ testing light control, switch control, and thermostat control functionality.
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
 
 from actions.home_assistant.interface import (
     HomeAssistantInput,
     HomeAssistantOutput,
     DeviceType,
     LightAction,
-    SwitchAction,
     ThermostatAction,
 )
 from actions.home_assistant.connector.rest_api import (
@@ -387,7 +388,6 @@ class TestHomeAssistantInterface:
         assert DeviceType.THERMOSTAT.value == "climate"
         assert DeviceType.COVER.value == "cover"
         assert DeviceType.FAN.value == "fan"
-
     def test_light_action_enum(self):
         """Test LightAction enum values."""
         assert LightAction.ON.value == "turn_on"
@@ -401,3 +401,89 @@ class TestHomeAssistantInterface:
         assert ThermostatAction.SET_TEMPERATURE.value == "set_temperature"
         assert ThermostatAction.SET_HVAC_MODE.value == "set_hvac_mode"
         assert ThermostatAction.SET_FAN_MODE.value == "set_fan_mode"
+
+
+class TestHomeAssistantNetworkErrors:
+    """Tests for network error handling."""
+
+    @pytest.fixture
+    def connector(self):
+        """Create a test connector instance."""
+        config = HomeAssistantConfig(
+            base_url="http://localhost:8123",
+            access_token="test_token_12345",
+            verify_ssl=False,
+            timeout=5,
+        )
+        return HomeAssistantRESTConnector(config)
+
+    @pytest.mark.asyncio
+    async def test_call_service_connection_error(self, connector):
+        """Test _call_service handles aiohttp.ClientError gracefully."""
+        mock_session = AsyncMock()
+        mock_session.post.side_effect = aiohttp.ClientError("Connection refused")
+
+        with patch.object(
+            connector, "_get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            mock_get_session.return_value = mock_session
+            result = await connector._call_service(
+                "light", "turn_on", {"entity_id": "light.test"}
+            )
+
+            assert result["success"] is False
+            assert "Connection refused" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_call_service_timeout_error(self, connector):
+        """Test _call_service handles timeout errors gracefully."""
+        mock_session = AsyncMock()
+        mock_session.post.side_effect = aiohttp.ClientError("Connection timeout")
+
+        with patch.object(
+            connector, "_get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            mock_get_session.return_value = mock_session
+            result = await connector._call_service(
+                "switch", "turn_on", {"entity_id": "switch.test"}
+            )
+
+            assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_control_light_rgb_out_of_range(self, connector):
+        """Test that RGB values outside 0-255 are rejected."""
+        result = await connector._control_light(
+            entity_id="light.test",
+            action="color",
+            color_rgb="300,-1,256",
+        )
+
+        assert result.success is False
+        assert "out of range" in result.message
+
+    @pytest.mark.asyncio
+    async def test_get_entity_state_connection_error(self, connector):
+        """Test _get_entity_state handles connection errors."""
+        mock_session = AsyncMock()
+        mock_session.get.side_effect = aiohttp.ClientError("Connection refused")
+
+        with patch.object(
+            connector, "_get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            mock_get_session.return_value = mock_session
+            result = await connector._get_entity_state("light.test")
+
+            assert result is None
+
+    def test_empty_access_token_warning(self):
+        """Test that empty access_token logs a warning."""
+        import logging
+
+        with patch.object(logging, "warning") as mock_warn:
+            config = HomeAssistantConfig(
+                base_url="http://localhost:8123",
+                access_token="",
+            )
+            HomeAssistantRESTConnector(config)
+            mock_warn.assert_called()

--- a/tests/inputs/test_home_assistant_state.py
+++ b/tests/inputs/test_home_assistant_state.py
@@ -7,7 +7,9 @@ input plugin, testing device state polling and formatting.
 
 import pytest
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
 
 from inputs.plugins.home_assistant_state import (
     HomeAssistantInputConfig,
@@ -336,16 +338,22 @@ class TestHomeAssistantStateInput:
         assert message is None
 
     def test_formatted_latest_buffer(self, state_input):
-        """Test getting formatted latest buffer."""
+        """Test getting formatted latest buffer matches OM1 convention."""
         state_input.messages = [
             Message(timestamp=time.time(), message="Test state info"),
         ]
 
-        formatted = state_input.formatted_latest_buffer()
+        # Mock IOProvider to avoid singleton issues in tests
+        with patch.object(state_input, "io_provider") as mock_io:
+            formatted = state_input.formatted_latest_buffer()
 
-        assert formatted is not None
-        assert "[Test Smart Home]" in formatted
-        assert "Test state info" in formatted
+            assert formatted is not None
+            assert "\nINPUT: Test Smart Home\n// START\n" in formatted
+            assert "Test state info" in formatted
+            assert "\n// END\n" in formatted
+            mock_io.add_input.assert_called_once()
+            # Buffer should be cleared after formatting
+            assert state_input.messages == []
 
     def test_formatted_latest_buffer_empty(self, state_input):
         """Test getting formatted buffer when empty."""
@@ -365,4 +373,76 @@ class TestHomeAssistantStateInput:
 
             # Should return None without calling _get_all_states
             # because interval hasn't passed
+            assert result is None
             mock_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_executes_after_interval(self, state_input):
+        """Test that polling executes after the interval has passed."""
+        # Set last poll time far enough in the past
+        state_input._last_poll_time = time.time() - state_input.poll_interval - 1
+
+        mock_states = [
+            DeviceState(
+                entity_id="light.test",
+                state="on",
+                friendly_name="Test Light",
+                attributes={"brightness": 255},
+                last_changed="",
+            ),
+        ]
+
+        with patch.object(
+            state_input, "_get_all_states", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = mock_states
+            result = await state_input._poll()
+
+            mock_get.assert_called_once()
+            assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_poll_handles_network_error(self, state_input):
+        """Test that polling handles network errors gracefully."""
+        state_input._last_poll_time = 0
+
+        with patch.object(
+            state_input, "_get_all_states", new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.side_effect = Exception("Network unreachable")
+            result = await state_input._poll()
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_entity_state_http_error(self, state_input):
+        """Test handling of HTTP errors when getting entity state."""
+        mock_response = AsyncMock()
+        mock_response.status = 401
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get.return_value = mock_response
+
+        with patch.object(
+            state_input, "_get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            mock_get_session.return_value = mock_session
+            result = await state_input._get_entity_state("light.test")
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_entity_state_connection_error(self, state_input):
+        """Test handling of connection errors when getting entity state."""
+        mock_session = AsyncMock()
+        mock_session.get.side_effect = aiohttp.ClientError("Connection refused")
+
+        with patch.object(
+            state_input, "_get_session", new_callable=AsyncMock
+        ) as mock_get_session:
+            mock_get_session.return_value = mock_session
+            result = await state_input._get_entity_state("light.test")
+
+            assert result is None


### PR DESCRIPTION
## Summary
This PR adds Home Assistant integration to OM1, enabling robots to control and monitor smart home devices.

## 🤖 Home Assistant Integrated
- REST API connector (primary)
- MQTT connector (alternative)

## Features
### Action Plugin (`home_assistant`)
- **Lights**: on/off, toggle, brightness (0-255), RGB color
- **Switches**: on/off, toggle  
- **Thermostats**: set temperature, HVAC modes (heat/cool/auto/off)
- **Covers**: open/close/stop (blinds, garage doors)
- **Fans**: on/off, toggle

### Input Plugin (`HomeAssistantStateInput`)
- Real-time device state monitoring
- Change detection (only report when states change)
- Natural language formatting for LLM consumption
- Supports: lights, switches, climate, sensors, binary sensors, covers, fans

## Files Changed
- `src/actions/home_assistant/interface.py` - Action interface definitions
- `src/actions/home_assistant/connector/rest_api.py` - REST API connector
- `src/actions/home_assistant/connector/mqtt.py` - MQTT connector
- `src/inputs/plugins/home_assistant_state.py` - State monitoring input
- `tests/actions/test_home_assistant.py` - Action tests (30+ test cases)
- `tests/inputs/test_home_assistant_state.py` - Input tests
- `config/home_assistant.json5` - Demo configuration
- `docs/smart_devices/HOME_ASSISTANT_SETUP.md` - Setup documentation

## Configuration Example
```json5
{
  agent_actions: [{
    name: "home_assistant",
    llm_label: "smart_home",
    connector: "rest_api",
    config: {
      base_url: "http://homeassistant.local:8123",
      access_token: "YOUR_TOKEN"
    }
  }],
  agent_inputs: [{
    type: "HomeAssistantStateInput",
    config: {
      base_url: "http://homeassistant.local:8123",
      access_token: "YOUR_TOKEN",
      entity_ids: ["light.living_room", "climate.bedroom"]
    }
  }]
}
```

## 🎥 Demo Video
Coming soon - will record once PR is reviewed.

## 📑 Notes
- **Setup**: Get long-lived token from Home Assistant Profile → Long-Lived Access Tokens
- **Limitations**: MQTT connector requires aiomqtt package
- **Improvements**: Could add support for scenes, automations, and scripts

Closes #366
