### PR TITLE
fix: watch source mode config files for multi-mode hot reload

### DIFF
--- a/src/runtime/multi_mode/cortex.py
+++ b/src/runtime/multi_mode/cortex.py
@@ -2,8 +2,9 @@ import asyncio
 import logging
 import os
 import time
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
+import json5
 from actions.orchestrator import ActionOrchestrator
 from backgrounds.orchestrator import BackgroundOrchestrator
 from fuser import Fuser
@@ -74,13 +75,16 @@ class ModeCortexRuntime:
         self.check_interval = check_interval
         self.config_watcher_task: Optional[asyncio.Task] = None
         self.last_modified: Optional[float] = None
+        self.config_path = self.mode_manager._get_runtime_config_path()
+        self.source_config_path = self._get_source_config_path()
+        self.watched_config_mtimes: Dict[str, float] = {}
 
         # Initialize hot-reload if enabled
         if self.hot_reload:
-            self.config_path = self.mode_manager._get_runtime_config_path()
-            self.last_modified = self._get_file_mtime()
+            self._refresh_watched_config_mtimes()
+            self.last_modified = self.watched_config_mtimes.get(self.config_path, 0.0)
             logging.info(
-                f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
+                f"Hot-reload enabled for {len(self.watched_config_mtimes)} config file(s) (check interval: {check_interval}s)"
             )
 
         # Current runtime components
@@ -607,17 +611,132 @@ class ModeCortexRuntime:
             for name, config in self.mode_config.modes.items()
         }
 
-    def _get_file_mtime(self) -> float:
+    def _get_source_config_path(self) -> str:
+        """
+        Resolve the source configuration path from mode_config_name.
+
+        Returns
+        -------
+        str
+            Absolute path to the mode-aware source configuration file.
+        """
+        config_name = self.mode_config_name
+        if not config_name.endswith((".json", ".json5")):
+            config_name = f"{config_name}.json5"
+
+        if os.path.isabs(config_name):
+            return os.path.normpath(config_name)
+
+        if os.path.exists(config_name):
+            return os.path.abspath(config_name)
+
+        return os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../../../config", config_name)
+        )
+
+    def _extract_config_references(self, config_file_path: str) -> Set[str]:
+        """
+        Parse a config file and return referenced .json/.json5 paths.
+
+        Parameters
+        ----------
+        config_file_path : str
+            Path to the config file to parse.
+
+        Returns
+        -------
+        Set[str]
+            Absolute referenced config paths discovered in the file.
+        """
+        if not os.path.exists(config_file_path):
+            return set()
+
+        try:
+            with open(config_file_path, "r") as f:
+                raw_config = json5.load(f)
+        except Exception as e:
+            logging.debug(
+                f"Unable to parse config references from '{config_file_path}': {e}"
+            )
+            return set()
+
+        base_dir = os.path.dirname(config_file_path)
+        references: Set[str] = set()
+
+        def walk(value: Any) -> None:
+            if isinstance(value, dict):
+                for nested in value.values():
+                    walk(nested)
+                return
+
+            if isinstance(value, list):
+                for nested in value:
+                    walk(nested)
+                return
+
+            if not isinstance(value, str):
+                return
+
+            candidate = value.strip()
+            if "://" in candidate:
+                return
+
+            if not candidate.lower().endswith((".json", ".json5")):
+                return
+
+            resolved = (
+                candidate
+                if os.path.isabs(candidate)
+                else os.path.abspath(os.path.join(base_dir, candidate))
+            )
+            references.add(os.path.normpath(resolved))
+
+        walk(raw_config)
+        references.discard(os.path.normpath(os.path.abspath(config_file_path)))
+        return references
+
+    def _get_watched_config_paths(self) -> Set[str]:
+        """
+        Build the set of config files to watch for hot-reload.
+
+        Returns
+        -------
+        Set[str]
+            Absolute config paths to monitor.
+        """
+        watched_paths = {os.path.normpath(os.path.abspath(self.config_path))}
+
+        source_path = os.path.normpath(os.path.abspath(self.source_config_path))
+        watched_paths.add(source_path)
+        watched_paths.update(self._extract_config_references(source_path))
+
+        return watched_paths
+
+    def _refresh_watched_config_mtimes(self) -> None:
+        """
+        Refresh the watched config file map and their mtimes.
+        """
+        self.watched_config_mtimes = {
+            path: self._get_file_mtime(path) for path in self._get_watched_config_paths()
+        }
+
+    def _get_file_mtime(self, file_path: Optional[str] = None) -> float:
         """
         Get the modification time of the config file.
+
+        Parameters
+        ----------
+        file_path : Optional[str]
+            Path to the file. Defaults to runtime config path.
 
         Returns
         -------
         float
             The modification time as a timestamp
         """
-        if self.config_path and os.path.exists(self.config_path):
-            return os.path.getmtime(self.config_path)
+        target_path = self.config_path if file_path is None else file_path
+        if target_path and os.path.exists(target_path):
+            return os.path.getmtime(target_path)
         return 0.0
 
     async def _check_config_changes(self) -> None:
@@ -628,17 +747,35 @@ class ModeCortexRuntime:
             try:
                 await asyncio.sleep(self.check_interval)
 
-                if not self.config_path or not os.path.exists(self.config_path):
-                    continue
+                changed_paths: Set[str] = set()
+                current_watch_paths = self._get_watched_config_paths()
+                all_watch_paths = current_watch_paths | set(
+                    self.watched_config_mtimes.keys()
+                )
 
-                current_mtime = self._get_file_mtime()
+                current_mtimes: Dict[str, float] = {}
+                for path in all_watch_paths:
+                    current_mtime = self._get_file_mtime(path)
+                    current_mtimes[path] = current_mtime
 
-                if self.last_modified and current_mtime > self.last_modified:
+                    previous_mtime = self.watched_config_mtimes.get(path, 0.0)
+                    if current_mtime != previous_mtime:
+                        changed_paths.add(path)
+
+                if changed_paths:
                     logging.info(
-                        f"Runtime config file changed, reloading: {self.config_path}"
+                        "Configuration file changes detected: %s",
+                        ", ".join(sorted(changed_paths)),
                     )
-                    await self._reload_config()
-                    self.last_modified = current_mtime
+                    reload_from_runtime = changed_paths == {self.config_path}
+                    await self._reload_config(reload_from_runtime=reload_from_runtime)
+                    self._refresh_watched_config_mtimes()
+                else:
+                    self.watched_config_mtimes = {
+                        path: current_mtimes[path] for path in current_watch_paths
+                    }
+
+                self.last_modified = self.watched_config_mtimes.get(self.config_path, 0.0)
 
             except asyncio.CancelledError:
                 logging.debug("Config watcher cancelled")
@@ -647,16 +784,28 @@ class ModeCortexRuntime:
                 logging.error(f"Error checking config changes: {e}")
                 await asyncio.sleep(10)  # Wait before retrying
 
-    async def _reload_config(self) -> None:
+    async def _reload_config(self, reload_from_runtime: bool = False) -> None:
         """
-        Reload the mode configuration when runtime config file changes.
+        Reload the mode configuration after file changes are detected.
 
-        The runtime config file serves as a trigger - when it changes, we reload
-        from the original configuration source and then regenerate the runtime config.
+        Parameters
+        ----------
+        reload_from_runtime : bool, optional
+            If True, reload from runtime config snapshot; otherwise reload from
+            the original source config file and any referenced mode files.
         """
         try:
+            reload_path = self.config_path if reload_from_runtime else self.source_config_path
+            if not reload_path or not os.path.exists(reload_path):
+                logging.warning(
+                    "Reload source file missing (%s), falling back to runtime config",
+                    reload_path,
+                )
+                reload_path = self.config_path
+                reload_from_runtime = True
+
             logging.info(
-                f"Runtime config file changed, triggering reload: {self.config_path}"
+                f"Configuration changed, triggering reload from: {reload_path}"
             )
 
             self._is_reloading = True
@@ -665,14 +814,18 @@ class ModeCortexRuntime:
 
             await self._stop_current_orchestrators()
 
-            logging.info("Loading configuration from the new runtime file")
+            logging.info("Loading updated mode configuration")
             new_mode_config = load_mode_config(
                 self.mode_config_name,
-                mode_source_path=self.mode_manager._get_runtime_config_path(),
+                mode_source_path=reload_path,
             )
 
             self.mode_config = new_mode_config
             self.mode_manager.config = new_mode_config
+
+            # Keep runtime snapshot in sync when source files are edited directly.
+            if not reload_from_runtime:
+                self.mode_manager._create_runtime_config_file()
 
             if current_mode not in new_mode_config.modes:
                 logging.warning(

--- a/tests/runtime/multi_mode/test_cortex.py
+++ b/tests/runtime/multi_mode/test_cortex.py
@@ -375,6 +375,9 @@ class TestModeCortexRuntimeHotReload:
             assert runtime.check_interval == 30
             assert runtime.last_modified == 1234567890.0
             assert runtime.config_path.endswith("test_config.json5")
+            assert runtime.source_config_path.endswith("config/test_config.json5")
+            assert runtime.config_path in runtime.watched_config_mtimes
+            assert runtime.source_config_path in runtime.watched_config_mtimes
 
     def test_hot_reload_initialization_disabled(self, mock_system_config):
         """Test hot reload initialization when disabled."""
@@ -462,19 +465,24 @@ class TestModeCortexRuntimeHotReload:
                 mock_system_config, "test_config", hot_reload=True, check_interval=0.1
             )
             runtime.config_path = temp_config_file
-            runtime.last_modified = 1.0
+            runtime.watched_config_mtimes = {temp_config_file: 1.0}
 
             runtime._reload_config = AsyncMock()
 
-            task = asyncio.create_task(runtime._check_config_changes())
+            with patch.object(
+                runtime, "_get_watched_config_paths", return_value={temp_config_file}
+            ):
+                task = asyncio.create_task(runtime._check_config_changes())
 
-            try:
-                await asyncio.sleep(0.2)
-                task.cancel()
+                try:
+                    await asyncio.sleep(0.2)
+                    task.cancel()
 
-                runtime._reload_config.assert_called_once()
-            except asyncio.CancelledError:
-                pass
+                    runtime._reload_config.assert_called_once_with(
+                        reload_from_runtime=True
+                    )
+                except asyncio.CancelledError:
+                    pass
 
     @pytest.mark.asyncio
     async def test_check_config_changes_no_change(self, mock_system_config):
@@ -496,19 +504,25 @@ class TestModeCortexRuntimeHotReload:
             runtime = ModeCortexRuntime(
                 mock_system_config, "test_config", hot_reload=True, check_interval=0.1
             )
-            runtime.last_modified = 1234567890.0
+            runtime.config_path = "/fake/path/test_config.json5"
+            runtime.watched_config_mtimes = {runtime.config_path: 1234567890.0}
 
             runtime._reload_config = AsyncMock()
 
-            task = asyncio.create_task(runtime._check_config_changes())
+            with patch.object(
+                runtime,
+                "_get_watched_config_paths",
+                return_value={runtime.config_path},
+            ):
+                task = asyncio.create_task(runtime._check_config_changes())
 
-            try:
-                await asyncio.sleep(0.2)
-                task.cancel()
+                try:
+                    await asyncio.sleep(0.2)
+                    task.cancel()
 
-                runtime._reload_config.assert_not_called()
-            except asyncio.CancelledError:
-                pass
+                    runtime._reload_config.assert_not_called()
+                except asyncio.CancelledError:
+                    pass
 
     @pytest.mark.asyncio
     async def test_check_config_changes_nonexistent_file(self, mock_system_config):
@@ -529,19 +543,24 @@ class TestModeCortexRuntimeHotReload:
                 mock_system_config, "test_config", hot_reload=True, check_interval=0.1
             )
             runtime.config_path = "/nonexistent/file.json5"
-            runtime.last_modified = 1.0
+            runtime.watched_config_mtimes = {runtime.config_path: 0.0}
 
             runtime._reload_config = AsyncMock()
 
-            task = asyncio.create_task(runtime._check_config_changes())
+            with patch.object(
+                runtime,
+                "_get_watched_config_paths",
+                return_value={runtime.config_path},
+            ):
+                task = asyncio.create_task(runtime._check_config_changes())
 
-            try:
-                await asyncio.sleep(0.2)
-                task.cancel()
+                try:
+                    await asyncio.sleep(0.2)
+                    task.cancel()
 
-                runtime._reload_config.assert_not_called()
-            except asyncio.CancelledError:
-                pass
+                    runtime._reload_config.assert_not_called()
+                except asyncio.CancelledError:
+                    pass
 
     @pytest.mark.asyncio
     async def test_reload_config_success(self, mock_system_config):
@@ -571,23 +590,67 @@ class TestModeCortexRuntimeHotReload:
                 mock_system_config, "test_config", hot_reload=True
             )
             runtime.mode_manager = mock_manager
+            runtime.source_config_path = "/fake/path/source_config.json5"
 
             runtime._stop_current_orchestrators = AsyncMock()
             runtime._initialize_mode = AsyncMock()
             runtime._start_orchestrators = AsyncMock()
             runtime._run_cortex_loop = AsyncMock()
 
-            await runtime._reload_config()
+            with patch("os.path.exists", return_value=True):
+                await runtime._reload_config()
 
             mock_load_config.assert_called_once_with(
-                "test_config", mode_source_path="/fake/path/test_config.json5"
+                "test_config", mode_source_path="/fake/path/source_config.json5"
             )
+            mock_manager._create_runtime_config_file.assert_called_once()
             runtime._stop_current_orchestrators.assert_called_once()
             runtime._initialize_mode.assert_called_once_with("test_mode")
             runtime._start_orchestrators.assert_called_once()
 
             assert runtime.mode_config == new_mock_config
             assert runtime.mode_manager.config == new_mock_config
+
+    @pytest.mark.asyncio
+    async def test_reload_config_runtime_snapshot(self, mock_system_config):
+        """Test reloading from runtime snapshot path."""
+        with (
+            patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.multi_mode.cortex.IOProvider"),
+            patch("runtime.multi_mode.cortex.SleepTickerProvider"),
+            patch("runtime.multi_mode.cortex.load_mode_config") as mock_load_config,
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "test_mode"
+            mock_manager.state = Mock()
+            mock_manager.state.transition_history = []
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/runtime.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            new_mock_config = Mock(spec=ModeSystemConfig)
+            new_mock_config.default_mode = "test_mode"
+            new_mock_config.modes = {"test_mode": Mock()}
+            mock_load_config.return_value = new_mock_config
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=True
+            )
+            runtime.mode_manager = mock_manager
+
+            runtime._stop_current_orchestrators = AsyncMock()
+            runtime._initialize_mode = AsyncMock()
+            runtime._start_orchestrators = AsyncMock()
+
+            with patch("os.path.exists", return_value=True):
+                await runtime._reload_config(reload_from_runtime=True)
+
+            mock_load_config.assert_called_once_with(
+                "test_config", mode_source_path="/fake/path/runtime.json5"
+            )
+            mock_manager._create_runtime_config_file.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reload_config_mode_not_found(self, mock_system_config):


### PR DESCRIPTION
## Overview
Extends the multi-mode hot-reload system to watch **source configuration files** (and their referenced sub-configs), not just the generated runtime config snapshot.

Previously, `ModeCortexRuntime` only monitored the runtime config file for changes. If a user edited the original source config or any mode file it references, changes were silently ignored until a full restart. This patch closes that gap.

Relates to #984

## Type of change
- [x] Bug fix
- [x] New feature

## Changes
- **Source config resolution** (`_get_source_config_path`): resolves the original mode config file from `mode_config_name`, handling absolute paths, relative paths, and the default `config/` directory.
- **Config reference extraction** (`_extract_config_references`): parses a JSON5 config and recursively discovers any `.json`/`.json5` file paths referenced as string values (skipping URLs).
- **Multi-file watch set** (`_get_watched_config_paths`): builds the complete set of files to monitor — runtime config + source config + all referenced configs.
- **Mtime tracking** (`_refresh_watched_config_mtimes`): replaces the single `last_modified` check with a dict of per-file mtimes so any watched file change triggers a reload.
- **Smart reload path** (`_reload_config(reload_from_runtime=...)`): when only the runtime snapshot changed, reloads from the snapshot; when source files changed, reloads from the original source and regenerates the runtime snapshot to keep them in sync.

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [x] Local testing completed

## Impact
This is scoped entirely to `multi_mode/cortex.py` and its tests. It does not touch single-mode, does not add new dependencies (uses the existing `json5` import), and is fully backward-compatible — the default behaviour when only the runtime config changes is identical to before.

## Additional Information
This is complementary to the single-mode selective field reload work discussed in #984. That bounty focuses on partial field-level reloading in `single_mode/cortex.py`; this PR addresses a different gap — ensuring multi-mode source config files and their references are properly watched alongside the runtime snapshot.