### PR TITLE
docs: fix typos, add 401 status code, and Windows installation instructions

### DIFF
--- a/docs/api-reference/endpoints/llm.mdx
+++ b/docs/api-reference/endpoints/llm.mdx
@@ -498,9 +498,10 @@ curl -X POST https://api.openmind.org/api/core/openai/chat/completions \
 |------|-------------|
 | 200 | Success - Completion generated successfully |
 | 400 | Bad Request - Invalid JSON or malformed request |
+| 401 | Unauthorized - Missing or invalid API key |
 | 404 | Not Found - Unsupported provider or model |
-| 503 | Service Unavailable - Provider API unavailable or not configured |
 | 500 | Internal Server Error - Server-side processing error |
+| 503 | Service Unavailable - Provider API unavailable or not configured |
 
 ### Error Response Format
 

--- a/docs/developing/1_get-started.mdx
+++ b/docs/developing/1_get-started.mdx
@@ -9,6 +9,7 @@ description: "Learn how to install, set up and configure OM1."
 
 - Linux (Ubuntu 20, 22, 24)
 - MacOS 12.0+
+- Windows 10/11 (experimental)
 
 ### Hardware
 
@@ -36,6 +37,9 @@ brew install uv
 
 # Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 #### PortAudio Library
@@ -49,6 +53,12 @@ brew install portaudio
 # Linux
 sudo apt-get update
 sudo apt-get install portaudio19-dev
+
+# Windows (using Chocolatey)
+choco install portaudio
+
+# Windows (using vcpkg)
+vcpkg install portaudio
 ```
 
 #### Install python3-dev
@@ -70,6 +80,12 @@ brew install ffmpeg
 # Linux
 sudo apt-get update
 sudo apt-get install ffmpeg
+
+# Windows (using Chocolatey)
+choco install ffmpeg
+
+# Windows (using winget)
+winget install ffmpeg
 ```
 ## CLI
 

--- a/docs/robotics/motion_planning_turtlebot4.mdx
+++ b/docs/robotics/motion_planning_turtlebot4.mdx
@@ -38,7 +38,7 @@ Immediately after a frontal (or side) collision, the TB4 will back off about 10c
 
 2. TB4 Enhanced Collision Avoidance
 
-Beyond the immediate 10cm rewards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
+Beyond the immediate 10cm backwards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
 
 ```py
 # /actions/move_turtle/connector/zenoh.py

--- a/mintlify/api-reference/endpoints/llm.mdx
+++ b/mintlify/api-reference/endpoints/llm.mdx
@@ -498,9 +498,10 @@ curl -X POST https://api.openmind.org/api/core/openai/chat/completions \
 |------|-------------|
 | 200 | Success - Completion generated successfully |
 | 400 | Bad Request - Invalid JSON or malformed request |
+| 401 | Unauthorized - Missing or invalid API key |
 | 404 | Not Found - Unsupported provider or model |
-| 503 | Service Unavailable - Provider API unavailable or not configured |
 | 500 | Internal Server Error - Server-side processing error |
+| 503 | Service Unavailable - Provider API unavailable or not configured |
 
 ### Error Response Format
 

--- a/mintlify/developing/1_get-started.mdx
+++ b/mintlify/developing/1_get-started.mdx
@@ -9,6 +9,7 @@ description: "Learn how to install, set up and configure OM1."
 
 - Linux (Ubuntu 20, 22, 24)
 - MacOS 12.0+
+- Windows 10/11 (experimental)
 
 ### Hardware
 
@@ -36,6 +37,9 @@ brew install uv
 
 # Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 #### PortAudio Library
@@ -49,6 +53,12 @@ brew install portaudio
 # Linux
 sudo apt-get update
 sudo apt-get install portaudio19-dev
+
+# Windows (using Chocolatey)
+choco install portaudio
+
+# Windows (using vcpkg)
+vcpkg install portaudio
 ```
 
 #### Install python3-dev
@@ -70,6 +80,12 @@ brew install ffmpeg
 # Linux
 sudo apt-get update
 sudo apt-get install ffmpeg
+
+# Windows (using Chocolatey)
+choco install ffmpeg
+
+# Windows (using winget)
+winget install ffmpeg
 ```
 ## CLI
 

--- a/mintlify/robotics/motion_planning_turtlebot4.mdx
+++ b/mintlify/robotics/motion_planning_turtlebot4.mdx
@@ -38,7 +38,7 @@ Immediately after a frontal (or side) collision, the TB4 will back off about 10c
 
 2. TB4 Enhanced Collision Avoidance
 
-Beyond the immediate 10cm rewards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
+Beyond the immediate 10cm backwards motion, OM1 uses the TB4's collision switches to invoke an enhanced object avoidance behavior, which consists of turning 100 deg left or right, depending on which switch of several side or frontal collision switches were triggered. This "turning to face away" from the object is handled directly inside the `action` driver to ensure prompt responses to physical collisions:
 
 ```py
 # /actions/move_turtle/connector/zenoh.py


### PR DESCRIPTION
## Summary

This PR addresses multiple documentation issues identified in a comprehensive audit.

## Changes

### 1. Fix Typo in TurtleBot4 Docs
- **Location**: \obotics/motion_planning_turtlebot4.mdx\`n- **Fix**: Changed 'rewards' to 'backwards' in collision avoidance section
- **Fixes**: #2123

### 2. Add Missing HTTP 401 Status Code
- **Location**: \pi-reference/endpoints/llm.mdx\`n- **Fix**: Added 401 Unauthorized to the HTTP status codes table
- **Fixes**: #2125

### 3. Add Windows Installation Instructions
- **Location**: \developing/1_get-started.mdx\`n- **Fix**: Added Windows 10/11 as supported OS (experimental) and installation commands for uv, portaudio, and ffmpeg using Chocolatey/winget/vcpkg
- **Fixes**: #2124

## Full Audit Report

See complete audit with 22 issues found: https://gist.github.com/giwaov/58887474b474753f2508267d0fb047fd

## Testing

- [x] Verified changes in both \/docs\ and \/mintlify\ directories
- [x] No breaking changes to existing documentation

---
**Reporter**: @giwaov | Discord: 0xgiwa | Twitter: @0xgiwa