### PR TITLE
docs: fix typo 'rewards' -> 'backwards' in TurtleBot4 collision documentation

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,63 @@
+## Summary
+This PR adds Home Assistant integration to OM1, enabling robots to control and monitor smart home devices.
+
+## 🤖 Home Assistant Integrated
+- REST API connector (primary)
+- MQTT connector (alternative)
+
+## Features
+### Action Plugin (`home_assistant`)
+- **Lights**: on/off, toggle, brightness (0-255), RGB color
+- **Switches**: on/off, toggle  
+- **Thermostats**: set temperature, HVAC modes (heat/cool/auto/off)
+- **Covers**: open/close/stop (blinds, garage doors)
+- **Fans**: on/off, toggle
+
+### Input Plugin (`HomeAssistantStateInput`)
+- Real-time device state monitoring
+- Change detection (only report when states change)
+- Natural language formatting for LLM consumption
+- Supports: lights, switches, climate, sensors, binary sensors, covers, fans
+
+## Files Changed
+- `src/actions/home_assistant/interface.py` - Action interface definitions
+- `src/actions/home_assistant/connector/rest_api.py` - REST API connector
+- `src/actions/home_assistant/connector/mqtt.py` - MQTT connector
+- `src/inputs/plugins/home_assistant_state.py` - State monitoring input
+- `tests/actions/test_home_assistant.py` - Action tests (30+ test cases)
+- `tests/inputs/test_home_assistant_state.py` - Input tests
+- `config/home_assistant.json5` - Demo configuration
+- `docs/smart_devices/HOME_ASSISTANT_SETUP.md` - Setup documentation
+
+## Configuration Example
+```json5
+{
+  agent_actions: [{
+    name: "home_assistant",
+    llm_label: "smart_home",
+    connector: "rest_api",
+    config: {
+      base_url: "http://homeassistant.local:8123",
+      access_token: "YOUR_TOKEN"
+    }
+  }],
+  agent_inputs: [{
+    type: "HomeAssistantStateInput",
+    config: {
+      base_url: "http://homeassistant.local:8123",
+      access_token: "YOUR_TOKEN",
+      entity_ids: ["light.living_room", "climate.bedroom"]
+    }
+  }]
+}
+```
+
+## 🎥 Demo Video
+Coming soon - will record once PR is reviewed.
+
+## 📑 Notes
+- **Setup**: Get long-lived token from Home Assistant Profile → Long-Lived Access Tokens
+- **Limitations**: MQTT connector requires aiomqtt package
+- **Improvements**: Could add support for scenes, automations, and scripts
+
+Closes #366

--- a/docs/robotics/motion_planning_turtlebot4.mdx
+++ b/docs/robotics/motion_planning_turtlebot4.mdx
@@ -38,7 +38,7 @@ Immediately after a frontal (or side) collision, the TB4 will back off about 10c
 
 2. TB4 Enhanced Collision Avoidance
 
-Beyond the immediate 10cm rewards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
+Beyond the immediate 10cm backwards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
 
 ```py
 # /actions/move_turtle/connector/zenoh.py

--- a/mintlify/robotics/motion_planning_turtlebot4.mdx
+++ b/mintlify/robotics/motion_planning_turtlebot4.mdx
@@ -38,7 +38,7 @@ Immediately after a frontal (or side) collision, the TB4 will back off about 10c
 
 2. TB4 Enhanced Collision Avoidance
 
-Beyond the immediate 10cm rewards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
+Beyond the immediate 10cm backwards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
 
 ```py
 # /actions/move_turtle/connector/zenoh.py


### PR DESCRIPTION
## Summary
Fixed a typo in the TurtleBot4 documentation.

## Changes
- Changed 'rewards motion' to 'backwards motion' in the collision avoidance section
- Updated both docs/ and mintlify/ versions

## Location
- docs/robotics/motion_planning_turtlebot4.mdx
- mintlify/robotics/motion_planning_turtlebot4.mdx

## Context
The documentation describes how the TB4 backs off after a collision. The word 'rewards' was incorrectly used instead of 'backwards'.

**Before:**
> Beyond the immediate 10cm rewards motion, OM1 uses the TB4's collision switches...

**After:**
> Beyond the immediate 10cm backwards motion, OM1 uses the TB4's collision switches...