### PR TITLE
Fix test: expect 'om/' prefix for charging topic

### DIFF
--- a/tests/providers/test_unitree_go2_charging_provider.py
+++ b/tests/providers/test_unitree_go2_charging_provider.py
@@ -34,7 +34,7 @@ def test_initialization(mock_zenoh):
     """Test UnitreeGo2ChargingProvider initialization with default topic."""
     provider = UnitreeGo2ChargingProvider()
 
-    assert provider.sub_topic == "go2/charging_status"
+    assert provider.sub_topic == "om/go2/charging_status"
     assert provider.latest_status is None
     assert provider.status_history == []
     assert provider.running is False


### PR DESCRIPTION
This pull request updates the default subscription topic used by the `UnitreeGo2ChargingProvider` in its initialization test. The change ensures the provider subscribes to the correct topic for charging status updates.

* Changed the default value of `sub_topic` in the `test_initialization` test from `"go2/charging_status"` to `"om/go2/charging_status"` to match the expected topic naming convention.