### PR TITLE
fix:log silent exception in Qwen tool call parser 

### DIFF
--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -51,7 +51,8 @@ def _parse_qwen_tool_calls(text: str) -> list:
                         },
                     }
                 )
-        except Exception:
+        except Exception as e:
+            logging.warning("Failed to parse Qwen tool call block %d: %s", i, e)
             continue
     return tool_calls
 


### PR DESCRIPTION
  ## Overview                                                                                       
  The `_parse_qwen_tool_calls` function catches JSON parsing errors silently with a bare `except
  Exception: continue`, making it difficult to debug why tool calls are being dropped.

  ## Type of change
  - Bug fix

  ## Changes
  - `src/llm/plugins/qwen_llm.py` - Qwen tool call parsing errors were silently skipped. Added
  `logging.warning` so failed tool call blocks are visible in logs.

  ## Checklist
  - [x] Code complies with style guidelines
  - [x] Self-review completed
  - [x] Local testing completed

  ## Impact
  No behavioral changes. Only adds a log message to a previously silent exception handler, improving
  debuggability without affecting runtime flow.