### PR TITLE
Feat: Auto-create Coinbase Wallet if ID is missing

### DIFF
--- a/src/inputs/plugins/wallet_coinbase.py
+++ b/src/inputs/plugins/wallet_coinbase.py
@@ -62,20 +62,29 @@ class WalletCoinbase(FuserInput[WalletCoinbaseConfig, List[float]]):
         # TODO(Kyle): Support importing other wallets, following https://docs.cdp.coinbase.com/mpc-wallet/docs/wallets#importing-a-wallet
         API_KEY = os.environ.get("COINBASE_API_KEY")
         API_SECRET = os.environ.get("COINBASE_API_SECRET")
+        api_keys_present = False
         if not API_KEY or not API_SECRET:
             logging.error(
                 "COINBASE_API_KEY or COINBASE_API_SECRET environment variable is not set"
             )
         else:
             Cdp.configure(API_KEY, API_SECRET)
+            api_keys_present = True
 
         try:
             # fetch wallet data
-            if not self.COINBASE_WALLET_ID:
+            if self.COINBASE_WALLET_ID:
+                self.wallet = Wallet.fetch(self.COINBASE_WALLET_ID)
+                logging.info(f"Wallet: {self.wallet}")
+            elif api_keys_present:
+                logging.info("COINBASE_WALLET_ID not provided. Creating new wallet...")
+                self.wallet = Wallet.create()
+                logging.warning(
+                    f"NEW WALLET CREATED! ID: {self.wallet.id}\n"
+                    "Please set COINBASE_WALLET_ID environment variable to this value to persist this wallet."
+                )
+            else:
                 raise ValueError("COINBASE_WALLET_ID environment variable is not set")
-
-            self.wallet = Wallet.fetch(self.COINBASE_WALLET_ID)
-            logging.info(f"Wallet: {self.wallet}")
 
             self.balance = float(self.wallet.balance(self.asset_id))
             self.balance_previous = self.balance

--- a/tests/inputs/plugins/test_wallet_coinbase.py
+++ b/tests/inputs/plugins/test_wallet_coinbase.py
@@ -6,14 +6,39 @@ import pytest
 from inputs.plugins.wallet_coinbase import Message, WalletCoinbase, WalletCoinbaseConfig
 
 
-def test_initialization_with_missing_wallet_id():
-    """Missing COINBASE_WALLET_ID should fall back to a safe zero state."""
+def test_initialization_with_missing_wallet_id_and_missing_keys():
+    """Missing COINBASE_WALLET_ID and missing keys should result in no wallet."""
     with patch.dict(os.environ, {}, clear=True):
         wallet = WalletCoinbase(config=WalletCoinbaseConfig())
         assert wallet.wallet is None
         assert wallet.balance == 0.0
         assert wallet.balance_previous == 0.0
         assert wallet.asset_id == "eth"
+
+
+def test_initialization_creates_wallet_if_missing_id_but_keys_present():
+    """Missing COINBASE_WALLET_ID but present keys should create a new wallet."""
+    mock_wallet = MagicMock()
+    mock_wallet.id = "new_wallet_id"
+    mock_wallet.balance.return_value = "0.0"
+
+    env = {
+        "COINBASE_API_KEY": "k",
+        "COINBASE_API_SECRET": "s",
+        # COINBASE_WALLET_ID missing
+    }
+    with (
+        patch.dict(os.environ, env, clear=True),
+        patch("inputs.plugins.wallet_coinbase.Cdp.configure") as mock_configure,
+        patch("inputs.plugins.wallet_coinbase.Wallet.create", return_value=mock_wallet) as mock_create,
+    ):
+        wallet = WalletCoinbase(config=WalletCoinbaseConfig())
+
+        assert wallet.wallet == mock_wallet
+        assert wallet.balance == 0.0
+        
+        mock_configure.assert_called_once_with("k", "s")
+        mock_create.assert_called_once()
 
 
 def test_initialization_with_wallet_fetch_failure():


### PR DESCRIPTION
## Problem
Currently, the `WalletCoinbase` plugin raises an initialization error if `COINBASE_WALLET_ID` is missing from the configuration, even when valid API keys (`COINBASE_API_KEY` and `COINBASE_API_SECRET`) are provided. This forces users to manually create a wallet and find the ID before they can use the plugin.

There was a TODO in the code to implement automatic wallet creation in this scenario:
```python
# TODO(Kyle): Create Wallet if the wallet ID is not found

## Solution
- Updated `WalletCoinbase` to check for missing `COINBASE_WALLET_ID`.
- If the ID is missing but valid API keys are present, the plugin now automatically creates a new wallet using the Coinbase CDP SDK.
- The new Wallet ID is logged and used immediately, streamlining the setup process.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- Verified that providing only API keys successfully creates a new wallet and initializes the plugin.
- Verified that providing an existing Wallet ID still works as expected.