### PR TITLE
fix: resolve timestamp type inconsistencies in TeleOps dataclasses

### DIFF
--- a/src/providers/teleops_status_provider.py
+++ b/src/providers/teleops_status_provider.py
@@ -67,7 +67,7 @@ class CommandStatus:
     vx: float
     vy: float
     vyaw: float
-    timestamp: str
+    timestamp: float
 
     def to_dict(self) -> dict:
         """
@@ -194,7 +194,7 @@ class TeleopsStatus:
             Dictionary containing teleops status information.
         """
         return cls(
-            update_time=data.get("update_time", time.time()),
+            update_time=data.get("update_time", str(time.time())),
             battery_status=BatteryStatus.from_dict(data.get("battery_status", {})),
             action_status=ActionStatus.from_dict(data.get("action_status", {})),
             machine_name=data.get("machine_name", "unknown"),

--- a/tests/providers/test_teleops_status_provider.py
+++ b/tests/providers/test_teleops_status_provider.py
@@ -96,36 +96,45 @@ def test_battery_status_from_dict_with_defaults():
 
 def test_command_status_creation():
     """Test CommandStatus creation."""
-    command = CommandStatus(vx=1.5, vy=0.5, vyaw=0.2, timestamp="2024-01-01T00:00:00")
+    command = CommandStatus(vx=1.5, vy=0.5, vyaw=0.2, timestamp=1704067200.0)
 
     assert command.vx == 1.5
     assert command.vy == 0.5
     assert command.vyaw == 0.2
-    assert command.timestamp == "2024-01-01T00:00:00"
+    assert command.timestamp == 1704067200.0
 
 
 def test_command_status_to_dict():
     """Test CommandStatus to_dict conversion."""
-    command = CommandStatus(vx=1.0, vy=0.0, vyaw=0.5, timestamp="2024-01-01T00:00:00")
+    command = CommandStatus(vx=1.0, vy=0.0, vyaw=0.5, timestamp=1704067200.0)
 
     result = command.to_dict()
 
     assert result["vx"] == 1.0
     assert result["vy"] == 0.0
     assert result["vyaw"] == 0.5
-    assert result["timestamp"] == "2024-01-01T00:00:00"
+    assert result["timestamp"] == 1704067200.0
 
 
 def test_command_status_from_dict():
     """Test CommandStatus from_dict creation."""
-    data = {"vx": 2.0, "vy": 1.0, "vyaw": 0.3, "timestamp": "2024-01-01T12:00:00"}
+    data = {"vx": 2.0, "vy": 1.0, "vyaw": 0.3, "timestamp": 1704110400.0}
 
     command = CommandStatus.from_dict(data)
 
     assert command.vx == 2.0
     assert command.vy == 1.0
     assert command.vyaw == 0.3
-    assert command.timestamp == "2024-01-01T12:00:00"
+    assert command.timestamp == 1704110400.0
+
+
+def test_command_status_from_dict_with_defaults():
+    """Test CommandStatus from_dict default timestamp is a float."""
+    data = {"vx": 1.0, "vy": 0.0, "vyaw": 0.0}
+
+    command = CommandStatus.from_dict(data)
+
+    assert isinstance(command.timestamp, float)
 
 
 def test_action_type_enum():
@@ -240,6 +249,24 @@ def test_teleops_status_from_dict():
     assert status.video_connected is True
     assert status.battery_status.battery_level == 90.0
     assert status.action_status.action == ActionType.TELEOPS
+
+
+def test_teleops_status_from_dict_with_defaults():
+    """Test TeleopsStatus from_dict default update_time is a string."""
+    data = {
+        "battery_status": {
+            "battery_level": 50.0,
+            "temperature": 22.0,
+            "voltage": 11.0,
+            "timestamp": "1704067200.0",
+        },
+    }
+
+    status = TeleopsStatus.from_dict(data)
+
+    assert isinstance(status.update_time, str)
+    assert status.machine_name == "unknown"
+    assert status.video_connected is False
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #1895

This PR resolves the type annotation mismatches across TeleOps-related dataclasses in `src/providers/teleops_status_provider.py`. Two distinct inconsistencies existed:

### 1. `CommandStatus.timestamp`: annotation `str`, actual usage `float`

Every producer and consumer of `CommandStatus.timestamp` treats it as a float:

- **Keyboard controller** (`system_hw_test/om_keyboard_remote_control.py`) passes `time.time()` directly — a float.
- **`from_dict` default** falls back to `time.time()` — a float.
- **Action connectors** (`move_turtle/connector/zenoh_remote.py`, `move_go2_teleops/connector/remote.py`) compute latency as `time.time() - float(command_status.timestamp)`.
- **JSON round-trip**: `json.loads` naturally deserializes numbers as floats, so timestamps arriving over WebSocket are already floats.

The `str` annotation was simply wrong. This PR changes it to `float` to match `ActionStatus.timestamp`, which was already correctly annotated.

### 2. `TeleopsStatus.from_dict` default for `update_time`: returns `float`, annotation expects `str`

The `update_time` field is annotated as `str`, and every caller passes `str(time.time())`:

- `unitree_g1_basic.py`, `battery_unitree_go2.py`, `battery_turtlebot4.py` all pass `str(time.time())`
- `agent_teleops_status.py` stores `str(time.time())` in a variable first

But `from_dict` used a bare `time.time()` as the fallback — returning a float where a string was expected. This PR wraps it with `str()` to match the annotation and existing usage.

## Changes

- **`src/providers/teleops_status_provider.py`**:
  - `CommandStatus.timestamp`: `str` → `float`
  - `TeleopsStatus.from_dict`: `time.time()` → `str(time.time())` for the `update_time` default

- **`tests/providers/test_teleops_status_provider.py`**:
  - Updated `CommandStatus` tests to use Unix timestamp floats instead of ISO date strings
  - Added `test_command_status_from_dict_with_defaults` — verifies the default timestamp is a `float`
  - Added `test_teleops_status_from_dict_with_defaults` — verifies the default `update_time` is a `str`

## Why not standardize everything to one type?

`BatteryStatus.timestamp` and `TeleopsStatus.update_time` are consistently used as strings throughout the codebase (every caller wraps with `str()`), while `CommandStatus.timestamp` and `ActionStatus.timestamp` are consistently used as floats. Forcing a single type would require changes across multiple input plugins, background tasks, and action connectors with no functional benefit. This PR respects each field's actual usage pattern and fixes only the mismatches.

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] `ruff format --check` passes (already formatted)
- [x] `pyright` passes (0 errors)
- [x] All existing + new tests validate correct types
- [x] Verified JSON round-trip preserves float timestamps for latency calculation