### PR TITLE
test(actions): add unit tests for gps action

### DIFF
--- a/tests/actions/gps/connector/test_fabric.py
+++ b/tests/actions/gps/connector/test_fabric.py
@@ -1,15 +1,7 @@
-"""Tests for the GPS Fabric connector."""
-
-import sys
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-
-# Mock modules at module load time BEFORE any other imports
-mock_zenoh = MagicMock()
-mock_zenoh_msgs = MagicMock()
-sys.modules["zenoh"] = mock_zenoh
-sys.modules["zenoh_msgs"] = mock_zenoh_msgs
+import requests as req
 
 from actions.gps.connector.fabric import (  # noqa: E402
     GPSFabricConfig,
@@ -42,12 +34,17 @@ def gps_input_idle():
     return GPSInput(action=GPSAction.IDLE)
 
 
-@pytest.fixture(autouse=True)
-def reset_mocks():
-    """Reset all mock objects between tests."""
-    mock_zenoh.reset_mock()
-    mock_zenoh_msgs.reset_mock()
-    yield
+@pytest.fixture(scope="session", autouse=True)
+def mock_zenoh_modules():
+    """Mock zenoh modules before imports."""
+    with patch.dict(
+        "sys.modules",
+        {
+            "zenoh": MagicMock(),
+            "zenoh_msgs": MagicMock(),
+        },
+    ):
+        yield
 
 
 class TestGPSFabricConfig:
@@ -67,121 +64,115 @@ class TestGPSFabricConfig:
 class TestGPSFabricConnector:
     """Test the GPS Fabric connector."""
 
-    @patch("actions.gps.connector.fabric.IOProvider")
-    def test_init(self, mock_io_provider_class, default_config):
+    def test_init(self, default_config):
         """Test initialization of GPSFabricConnector."""
-        mock_io_instance = Mock()
-        mock_io_provider_class.return_value = mock_io_instance
+        with patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class:
+            mock_io_instance = Mock()
+            mock_io_provider_class.return_value = mock_io_instance
 
-        connector = GPSFabricConnector(default_config)
+            connector = GPSFabricConnector(default_config)
 
-        mock_io_provider_class.assert_called_once()
-        assert connector.io_provider is not None
-        assert connector.fabric_endpoint == "http://localhost:8545"
+            mock_io_provider_class.assert_called_once()
+            assert connector.io_provider is not None
+            assert connector.fabric_endpoint == "http://localhost:8545"
 
-    @patch("actions.gps.connector.fabric.IOProvider")
-    def test_init_with_custom_config(self, mock_io_provider_class, custom_config):
+    def test_init_with_custom_config(self, custom_config):
         """Test initialization with custom configuration."""
-        mock_io_instance = Mock()
-        mock_io_provider_class.return_value = mock_io_instance
+        with patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class:
+            mock_io_instance = Mock()
+            mock_io_provider_class.return_value = mock_io_instance
 
-        connector = GPSFabricConnector(custom_config)
+            connector = GPSFabricConnector(custom_config)
 
-        assert connector.fabric_endpoint == "http://custom:8080"
+            assert connector.fabric_endpoint == "http://custom:8080"
 
     @pytest.mark.asyncio
-    @patch("actions.gps.connector.fabric.IOProvider")
-    async def test_connect_share_location(
-        self, mock_io_provider_class, default_config, gps_input_share
-    ):
+    async def test_connect_share_location(self, default_config, gps_input_share):
         """Test connect with share location action."""
-        mock_io_instance = Mock()
-        mock_io_provider_class.return_value = mock_io_instance
+        with patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class:
+            mock_io_instance = Mock()
+            mock_io_provider_class.return_value = mock_io_instance
 
-        connector = GPSFabricConnector(default_config)
+            connector = GPSFabricConnector(default_config)
 
-        with patch.object(connector, "send_coordinates") as mock_send:
-            await connector.connect(gps_input_share)
-            mock_send.assert_called_once()
+            with patch.object(connector, "send_coordinates") as mock_send:
+                await connector.connect(gps_input_share)
+                mock_send.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("actions.gps.connector.fabric.IOProvider")
-    async def test_connect_idle(
-        self, mock_io_provider_class, default_config, gps_input_idle
-    ):
+    async def test_connect_idle(self, default_config, gps_input_idle):
         """Test connect with idle action does not send coordinates."""
-        mock_io_instance = Mock()
-        mock_io_provider_class.return_value = mock_io_instance
+        with patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class:
+            mock_io_instance = Mock()
+            mock_io_provider_class.return_value = mock_io_instance
 
-        connector = GPSFabricConnector(default_config)
+            connector = GPSFabricConnector(default_config)
 
-        with patch.object(connector, "send_coordinates") as mock_send:
-            await connector.connect(gps_input_idle)
-            mock_send.assert_not_called()
+            with patch.object(connector, "send_coordinates") as mock_send:
+                await connector.connect(gps_input_idle)
+                mock_send.assert_not_called()
 
-    @patch("actions.gps.connector.fabric.requests")
-    @patch("actions.gps.connector.fabric.IOProvider")
-    def test_send_coordinates_success(
-        self, mock_io_provider_class, mock_requests, default_config
-    ):
+    def test_send_coordinates_success(self, default_config):
         """Test send_coordinates with successful response."""
-        mock_io_instance = Mock()
-        mock_io_instance.get_dynamic_variable.side_effect = lambda x: {
-            "latitude": 37.7749,
-            "longitude": -122.4194,
-            "yaw_deg": 90.0,
-        }.get(x)
-        mock_io_provider_class.return_value = mock_io_instance
+        with (
+            patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class,
+            patch("actions.gps.connector.fabric.requests") as mock_requests,
+        ):
+            mock_io_instance = Mock()
+            mock_io_instance.get_dynamic_variable.side_effect = lambda x: {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "yaw_deg": 90.0,
+            }.get(x)
+            mock_io_provider_class.return_value = mock_io_instance
 
-        mock_response = Mock()
-        mock_response.json.return_value = {"result": True}
-        mock_requests.post.return_value = mock_response
+            mock_response = Mock()
+            mock_response.json.return_value = {"result": True}
+            mock_requests.post.return_value = mock_response
 
-        connector = GPSFabricConnector(default_config)
-        connector.send_coordinates()
+            connector = GPSFabricConnector(default_config)
+            connector.send_coordinates()
 
-        mock_requests.post.assert_called_once()
-        call_args = mock_requests.post.call_args
-        assert call_args[0][0] == "http://localhost:8545"
-        assert call_args[1]["json"]["method"] == "omp2p_shareStatus"
+            mock_requests.post.assert_called_once()
+            call_args = mock_requests.post.call_args
+            assert call_args[0][0] == "http://localhost:8545"
+            assert call_args[1]["json"]["method"] == "omp2p_shareStatus"
 
-    @patch("actions.gps.connector.fabric.requests")
-    @patch("actions.gps.connector.fabric.IOProvider")
-    def test_send_coordinates_no_coordinates(
-        self, mock_io_provider_class, mock_requests, default_config
-    ):
+    def test_send_coordinates_no_coordinates(self, default_config):
         """Test send_coordinates when no coordinates available."""
-        mock_io_instance = Mock()
-        mock_io_instance.get_dynamic_variable.return_value = None
-        mock_io_provider_class.return_value = mock_io_instance
+        with (
+            patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class,
+            patch("actions.gps.connector.fabric.requests") as mock_requests,
+        ):
+            mock_io_instance = Mock()
+            mock_io_instance.get_dynamic_variable.return_value = None
+            mock_io_provider_class.return_value = mock_io_instance
 
-        connector = GPSFabricConnector(default_config)
-        result = connector.send_coordinates()
+            connector = GPSFabricConnector(default_config)
+            result = connector.send_coordinates()
 
-        assert result is None
-        mock_requests.post.assert_not_called()
+            assert result is None
+            mock_requests.post.assert_not_called()
 
-    @patch("actions.gps.connector.fabric.requests")
-    @patch("actions.gps.connector.fabric.IOProvider")
-    def test_send_coordinates_request_failure(
-        self, mock_io_provider_class, mock_requests, default_config
-    ):
+    def test_send_coordinates_request_failure(self, default_config):
         """Test send_coordinates handles request exception."""
-        import requests as req
+        with (
+            patch("actions.gps.connector.fabric.IOProvider") as mock_io_provider_class,
+            patch("actions.gps.connector.fabric.requests") as mock_requests,
+        ):
+            mock_io_instance = Mock()
+            mock_io_instance.get_dynamic_variable.side_effect = lambda x: {
+                "latitude": 37.7749,
+                "longitude": -122.4194,
+                "yaw_deg": 90.0,
+            }.get(x)
+            mock_io_provider_class.return_value = mock_io_instance
 
-        mock_io_instance = Mock()
-        mock_io_instance.get_dynamic_variable.side_effect = lambda x: {
-            "latitude": 37.7749,
-            "longitude": -122.4194,
-            "yaw_deg": 90.0,
-        }.get(x)
-        mock_io_provider_class.return_value = mock_io_instance
+            mock_requests.post.side_effect = req.RequestException("Connection error")
+            mock_requests.RequestException = req.RequestException
 
-        mock_requests.post.side_effect = req.RequestException("Connection error")
-        mock_requests.RequestException = req.RequestException
+            connector = GPSFabricConnector(default_config)
+            # Should not raise exception
+            connector.send_coordinates()
 
-        connector = GPSFabricConnector(default_config)
-        # Should not raise exception
-        connector.send_coordinates()
-
-        mock_requests.post.assert_called_once()
+            mock_requests.post.assert_called_once()

--- a/tests/actions/gps/test_interface.py
+++ b/tests/actions/gps/test_interface.py
@@ -1,5 +1,3 @@
-"""Tests for the GPS action interface."""
-
 from actions.gps.interface import GPS, GPSAction, GPSInput
 
 


### PR DESCRIPTION
## Summary

Added comprehensive unit tests for the GPS action module which previously had no test coverage.

## Changes

- `tests/actions/gps/test_interface.py`: Tests for GPSAction enum, GPSInput dataclass, and GPS interface
- `tests/actions/gps/connector/test_fabric.py`: Tests for GPSFabricConfig and GPSFabricConnector

## Test Coverage

- GPSAction enum values and type validation (2 actions: share_location, idle)
- GPSInput creation with all action types
- GPS interface with input/output handling
- GPSFabricConfig default and custom values
- GPSFabricConnector initialization
- Connect behavior for share location vs idle actions
- send_coordinates success, no coordinates, and request failure cases

## Testing

- All 16 tests pass
- Pre-commit checks pass
- Ruff linting passes

## Notes

- Follows existing test patterns (no `__init__.py` files in test directories)
- Uses proper module mocking for external dependencies