### PR TITLE
feat(wallet): Auto-create Coinbase wallet if not found

### DIFF
--- a/src/inputs/plugins/wallet_coinbase.py
+++ b/src/inputs/plugins/wallet_coinbase.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 from typing import List, Optional
 
-from cdp import Cdp, Wallet
+from cdp import Cdp, Wallet, WalletData
 from pydantic import Field
 
 from inputs.base import Message, SensorConfig
@@ -34,7 +34,12 @@ class WalletCoinbaseConfig(SensorConfig):
     asset_id: str = Field(default="eth", description="Asset ID to query")
     network_id: str = Field(
         default="base-sepolia",
-        description="Network ID for wallet creation (e.g., base-sepolia, base-mainnet)",
+        description=(
+            "Network ID for wallet creation. Supported networks include: "
+            "base-sepolia (testnet), base-mainnet, ethereum-mainnet, ethereum-sepolia, "
+            "polygon-mainnet, arbitrum-mainnet. See CDP SDK docs for full list: "
+            "https://docs.cdp.coinbase.com/wallet-api/docs/networks"
+        ),
     )
     wallet_seed_file: str = Field(
         default=DEFAULT_WALLET_SEED_FILE,
@@ -149,7 +154,11 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
 
     def _load_wallet_from_seed_file(self) -> Optional[Wallet]:
         """
-        Load wallet from saved seed file.
+        Load wallet from saved seed file using Wallet.import_data.
+
+        This method properly restores the wallet with signing capabilities
+        by using WalletData, which handles cases where the wallet may have
+        been deleted from the server.
 
         Returns
         -------
@@ -161,54 +170,138 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
                 return None
 
             with open(self.wallet_seed_file, "r") as f:
-                wallet_data = json.load(f)
+                saved_data = json.load(f)
 
-            wallet_id = wallet_data.get("wallet_id")
-            seed = wallet_data.get("seed")
+            wallet_id = saved_data.get("wallet_id")
+            seed = saved_data.get("seed")
+            network_id = saved_data.get("network_id")
 
-            if not wallet_id:
-                logging.warning("Wallet seed file exists but missing wallet_id")
+            if not wallet_id or not seed:
+                logging.warning(
+                    "Wallet seed file exists but missing wallet_id or seed"
+                )
                 return None
 
-            wallet = Wallet.fetch(wallet_id)
+            # Use WalletData to properly restore wallet with signing capabilities
+            wallet_data = WalletData(
+                wallet_id=wallet_id,
+                seed=seed,
+                network_id=network_id,
+            )
 
-            # Load seed for signing capabilities
-            if seed:
-                wallet.load_seed(self.wallet_seed_file)
-                logging.info(f"Loaded wallet with signing capabilities: {wallet.id}")
-            else:
-                logging.info(f"Loaded wallet (view-only): {wallet.id}")
+            try:
+                # import_data handles wallet restoration properly
+                wallet = Wallet.import_data(wallet_data)
+                logging.info(
+                    f"Loaded wallet with signing capabilities: {wallet.id}"
+                )
+                return wallet
+            except Exception as fetch_error:
+                # Wallet may have been deleted from server
+                # Try to recreate with the same seed to preserve the address
+                logging.warning(
+                    f"Wallet {wallet_id} not found on server, attempting to recreate: {fetch_error}"
+                )
+                return self._recreate_wallet_from_seed(seed, network_id)
 
-            return wallet
+        except json.JSONDecodeError as e:
+            logging.warning(f"Wallet seed file is malformed: {e}")
+            return None
         except Exception as e:
             logging.warning(f"Could not load wallet from seed file: {e}")
             return None
 
-    def _load_wallet_seed(self, wallet: Wallet) -> None:
+    def _recreate_wallet_from_seed(self, seed: str, network_id: Optional[str]) -> Optional[Wallet]:
+        """
+        Recreate a wallet from seed when the original wallet was deleted.
+
+        This preserves the wallet addresses derived from the seed.
+
+        Parameters
+        ----------
+        seed : str
+            The wallet seed hex string.
+        network_id : Optional[str]
+            The network ID for the wallet.
+
+        Returns
+        -------
+        Optional[Wallet]
+            The recreated wallet, or None if recreation failed.
+        """
+        try:
+            target_network = network_id or self.network_id
+            logging.info(f"Recreating wallet on network: {target_network}")
+
+            # Create new wallet with the existing seed
+            wallet = Wallet.create_with_seed(
+                seed=seed,
+                network_id=target_network,
+            )
+
+            # Update saved data with new wallet ID
+            self._save_wallet_seed(wallet)
+
+            logging.info(
+                f"Wallet recreated with new ID: {wallet.id}, "
+                f"preserving original addresses"
+            )
+            return wallet
+        except Exception as e:
+            logging.error(f"Failed to recreate wallet from seed: {e}")
+            return None
+
+    def _load_wallet_seed(self, wallet: Wallet) -> bool:
         """
         Attempt to load seed for an existing wallet to enable signing.
+
+        Uses load_seed_from_file (the non-deprecated API) to restore
+        signing capabilities for a fetched wallet.
 
         Parameters
         ----------
         wallet : Wallet
             The wallet to load seed for.
+
+        Returns
+        -------
+        bool
+            True if seed was loaded successfully, False otherwise.
         """
         try:
-            if os.path.exists(self.wallet_seed_file):
-                with open(self.wallet_seed_file, "r") as f:
-                    wallet_data = json.load(f)
+            if not os.path.exists(self.wallet_seed_file):
+                return False
 
-                if wallet_data.get("wallet_id") == wallet.id and wallet_data.get(
-                    "seed"
-                ):
-                    wallet.load_seed(self.wallet_seed_file)
-                    logging.info(f"Loaded seed for wallet: {wallet.id}")
+            with open(self.wallet_seed_file, "r") as f:
+                saved_data = json.load(f)
+
+            if saved_data.get("wallet_id") != wallet.id:
+                logging.debug(
+                    f"Seed file wallet ID ({saved_data.get('wallet_id')}) "
+                    f"does not match current wallet ({wallet.id})"
+                )
+                return False
+
+            if not saved_data.get("seed"):
+                logging.debug("Seed file exists but seed is empty")
+                return False
+
+            # Use the non-deprecated API
+            wallet.load_seed_from_file(self.wallet_seed_file)
+            logging.info(f"Loaded seed for wallet: {wallet.id}")
+            return True
+
         except Exception as e:
             logging.debug(f"Could not load seed for wallet: {e}")
+            return False
 
     def _create_new_wallet(self) -> Optional[Wallet]:
         """
         Create a new wallet and save its seed for future use.
+
+        If seed saving fails, the wallet is still returned but a critical
+        warning is logged. The wallet ID is set in the environment so the
+        current session can continue working.
 
         Returns
         -------
@@ -220,12 +313,18 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
             wallet = Wallet.create(network_id=self.network_id)
 
             # Save wallet data for future use
-            self._save_wallet_seed(wallet)
+            seed_saved = self._save_wallet_seed(wallet)
 
             logging.info(f"Created new wallet: {wallet.id}")
             logging.info(
                 f"Default address: {wallet.default_address.address_id if wallet.default_address else 'N/A'}"
             )
+
+            if not seed_saved:
+                logging.warning(
+                    f"Wallet {wallet.id} created but seed was not persisted. "
+                    f"This wallet may not be recoverable after restart."
+                )
 
             # Set environment variable for current session
             os.environ["COINBASE_WALLET_ID"] = wallet.id
@@ -235,19 +334,30 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
             logging.error(f"Failed to create new wallet: {e}")
             return None
 
-    def _save_wallet_seed(self, wallet: Wallet) -> None:
+    def _save_wallet_seed(self, wallet: Wallet) -> bool:
         """
         Save wallet seed to file for future use.
+
+        The seed file is saved with restrictive permissions (0600) for security.
+        If saving fails, a warning is logged with the wallet ID so users can
+        manually save it.
 
         Parameters
         ----------
         wallet : Wallet
             The wallet to save.
+
+        Returns
+        -------
+        bool
+            True if seed was saved successfully, False otherwise.
         """
         try:
             # Ensure directory exists
+            # Note: os.path.dirname returns empty string for files in current directory,
+            # which is acceptable since current directory always exists
             seed_dir = os.path.dirname(self.wallet_seed_file)
-            if seed_dir:
+            if seed_dir:  # Only create if there's a directory component
                 Path(seed_dir).mkdir(parents=True, exist_ok=True)
 
             # Export and save wallet data
@@ -265,8 +375,16 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
             os.chmod(self.wallet_seed_file, 0o600)
 
             logging.info(f"Wallet seed saved to: {self.wallet_seed_file}")
+            return True
+
         except Exception as e:
-            logging.error(f"Failed to save wallet seed: {e}")
+            # Log critical warning with wallet ID so user can manually save
+            logging.error(
+                f"CRITICAL: Failed to save wallet seed for wallet {wallet.id}: {e}. "
+                f"Please manually save this wallet ID to avoid losing access. "
+                f"Set COINBASE_WALLET_ID={wallet.id} in your environment."
+            )
+            return False
 
     async def _poll(self) -> List[float]:
         """

--- a/tests/inputs/plugins/test_wallet_coinbase.py
+++ b/tests/inputs/plugins/test_wallet_coinbase.py
@@ -1,4 +1,6 @@
+import json
 import os
+import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -292,3 +294,333 @@ def test_formatted_latest_buffer_with_empty_buffer():
 
     result = wallet.formatted_latest_buffer()
     assert result is None
+
+
+# =============================================================================
+# Tests for wallet auto-creation and seed persistence (new functionality)
+# =============================================================================
+
+
+def test_create_wallet_when_no_wallet_id_set():
+    """Should create new wallet when COINBASE_WALLET_ID is not set."""
+    mock_wallet = MagicMock()
+    mock_wallet.id = "new-wallet-id"
+    mock_wallet.balance.return_value = "0.0"
+    mock_wallet.default_address = MagicMock()
+    mock_wallet.default_address.address_id = "0x1234"
+
+    mock_wallet_data = MagicMock()
+    mock_wallet_data.wallet_id = "new-wallet-id"
+    mock_wallet_data.seed = "abc123seed"
+    mock_wallet_data.network_id = "base-sepolia"
+    mock_wallet.export_data.return_value = mock_wallet_data
+
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.create",
+                return_value=mock_wallet,
+            ),
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            assert wallet.wallet == mock_wallet
+            assert wallet.COINBASE_WALLET_ID == "new-wallet-id"
+
+            # Verify seed file was created
+            assert os.path.exists(temp_file)
+
+            with open(temp_file, "r") as f:
+                saved_data = json.load(f)
+            assert saved_data["wallet_id"] == "new-wallet-id"
+            assert saved_data["seed"] == "abc123seed"
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_load_wallet_from_seed_file():
+    """Should load wallet from saved seed file using import_data."""
+    mock_wallet = MagicMock()
+    mock_wallet.id = "saved-wallet-id"
+    mock_wallet.balance.return_value = "5.0"
+
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(
+            {
+                "wallet_id": "saved-wallet-id",
+                "seed": "saved-seed-hex",
+                "network_id": "base-sepolia",
+            },
+            f,
+        )
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.import_data",
+                return_value=mock_wallet,
+            ) as mock_import,
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            assert wallet.wallet == mock_wallet
+            mock_import.assert_called_once()
+
+
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_load_wallet_with_malformed_seed_file():
+    """Should handle malformed seed file gracefully."""
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write("not valid json {{{")
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        mock_new_wallet = MagicMock()
+        mock_new_wallet.id = "new-wallet-id"
+        mock_new_wallet.balance.return_value = "0.0"
+        mock_new_wallet.default_address = MagicMock()
+        mock_new_wallet.default_address.address_id = "0x5678"
+
+        mock_wallet_data = MagicMock()
+        mock_wallet_data.wallet_id = "new-wallet-id"
+        mock_wallet_data.seed = "new-seed"
+        mock_wallet_data.network_id = "base-sepolia"
+        mock_new_wallet.export_data.return_value = mock_wallet_data
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.create",
+                return_value=mock_new_wallet,
+            ),
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            # Should create new wallet when seed file is malformed
+            assert wallet.wallet == mock_new_wallet
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_recreate_wallet_when_deleted_from_server():
+    """Should recreate wallet from seed when original was deleted from server."""
+    mock_recreated_wallet = MagicMock()
+    mock_recreated_wallet.id = "recreated-wallet-id"
+    mock_recreated_wallet.balance.return_value = "0.0"
+    mock_recreated_wallet.default_address = MagicMock()
+    mock_recreated_wallet.default_address.address_id = "0x1234"
+
+    mock_wallet_data = MagicMock()
+    mock_wallet_data.wallet_id = "recreated-wallet-id"
+    mock_wallet_data.seed = "original-seed"
+    mock_wallet_data.network_id = "base-sepolia"
+    mock_recreated_wallet.export_data.return_value = mock_wallet_data
+
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(
+            {
+                "wallet_id": "deleted-wallet-id",
+                "seed": "original-seed",
+                "network_id": "base-sepolia",
+            },
+            f,
+        )
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.import_data",
+                side_effect=Exception("Wallet not found on server"),
+            ),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.create_with_seed",
+                return_value=mock_recreated_wallet,
+            ) as mock_create_with_seed,
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            # Should have recreated wallet with original seed
+            assert wallet.wallet == mock_recreated_wallet
+            mock_create_with_seed.assert_called_once_with(
+                seed="original-seed",
+                network_id="base-sepolia",
+            )
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_env_wallet_id_takes_priority_over_seed_file():
+    """Environment variable COINBASE_WALLET_ID should take priority."""
+    mock_env_wallet = MagicMock()
+    mock_env_wallet.id = "env-wallet-id"
+    mock_env_wallet.balance.return_value = "10.0"
+
+    env = {
+        "COINBASE_WALLET_ID": "env-wallet-id",
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(
+            {
+                "wallet_id": "file-wallet-id",
+                "seed": "file-seed",
+                "network_id": "base-sepolia",
+            },
+            f,
+        )
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.fetch",
+                return_value=mock_env_wallet,
+            ) as mock_fetch,
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            # Should use wallet from env, not from file
+            assert wallet.wallet == mock_env_wallet
+            mock_fetch.assert_called_with("env-wallet-id")
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_seed_file_missing_wallet_id():
+    """Should handle seed file with missing wallet_id."""
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"seed": "seed-only-no-id"}, f)
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(wallet_seed_file=temp_file)
+
+        mock_new_wallet = MagicMock()
+        mock_new_wallet.id = "new-wallet-id"
+        mock_new_wallet.balance.return_value = "0.0"
+        mock_new_wallet.default_address = MagicMock()
+
+        mock_wallet_data = MagicMock()
+        mock_wallet_data.wallet_id = "new-wallet-id"
+        mock_wallet_data.seed = "new-seed"
+        mock_wallet_data.network_id = "base-sepolia"
+        mock_new_wallet.export_data.return_value = mock_wallet_data
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.create",
+                return_value=mock_new_wallet,
+            ),
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            # Should create new wallet since file is missing wallet_id
+            assert wallet.wallet == mock_new_wallet
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)
+
+
+def test_custom_network_id_config():
+    """Should use custom network_id from config."""
+    mock_wallet = MagicMock()
+    mock_wallet.id = "mainnet-wallet"
+    mock_wallet.balance.return_value = "100.0"
+    mock_wallet.default_address = MagicMock()
+
+    mock_wallet_data = MagicMock()
+    mock_wallet_data.wallet_id = "mainnet-wallet"
+    mock_wallet_data.seed = "mainnet-seed"
+    mock_wallet_data.network_id = "base-mainnet"
+    mock_wallet.export_data.return_value = mock_wallet_data
+
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        temp_file = f.name
+
+    try:
+        config = WalletCoinbaseConfig(
+            network_id="base-mainnet",
+            wallet_seed_file=temp_file,
+        )
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("inputs.plugins.wallet_coinbase.Cdp.configure"),
+            patch(
+                "inputs.plugins.wallet_coinbase.Wallet.create",
+                return_value=mock_wallet,
+            ) as mock_create,
+        ):
+            wallet = WalletCoinbase(config=config)
+
+            mock_create.assert_called_with(network_id="base-mainnet")
+            assert wallet.network_id == "base-mainnet"
+    finally:
+        if os.path.exists(temp_file):
+            os.unlink(temp_file)


### PR DESCRIPTION
## Problem
Resolves TODO(Kyle) in `src/inputs/plugins/wallet_coinbase.py`:
> TODO(Kyle): Create Wallet if the wallet ID is not found

Currently, users must manually create a Coinbase wallet and set `COINBASE_WALLET_ID` environment variable before using the wallet integration. This creates friction for new users.

## Solution
Implement automatic wallet creation with persistence:

1. **Priority-based wallet retrieval:**
   - First try `COINBASE_WALLET_ID` environment variable
   - Then try loading from saved seed file
   - Finally, create new wallet and save seed

2. **Wallet persistence:**
   - Save wallet seed to `~/.om1/coinbase_wallet_seed.json`
   - Secure file permissions (0600)
   - Enables signing capabilities on subsequent runs

3. **New configuration options:**
   - `network_id`: Configure target network (default: base-sepolia)
   - `wallet_seed_file`: Custom path for seed storage

## Testing
- Verified syntax with `python -m py_compile`
- Manual testing with CDP SDK

## Security Considerations
- Wallet seed file has restrictive permissions (owner-only)
- Seed is required for signing transactions