### PR TITLE
fix: correct log messages in Kokoro TTS connector from ElevenLabs to Kokoro

### DIFF
--- a/src/actions/speak/connector/kokoro_tts.py
+++ b/src/actions/speak/connector/kokoro_tts.py
@@ -132,9 +132,9 @@ class SpeakKokoroTTSConnector(ActionConnector[SpeakKokoroTTSConfig, SpeakInput])
             if self.audio_pub:
                 self.audio_pub.put(self.audio_status.serialize())
 
-            logging.info("Elevenlabs TTS Zenoh client opened")
+            logging.info("Kokoro TTS Zenoh client opened")
         except Exception as e:
-            logging.error(f"Error opening Elevenlabs TTS Zenoh client: {e}")
+            logging.error(f"Error opening Kokoro TTS Zenoh client: {e}")
 
         # Initialize Kokoro TTS Provider
         self.tts = KokoroTTSProvider(
@@ -287,11 +287,11 @@ class SpeakKokoroTTSConnector(ActionConnector[SpeakKokoroTTSConfig, SpeakInput])
 
     def stop(self) -> None:
         """
-        Stop the Elevenlabs TTS connector and cleanup resources.
+        Stop the Kokoro TTS connector and cleanup resources.
         """
         if self.session:
             self.session.close()
-            logging.info("Elevenlabs TTS Zenoh client closed")
+            logging.info("Kokoro TTS Zenoh client closed")
 
         if self.tts:
             self.tts.stop()


### PR DESCRIPTION
## Summary

The Kokoro TTS connector (src/actions/speak/connector/kokoro_tts.py) contained copy-paste errors from the ElevenLabs connector, where log messages and docstrings incorrectly referenced 'Elevenlabs TTS' instead of 'Kokoro TTS'.

## Problem

When troubleshooting or monitoring TTS functionality, log messages in the Kokoro TTS connector incorrectly stated 'Elevenlabs TTS', which causes confusion:

- Users might think ElevenLabs is being used when actually Kokoro is configured
- Debugging becomes harder when logs don't match the actual component
- The stop method docstring claimed to be for ElevenLabs instead of Kokoro

## Changes

| Location | Before | After |
|----------|--------|-------|
| Line 135 | \Elevenlabs TTS Zenoh client opened\ | \Kokoro TTS Zenoh client opened\ |
| Line 137 | \Error opening Elevenlabs TTS Zenoh client\ | \Error opening Kokoro TTS Zenoh client\ |
| Line 290 (docstring) | \Stop the Elevenlabs TTS connector\ | \Stop the Kokoro TTS connector\ |
| Line 294 | \Elevenlabs TTS Zenoh client closed\ | \Kokoro TTS Zenoh client closed\ |

## Impact

This fix improves debugging clarity and log accuracy for users of the Kokoro TTS connector.

## Related

This is a similar copy-paste issue to PR #2151 which fixed the same problem in kokoro_tts_provider.py.