### PR TITLE
test: add unit tests for D435, G1 Navigation, Go2 AMCL, and Go2 Lidar Localization background plugins

### DIFF
--- a/tests/backgrounds/plugins/test_d435.py
+++ b/tests/backgrounds/plugins/test_d435.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backgrounds.base import Background, BackgroundConfig
+from backgrounds.plugins.d435 import D435
+
+
+class TestD435:
+    """Test cases for D435 background plugin."""
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_initialization(self, mock_provider_class):
+        """Test D435 background initializes provider and calls start."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+        assert background.d435_provider == mock_provider
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            D435(config)
+
+        assert "Initiated D435 Provider in background" in caplog.text
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_inherits_from_background(self, mock_provider_class):
+        """Test that D435 inherits from Background."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        assert isinstance(background, Background)
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that configuration is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        assert background.config == config
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_provider_start_called_on_init(self, mock_provider_class):
+        """Test that provider.start() is called during initialization."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        D435(config)
+
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_provider_exception_propagates(self, mock_provider_class):
+        """Test that provider initialization errors propagate."""
+        mock_provider_class.side_effect = Exception("Zenoh connection failed")
+
+        config = BackgroundConfig()
+        with pytest.raises(Exception, match="Zenoh connection failed"):
+            D435(config)

--- a/tests/backgrounds/plugins/test_unitree_g1_navigation.py
+++ b/tests/backgrounds/plugins/test_unitree_g1_navigation.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backgrounds.base import Background, BackgroundConfig
+from backgrounds.plugins.unitree_g1_navigation import UnitreeG1Navigation
+
+
+class TestUnitreeG1Navigation:
+    """Test cases for UnitreeG1Navigation background plugin."""
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initializes provider and calls start."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+        assert background.unitree_g1_navigation_provider == mock_provider
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeG1Navigation(config)
+
+        assert "Unitree G1 Navigation Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_inherits_from_background(self, mock_provider_class):
+        """Test that UnitreeG1Navigation inherits from Background."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        assert isinstance(background, Background)
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that configuration is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        assert background.config == config
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_provider_exception_propagates(self, mock_provider_class):
+        """Test that provider initialization errors propagate."""
+        mock_provider_class.side_effect = Exception("Navigation init failed")
+
+        config = BackgroundConfig()
+        with pytest.raises(Exception, match="Navigation init failed"):
+            UnitreeG1Navigation(config)

--- a/tests/backgrounds/plugins/test_unitree_go2_amcl.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_amcl.py
@@ -1,0 +1,66 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backgrounds.base import Background, BackgroundConfig
+from backgrounds.plugins.unitree_go2_amcl import UnitreeGo2AMCL
+
+
+class TestUnitreeGo2AMCL:
+    """Test cases for UnitreeGo2AMCL background plugin."""
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initializes provider and calls start."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+        assert background.unitree_go2_amcl_provider == mock_provider
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2AMCL(config)
+
+        assert "Unitree Go2 AMCL Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_inherits_from_background(self, mock_provider_class):
+        """Test that UnitreeGo2AMCL inherits from Background."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        assert isinstance(background, Background)
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that configuration is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        assert background.config == config
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_provider_exception_propagates(self, mock_provider_class):
+        """Test that provider initialization errors propagate."""
+        mock_provider_class.side_effect = Exception("AMCL connection failed")
+
+        config = BackgroundConfig()
+        with pytest.raises(Exception, match="AMCL connection failed"):
+            UnitreeGo2AMCL(config)

--- a/tests/backgrounds/plugins/test_unitree_go2_lidar_localization.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_lidar_localization.py
@@ -1,0 +1,94 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backgrounds.base import Background, BackgroundConfig
+from backgrounds.plugins.unitree_go2_lidar_localization import (
+    UnitreeGo2LidarLocalization,
+)
+
+
+class TestUnitreeGo2LidarLocalization:
+    """Test cases for UnitreeGo2LidarLocalization background plugin."""
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_initialization(self, mock_provider_class):
+        """Test background initializes provider and calls start."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+        assert background.unitree_go2_lidar_localization_provider == mock_provider
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2LidarLocalization(config)
+
+        assert (
+            "Unitree Go2 Lidar Localization Provider initialized in background"
+            in caplog.text
+        )
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_inherits_from_background(self, mock_provider_class):
+        """Test that UnitreeGo2LidarLocalization inherits from Background."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        assert isinstance(background, Background)
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_config_stored(self, mock_provider_class):
+        """Test that configuration is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        assert background.config == config
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_provider_start_called_on_init(self, mock_provider_class):
+        """Test that provider.start() is called during initialization."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        UnitreeGo2LidarLocalization(config)
+
+        mock_provider.start.assert_called_once()
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_provider_exception_propagates(self, mock_provider_class):
+        """Test that provider initialization errors propagate."""
+        mock_provider_class.side_effect = Exception("Lidar connection failed")
+
+        config = BackgroundConfig()
+        with pytest.raises(Exception, match="Lidar connection failed"):
+            UnitreeGo2LidarLocalization(config)


### PR DESCRIPTION
## Summary

- Add unit tests for **4 untested background plugins**: D435, UnitreeG1Navigation, UnitreeGo2AMCL, and UnitreeGo2LidarLocalization
- Tests cover initialization, provider start invocation, logging output, inheritance, config storage, and error propagation
- All hardware/network dependencies are mocked
- Follows existing test conventions from `test_agent_teleops_status.py`

## Test Coverage Added

| Plugin | Test File | Tests |
|--------|-----------|-------|
| `d435.py` | `test_d435.py` | 6 |
| `unitree_g1_navigation.py` | `test_unitree_g1_navigation.py` | 5 |
| `unitree_go2_amcl.py` | `test_unitree_go2_amcl.py` | 5 |
| `unitree_go2_lidar_localization.py` | `test_unitree_go2_lidar_localization.py` | 6 |

## Test plan

- [x] Ruff lint passes
- [x] Ruff format passes
- [ ] CI unit tests pass
- [ ] Codecov reports no coverage regressions