### PR TITLE
Refactor: Inject TTS provider into Unitree navigation providers for better testability

### DIFF
--- a/src/providers/unitree_g1_navigation_provider.py
+++ b/src/providers/unitree_g1_navigation_provider.py
@@ -49,6 +49,7 @@ class UnitreeG1NavigationProvider:
         navigation_status_topic: str = "navigate_to_pose/_action/status",
         goal_pose_topic: str = "goal_pose",
         cancel_goal_topic: str = "navigate_to_pose/_action/cancel_goal",
+        tts_provider: Optional[object] = None,
     ):
         """
         Initialize the Unitree G1 Navigation Provider with a specific topic.
@@ -63,6 +64,9 @@ class UnitreeG1NavigationProvider:
             The topic on which to publish goal poses (default is "goal_pose").
         cancel_goal_topic : str, optional
             The topic on which to publish goal cancellations (default is "navigate_to_pose/_action/cancel_goal").
+        tts_provider : Optional[object], optional
+            The TTS provider instance to use for speech feedback.
+            Defaults to ElevenLabsTTSProvider if None.
         """
         self.session: Optional[zenoh.Session] = None
         try:
@@ -77,7 +81,13 @@ class UnitreeG1NavigationProvider:
         self.running: bool = False
         self._nav_in_progress: bool = False
         self._current_destination: Optional[str] = None
-        self.tts_provider = ElevenLabsTTSProvider()
+        
+        # Use injected TTS provider or default to ElevenLabsTTSProvider
+        if tts_provider is None:
+            self.tts_provider = ElevenLabsTTSProvider()
+        else:
+            self.tts_provider = tts_provider
+            
         self.ai_status_topic = "om/ai/request"
         self.ai_status_pub = None
         if self.session:

--- a/src/providers/unitree_go2_navigation_provider.py
+++ b/src/providers/unitree_go2_navigation_provider.py
@@ -50,6 +50,7 @@ class UnitreeGo2NavigationProvider:
         navigation_status_topic: str = "navigate_to_pose/_action/status",
         goal_pose_topic: str = "goal_pose",
         cancel_goal_topic: str = "navigate_to_pose/_action/cancel_goal",
+        tts_provider: Optional[object] = None,
     ):
         """
         Initialize the Unitree Go2 Navigation Provider with a specific topic.
@@ -64,6 +65,9 @@ class UnitreeGo2NavigationProvider:
             The topic on which to publish goal poses (default is "goal_pose").
         cancel_goal_topic : str, optional
             The topic on which to publish goal cancellations (default is "navigate_to_pose/_action/cancel_goal").
+        tts_provider : Optional[object], optional
+            The TTS provider instance to use for speech feedback.
+            Defaults to ElevenLabsTTSProvider if None.
         """
         self.session: Optional[zenoh.Session] = None
 
@@ -84,7 +88,10 @@ class UnitreeGo2NavigationProvider:
         self._current_destination: Optional[str] = None  # Track destination name
 
         # TTS provider for speech feedback
-        self.tts_provider = ElevenLabsTTSProvider()
+        if tts_provider is None:
+            self.tts_provider = ElevenLabsTTSProvider()
+        else:
+            self.tts_provider = tts_provider
 
         # AI status control
         self.ai_status_topic = "om/ai/request"


### PR DESCRIPTION
## Problem
The `UnitreeGo2NavigationProvider` and `UnitreeG1NavigationProvider` classes were directly instantiating their TTS (Text-to-Speech) dependencies internally. This tight coupling made it difficult to mock the TTS service during unit testing, leading to potential side effects (like actual audio output) or failures in test environments where audio devices are unavailable.

## Solution
- Refactored `UnitreeGo2NavigationProvider` and `UnitreeG1NavigationProvider` to accept an optional `tts_provider` argument in their `__init__` methods (Dependecy Injection).
- Updated the initialization logic to use the injected provider if available; otherwise, it falls back to the default implementation as before.
- This change allows tests to inject a mock TTS provider, isolating the navigation logic from the TTS implementation.

## Type of Change
- [x] Refactor (no new functionality, no behavior change)

## Testing
- Existing tests should pass as the default behavior remains unchanged.
- New unit tests can now be written with mocked TTS providers.