### PR TITLE
feat: selective field-based config hot-reload

### DIFF
--- a/src/runtime/multi_mode/cortex.py
+++ b/src/runtime/multi_mode/cortex.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 import os
 import time
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
+
+import json5
 
 from actions.orchestrator import ActionOrchestrator
 from backgrounds.orchestrator import BackgroundOrchestrator
@@ -19,6 +21,21 @@ from runtime.multi_mode.config import (
 )
 from runtime.multi_mode.manager import ModeManager
 from simulators.orchestrator import SimulatorOrchestrator
+
+# Top-level fields that can be updated in-place without restarting.
+HOT_RELOAD_SAFE_FIELDS: Set[str] = {
+    "system_governance",
+    "system_prompt_examples",
+}
+
+# Per-mode fields that can be updated in-place.
+HOT_RELOAD_SAFE_MODE_FIELDS: Set[str] = {
+    "system_prompt_base",
+    "system_prompt_examples",
+    "hertz",
+    "description",
+    "display_name",
+}
 
 
 class ModeCortexRuntime:
@@ -75,10 +92,13 @@ class ModeCortexRuntime:
         self.config_watcher_task: Optional[asyncio.Task] = None
         self.last_modified: Optional[float] = None
 
+        self._last_raw_config: Optional[dict] = None
+
         # Initialize hot-reload if enabled
         if self.hot_reload:
             self.config_path = self.mode_manager._get_runtime_config_path()
             self.last_modified = self._get_file_mtime()
+            self._last_raw_config = self._read_raw_config()
             logging.info(
                 f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
             )
@@ -620,10 +640,118 @@ class ModeCortexRuntime:
             return os.path.getmtime(self.config_path)
         return 0.0
 
+    def _read_raw_config(self) -> Optional[dict]:
+        """Read the raw JSON5 config from disk without instantiating components."""
+        try:
+            with open(self.config_path, "r") as f:
+                return json5.load(f)
+        except Exception:
+            logging.exception("Failed to read raw config file")
+            return None
+
+    @staticmethod
+    def _detect_changed_fields(
+        old_config: dict, new_config: dict
+    ) -> Dict[str, Set[str]]:
+        """Compare two raw mode-system config dicts and categorize changes.
+
+        Returns
+        -------
+        dict
+            ``{"safe": set_of_field_paths, "unsafe": set_of_field_paths}``
+            Mode-specific fields use dot notation: ``modes.<name>.<field>``
+        """
+        changed_safe: Set[str] = set()
+        changed_unsafe: Set[str] = set()
+
+        # Compare top-level fields (excluding modes and transition_rules)
+        all_keys = set(old_config.keys()) | set(new_config.keys())
+        for key in all_keys:
+            if key in ("modes", "transition_rules"):
+                continue
+            if old_config.get(key) != new_config.get(key):
+                if key in HOT_RELOAD_SAFE_FIELDS:
+                    changed_safe.add(key)
+                else:
+                    changed_unsafe.add(key)
+
+        # Transition rules changed → full reload
+        if old_config.get("transition_rules") != new_config.get("transition_rules"):
+            changed_unsafe.add("transition_rules")
+
+        # Compare modes
+        old_modes = old_config.get("modes", {})
+        new_modes = new_config.get("modes", {})
+
+        if set(old_modes.keys()) != set(new_modes.keys()):
+            # Modes added or removed → full reload
+            changed_unsafe.add("modes")
+        else:
+            for mode_name in old_modes:
+                old_mode = old_modes[mode_name]
+                new_mode = new_modes[mode_name]
+                mode_keys = set(old_mode.keys()) | set(new_mode.keys())
+                for key in mode_keys:
+                    if old_mode.get(key) != new_mode.get(key):
+                        field_path = f"modes.{mode_name}.{key}"
+                        if key in HOT_RELOAD_SAFE_MODE_FIELDS:
+                            changed_safe.add(field_path)
+                        else:
+                            changed_unsafe.add(field_path)
+
+        return {"safe": changed_safe, "unsafe": changed_unsafe}
+
+    async def _apply_safe_reload(
+        self, new_raw_config: dict, changed_fields: Set[str]
+    ) -> None:
+        """Update safe fields in-place on the live config objects."""
+        current_mode_name = self.mode_manager.current_mode_name
+
+        for field_path in changed_fields:
+            if field_path.startswith("modes."):
+                parts = field_path.split(".")
+                mode_name, field_name = parts[1], parts[2]
+                new_value = new_raw_config["modes"][mode_name].get(field_name)
+
+                if field_name == "hertz":
+                    if (
+                        not isinstance(new_value, (int, float))
+                        or new_value <= 0
+                    ):
+                        logging.warning(
+                            f"Ignoring invalid hertz value for mode "
+                            f"'{mode_name}': {new_value}"
+                        )
+                        continue
+
+                # Update the ModeConfig
+                mode_cfg = self.mode_config.modes.get(mode_name)
+                if mode_cfg and hasattr(mode_cfg, field_name):
+                    setattr(mode_cfg, field_name, new_value)
+
+                # If it's the active mode, also patch the live RuntimeConfig
+                if mode_name == current_mode_name and self.current_config:
+                    if hasattr(self.current_config, field_name):
+                        setattr(self.current_config, field_name, new_value)
+
+                logging.info(
+                    f"Hot-reloaded '{field_path}' in-place"
+                )
+            else:
+                # Top-level field (e.g. system_governance)
+                new_value = new_raw_config.get(field_path)
+
+                if hasattr(self.mode_config, field_path):
+                    setattr(self.mode_config, field_path, new_value)
+
+                # Also update the live RuntimeConfig if applicable
+                if self.current_config and hasattr(self.current_config, field_path):
+                    setattr(self.current_config, field_path, new_value)
+
+                logging.info(f"Hot-reloaded '{field_path}' in-place")
+
     async def _check_config_changes(self) -> None:
-        """
-        Periodically check for config file changes and reload if necessary.
-        """
+        """Periodically check for config file changes and selectively reload."""
         while True:
             try:
                 await asyncio.sleep(self.check_interval)
@@ -635,9 +763,47 @@ class ModeCortexRuntime:
 
                 if self.last_modified and current_mtime > self.last_modified:
                     logging.info(
-                        f"Runtime config file changed, reloading: {self.config_path}"
+                        f"Config file changed, analyzing: {self.config_path}"
                     )
-                    await self._reload_config()
+
+                    new_raw = self._read_raw_config()
+                    if new_raw is None:
+                        logging.error(
+                            "Failed to read updated config, skipping reload"
+                        )
+                        self.last_modified = current_mtime
+                        continue
+
+                    if self._last_raw_config is not None:
+                        changes = self._detect_changed_fields(
+                            self._last_raw_config, new_raw
+                        )
+
+                        if not changes["safe"] and not changes["unsafe"]:
+                            logging.info(
+                                "Config file touched but no field changes detected"
+                            )
+                        elif changes["unsafe"]:
+                            logging.info(
+                                f"Structural field changes detected: "
+                                f"{changes['unsafe']}. Performing full reload."
+                            )
+                            await self._full_reload()
+                        else:
+                            logging.info(
+                                f"Safe field changes detected: "
+                                f"{changes['safe']}. Applying in-place update."
+                            )
+                            await self._apply_safe_reload(
+                                new_raw, changes["safe"]
+                            )
+                    else:
+                        logging.info(
+                            "No previous config snapshot, performing full reload"
+                        )
+                        await self._full_reload()
+
+                    self._last_raw_config = new_raw
                     self.last_modified = current_mtime
 
             except asyncio.CancelledError:
@@ -645,18 +811,13 @@ class ModeCortexRuntime:
                 break
             except Exception as e:
                 logging.error(f"Error checking config changes: {e}")
-                await asyncio.sleep(10)  # Wait before retrying
+                await asyncio.sleep(10)
 
-    async def _reload_config(self) -> None:
-        """
-        Reload the mode configuration when runtime config file changes.
-
-        The runtime config file serves as a trigger - when it changes, we reload
-        from the original configuration source and then regenerate the runtime config.
-        """
+    async def _full_reload(self) -> None:
+        """Full reload: stop orchestrators, reload config, restart everything."""
         try:
             logging.info(
-                f"Runtime config file changed, triggering reload: {self.config_path}"
+                f"Full reload triggered: {self.config_path}"
             )
 
             self._is_reloading = True
@@ -676,7 +837,8 @@ class ModeCortexRuntime:
 
             if current_mode not in new_mode_config.modes:
                 logging.warning(
-                    f"Current mode '{current_mode}' not found in reloaded config, switching to default mode '{new_mode_config.default_mode}'"
+                    f"Current mode '{current_mode}' not found in reloaded config, "
+                    f"switching to default mode '{new_mode_config.default_mode}'"
                 )
                 current_mode = new_mode_config.default_mode
 
@@ -692,7 +854,7 @@ class ModeCortexRuntime:
             await self._start_orchestrators()
 
             logging.info(
-                f"Mode configuration reloaded successfully, active mode: {current_mode}"
+                f"Full reload completed, active mode: {current_mode}"
             )
 
         except Exception as e:

--- a/src/runtime/single_mode/cortex.py
+++ b/src/runtime/single_mode/cortex.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import os
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 import json5
 
@@ -14,6 +14,15 @@ from providers.io_provider import IOProvider
 from providers.sleep_ticker_provider import SleepTickerProvider
 from runtime.single_mode.config import RuntimeConfig, load_config
 from simulators.orchestrator import SimulatorOrchestrator
+
+# Fields that can be updated in-place without restarting orchestrators.
+# These are simple value fields consumed by the Fuser or cortex loop.
+HOT_RELOAD_SAFE_FIELDS: Set[str] = {
+    "system_prompt_base",
+    "system_governance",
+    "system_prompt_examples",
+    "hertz",
+}
 
 
 class CortexRuntime:
@@ -77,10 +86,12 @@ class CortexRuntime:
         self.cortex_loop_task: Optional[asyncio.Task] = None
 
         self._is_reloading = False
+        self._last_raw_config: Optional[dict] = None
 
         if self.hot_reload:
             self.config_path = self._create_runtime_config_file()
             self.last_modified = self._get_file_mtime()
+            self._last_raw_config = self._read_raw_config()
             logging.info(
                 f"Hot-reload enabled for runtime config: {self.config_path} (check interval: {check_interval}s)"
             )
@@ -212,10 +223,70 @@ class CortexRuntime:
         except OSError:
             return 0.0
 
+    def _read_raw_config(self) -> Optional[dict]:
+        """Read the raw JSON5 config from disk without instantiating components."""
+        try:
+            with open(self.config_path, "r") as f:
+                return json5.load(f)
+        except Exception:
+            logging.exception("Failed to read raw config file")
+            return None
+
+    @staticmethod
+    def _detect_changed_fields(
+        old_config: dict, new_config: dict
+    ) -> Dict[str, Set[str]]:
+        """Compare two raw config dicts and categorize changed fields.
+
+        Returns
+        -------
+        dict
+            ``{"safe": set_of_safe_field_names, "unsafe": set_of_unsafe_field_names}``
+        """
+        changed_safe: Set[str] = set()
+        changed_unsafe: Set[str] = set()
+
+        all_keys = set(old_config.keys()) | set(new_config.keys())
+        for key in all_keys:
+            if old_config.get(key) != new_config.get(key):
+                if key in HOT_RELOAD_SAFE_FIELDS:
+                    changed_safe.add(key)
+                else:
+                    changed_unsafe.add(key)
+
+        return {"safe": changed_safe, "unsafe": changed_unsafe}
+
+    async def _apply_safe_reload(
+        self, new_raw_config: dict, changed_fields: Set[str]
+    ) -> None:
+        """Update safe fields in-place on the live RuntimeConfig."""
+        for field in changed_fields:
+            new_value = new_raw_config.get(field)
+
+            if field == "hertz":
+                if (
+                    not isinstance(new_value, (int, float))
+                    or new_value <= 0
+                ):
+                    logging.warning(
+                        f"Ignoring invalid hertz value: {new_value}"
+                    )
+                    continue
+
+            if hasattr(self.config, field):
+                old_value = getattr(self.config, field)
+                setattr(self.config, field, new_value)
+                logging.info(
+                    f"Hot-reloaded '{field}' in-place "
+                    f"(was {repr(old_value)[:80]})"
+                )
+            else:
+                logging.warning(
+                    f"Field '{field}' not found on RuntimeConfig, skipping"
+                )
+
     async def _check_config_changes(self) -> None:
-        """
-        Periodically check for config file changes and reload if needed.
-        """
+        """Periodically check for config file changes and selectively reload."""
         while True:
             try:
                 await asyncio.sleep(self.check_interval)
@@ -226,8 +297,48 @@ class CortexRuntime:
                 current_mtime = self._get_file_mtime()
 
                 if self.last_modified and current_mtime > self.last_modified:
-                    logging.info(f"Config file changed, reloading: {self.config_path}")
-                    await self._reload_config()
+                    logging.info(
+                        f"Config file changed, analyzing: {self.config_path}"
+                    )
+
+                    new_raw = self._read_raw_config()
+                    if new_raw is None:
+                        logging.error(
+                            "Failed to read updated config, skipping reload"
+                        )
+                        self.last_modified = current_mtime
+                        continue
+
+                    if self._last_raw_config is not None:
+                        changes = self._detect_changed_fields(
+                            self._last_raw_config, new_raw
+                        )
+
+                        if not changes["safe"] and not changes["unsafe"]:
+                            logging.info(
+                                "Config file touched but no field changes detected"
+                            )
+                        elif changes["unsafe"]:
+                            logging.info(
+                                f"Structural field changes detected: "
+                                f"{changes['unsafe']}. Performing full reload."
+                            )
+                            await self._full_reload()
+                        else:
+                            logging.info(
+                                f"Safe field changes detected: "
+                                f"{changes['safe']}. Applying in-place update."
+                            )
+                            await self._apply_safe_reload(
+                                new_raw, changes["safe"]
+                            )
+                    else:
+                        logging.info(
+                            "No previous config snapshot, performing full reload"
+                        )
+                        await self._full_reload()
+
+                    self._last_raw_config = new_raw
                     self.last_modified = current_mtime
 
             except asyncio.CancelledError:
@@ -237,12 +348,10 @@ class CortexRuntime:
                 logging.exception("Error checking config changes")
                 await asyncio.sleep(5)
 
-    async def _reload_config(self) -> None:
-        """
-        Reload the configuration and restart all components.
-        """
+    async def _full_reload(self) -> None:
+        """Reload the configuration and restart all components."""
         try:
-            logging.info(f"Reloading configuration: {self.config_name}")
+            logging.info(f"Full reload: {self.config_name}")
             self._is_reloading = True
 
             if not self.config_name:
@@ -266,7 +375,7 @@ class CortexRuntime:
 
             self.cortex_loop_task = asyncio.create_task(self._run_cortex_loop())
 
-            logging.info("Configuration reloaded successfully")
+            logging.info("Full configuration reload completed successfully")
 
         except Exception:
             logging.exception("Failed to reload configuration")

--- a/tests/runtime/multi_mode/test_cortex.py
+++ b/tests/runtime/multi_mode/test_cortex.py
@@ -464,7 +464,11 @@ class TestModeCortexRuntimeHotReload:
             runtime.config_path = temp_config_file
             runtime.last_modified = 1.0
 
-            runtime._reload_config = AsyncMock()
+            runtime._last_raw_config = {"default_mode": "default"}
+            runtime._read_raw_config = Mock(
+                return_value={"default_mode": "default", "agent_inputs": [{"type": "new"}]}
+            )
+            runtime._full_reload = AsyncMock()
 
             task = asyncio.create_task(runtime._check_config_changes())
 
@@ -472,7 +476,7 @@ class TestModeCortexRuntimeHotReload:
                 await asyncio.sleep(0.2)
                 task.cancel()
 
-                runtime._reload_config.assert_called_once()
+                runtime._full_reload.assert_called_once()
             except asyncio.CancelledError:
                 pass
 
@@ -498,7 +502,7 @@ class TestModeCortexRuntimeHotReload:
             )
             runtime.last_modified = 1234567890.0
 
-            runtime._reload_config = AsyncMock()
+            runtime._full_reload = AsyncMock()
 
             task = asyncio.create_task(runtime._check_config_changes())
 
@@ -506,7 +510,7 @@ class TestModeCortexRuntimeHotReload:
                 await asyncio.sleep(0.2)
                 task.cancel()
 
-                runtime._reload_config.assert_not_called()
+                runtime._full_reload.assert_not_called()
             except asyncio.CancelledError:
                 pass
 
@@ -531,7 +535,7 @@ class TestModeCortexRuntimeHotReload:
             runtime.config_path = "/nonexistent/file.json5"
             runtime.last_modified = 1.0
 
-            runtime._reload_config = AsyncMock()
+            runtime._full_reload = AsyncMock()
 
             task = asyncio.create_task(runtime._check_config_changes())
 
@@ -539,13 +543,13 @@ class TestModeCortexRuntimeHotReload:
                 await asyncio.sleep(0.2)
                 task.cancel()
 
-                runtime._reload_config.assert_not_called()
+                runtime._full_reload.assert_not_called()
             except asyncio.CancelledError:
                 pass
 
     @pytest.mark.asyncio
-    async def test_reload_config_success(self, mock_system_config):
-        """Test successful config reload."""
+    async def test_full_reload_success(self, mock_system_config):
+        """Test successful full config reload."""
         with (
             patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
             patch("runtime.multi_mode.cortex.IOProvider"),
@@ -577,7 +581,7 @@ class TestModeCortexRuntimeHotReload:
             runtime._start_orchestrators = AsyncMock()
             runtime._run_cortex_loop = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             mock_load_config.assert_called_once_with(
                 "test_config", mode_source_path="/fake/path/test_config.json5"
@@ -590,8 +594,8 @@ class TestModeCortexRuntimeHotReload:
             assert runtime.mode_manager.config == new_mock_config
 
     @pytest.mark.asyncio
-    async def test_reload_config_mode_not_found(self, mock_system_config):
-        """Test config reload when current mode is not in new config."""
+    async def test_full_reload_mode_not_found(self, mock_system_config):
+        """Test full reload when current mode is not in new config."""
         with (
             patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
             patch("runtime.multi_mode.cortex.IOProvider"),
@@ -623,14 +627,14 @@ class TestModeCortexRuntimeHotReload:
             runtime._start_orchestrators = AsyncMock()
             runtime._run_cortex_loop = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             runtime._initialize_mode.assert_called_once_with("default_mode")
             assert runtime.mode_manager.state.current_mode == "default_mode"
 
     @pytest.mark.asyncio
-    async def test_reload_config_failure(self, mock_system_config):
-        """Test config reload failure handling."""
+    async def test_full_reload_failure(self, mock_system_config):
+        """Test full reload failure handling."""
         with (
             patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
             patch("runtime.multi_mode.cortex.IOProvider"),
@@ -654,7 +658,7 @@ class TestModeCortexRuntimeHotReload:
 
             runtime._stop_current_orchestrators = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             runtime._stop_current_orchestrators.assert_called_once()
 
@@ -744,3 +748,217 @@ class TestModeCortexRuntimeHotReload:
 
                 mock_config_watcher.cancel.assert_called_once()
                 mock_gather.assert_called_once()
+
+
+class TestMultiModeSelectiveHotReload:
+    """Test cases for selective field-based hot reload in ModeCortexRuntime."""
+
+    def test_detect_changed_fields_safe_top_level(self):
+        """Top-level safe fields changed → in 'safe' set."""
+        old = {"system_governance": "old", "default_mode": "m1", "modes": {}}
+        new = {"system_governance": "new", "default_mode": "m1", "modes": {}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert result["safe"] == {"system_governance"}
+        assert result["unsafe"] == set()
+
+    def test_detect_changed_fields_unsafe_top_level(self):
+        """Top-level unsafe fields changed → in 'unsafe' set."""
+        old = {"default_mode": "m1", "api_key": "old", "modes": {}}
+        new = {"default_mode": "m2", "api_key": "new", "modes": {}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert result["safe"] == set()
+        assert result["unsafe"] == {"default_mode", "api_key"}
+
+    def test_detect_changed_fields_safe_mode_fields(self):
+        """Per-mode safe fields changed → in 'safe' set with dot notation."""
+        old = {"modes": {"scan": {"system_prompt_base": "old", "hertz": 1}}}
+        new = {"modes": {"scan": {"system_prompt_base": "new", "hertz": 2}}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert "modes.scan.system_prompt_base" in result["safe"]
+        assert "modes.scan.hertz" in result["safe"]
+        assert result["unsafe"] == set()
+
+    def test_detect_changed_fields_unsafe_mode_fields(self):
+        """Per-mode unsafe fields changed → in 'unsafe' set."""
+        old = {"modes": {"scan": {"agent_inputs": []}}}
+        new = {"modes": {"scan": {"agent_inputs": [{"type": "X"}]}}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert "modes.scan.agent_inputs" in result["unsafe"]
+
+    def test_detect_changed_fields_modes_added(self):
+        """Mode added → 'modes' in unsafe set."""
+        old = {"modes": {"scan": {}}}
+        new = {"modes": {"scan": {}, "alert": {}}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert "modes" in result["unsafe"]
+
+    def test_detect_changed_fields_modes_removed(self):
+        """Mode removed → 'modes' in unsafe set."""
+        old = {"modes": {"scan": {}, "alert": {}}}
+        new = {"modes": {"scan": {}}}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert "modes" in result["unsafe"]
+
+    def test_detect_changed_fields_transition_rules(self):
+        """Transition rules changed → unsafe."""
+        old = {"modes": {}, "transition_rules": [{"from": "a", "to": "b"}]}
+        new = {"modes": {}, "transition_rules": [{"from": "a", "to": "c"}]}
+        result = ModeCortexRuntime._detect_changed_fields(old, new)
+        assert "transition_rules" in result["unsafe"]
+
+    def test_detect_changed_fields_no_changes(self):
+        """Identical configs → both sets empty."""
+        cfg = {"system_governance": "gov", "modes": {"m1": {"hertz": 1}}}
+        result = ModeCortexRuntime._detect_changed_fields(cfg, cfg.copy())
+        assert result["safe"] == set()
+        assert result["unsafe"] == set()
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_active_mode(self, mock_system_config):
+        """Safe reload updates active mode's RuntimeConfig in-place."""
+        with (
+            patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.multi_mode.cortex.IOProvider"),
+            patch("runtime.multi_mode.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "scan"
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=False
+            )
+            runtime.mode_manager = mock_manager
+
+            # Set up a mock current_config and mode_config
+            runtime.current_config = Mock()
+            runtime.current_config.system_prompt_base = "old"
+            runtime.current_config.hertz = 1.0
+
+            mock_mode = Mock()
+            mock_mode.system_prompt_base = "old"
+            mock_mode.hertz = 1.0
+            runtime.mode_config.modes = {"scan": mock_mode}
+
+            new_raw = {
+                "modes": {
+                    "scan": {"system_prompt_base": "new prompt", "hertz": 5.0}
+                }
+            }
+            await runtime._apply_safe_reload(
+                new_raw,
+                {"modes.scan.system_prompt_base", "modes.scan.hertz"},
+            )
+
+            assert runtime.current_config.system_prompt_base == "new prompt"
+            assert runtime.current_config.hertz == 5.0
+            assert mock_mode.system_prompt_base == "new prompt"
+            assert mock_mode.hertz == 5.0
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_inactive_mode(self, mock_system_config):
+        """Safe reload on inactive mode updates ModeConfig but not RuntimeConfig."""
+        with (
+            patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.multi_mode.cortex.IOProvider"),
+            patch("runtime.multi_mode.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "scan"
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=False
+            )
+            runtime.mode_manager = mock_manager
+
+            runtime.current_config = Mock()
+            runtime.current_config.system_prompt_base = "scan prompt"
+
+            mock_alert_mode = Mock()
+            mock_alert_mode.system_prompt_base = "old alert"
+            runtime.mode_config.modes = {"scan": Mock(), "alert": mock_alert_mode}
+
+            new_raw = {
+                "modes": {"alert": {"system_prompt_base": "new alert"}}
+            }
+            await runtime._apply_safe_reload(
+                new_raw, {"modes.alert.system_prompt_base"}
+            )
+
+            # ModeConfig updated
+            assert mock_alert_mode.system_prompt_base == "new alert"
+            # Active RuntimeConfig NOT changed (different mode)
+            assert runtime.current_config.system_prompt_base == "scan prompt"
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_invalid_hertz(self, mock_system_config):
+        """Invalid hertz in mode field is rejected."""
+        with (
+            patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.multi_mode.cortex.IOProvider"),
+            patch("runtime.multi_mode.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "scan"
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=False
+            )
+            runtime.mode_manager = mock_manager
+
+            runtime.current_config = Mock()
+            runtime.current_config.hertz = 2.0
+
+            mock_mode = Mock()
+            mock_mode.hertz = 2.0
+            runtime.mode_config.modes = {"scan": mock_mode}
+
+            new_raw = {"modes": {"scan": {"hertz": -1}}}
+            await runtime._apply_safe_reload(new_raw, {"modes.scan.hertz"})
+
+            assert runtime.current_config.hertz == 2.0
+            assert mock_mode.hertz == 2.0
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_top_level_governance(self, mock_system_config):
+        """Safe reload of top-level system_governance updates both configs."""
+        with (
+            patch("runtime.multi_mode.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.multi_mode.cortex.IOProvider"),
+            patch("runtime.multi_mode.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "scan"
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=False
+            )
+            runtime.mode_manager = mock_manager
+            runtime.mode_config.system_governance = "old rules"
+            runtime.current_config = Mock()
+            runtime.current_config.system_governance = "old rules"
+
+            new_raw = {"system_governance": "new safety rules"}
+            await runtime._apply_safe_reload(new_raw, {"system_governance"})
+
+            assert runtime.mode_config.system_governance == "new safety rules"
+            assert runtime.current_config.system_governance == "new safety rules"

--- a/tests/runtime/single_mode/test_cortex.py
+++ b/tests/runtime/single_mode/test_cortex.py
@@ -354,8 +354,10 @@ class TestCortexRuntimeHotReload:
             )
             runtime.config_path = temp_config_file
             runtime.last_modified = 1.0
+            runtime._last_raw_config = {"hertz": 1}
+            runtime._read_raw_config = Mock(return_value={"hertz": 1, "agent_inputs": [{"type": "new"}]})
 
-            runtime._reload_config = AsyncMock()
+            runtime._full_reload = AsyncMock()
 
             task = asyncio.create_task(runtime._check_config_changes())
 
@@ -363,7 +365,7 @@ class TestCortexRuntimeHotReload:
                 await asyncio.sleep(0.2)
                 task.cancel()
 
-                runtime._reload_config.assert_called_once()
+                runtime._full_reload.assert_called_once()
             except asyncio.CancelledError:
                 pass
 
@@ -398,7 +400,7 @@ class TestCortexRuntimeHotReload:
             )
             runtime.last_modified = 1234567890.0
 
-            runtime._reload_config = AsyncMock()
+            runtime._full_reload = AsyncMock()
 
             task = asyncio.create_task(runtime._check_config_changes())
 
@@ -406,13 +408,13 @@ class TestCortexRuntimeHotReload:
                 await asyncio.sleep(0.2)
                 task.cancel()
 
-                runtime._reload_config.assert_not_called()
+                runtime._full_reload.assert_not_called()
             except asyncio.CancelledError:
                 pass
 
     @pytest.mark.asyncio
-    async def test_reload_config_success(self, mock_config, mock_dependencies):
-        """Test successful config reload."""
+    async def test_full_reload_success(self, mock_config, mock_dependencies):
+        """Test successful full config reload."""
         with (
             patch(
                 "runtime.single_mode.cortex.Fuser",
@@ -445,7 +447,7 @@ class TestCortexRuntimeHotReload:
             runtime._stop_current_orchestrators = AsyncMock()
             runtime._start_orchestrators = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             mock_load_config.assert_called_once()
             runtime._stop_current_orchestrators.assert_called_once()
@@ -454,8 +456,8 @@ class TestCortexRuntimeHotReload:
             assert runtime.config == new_mock_config
 
     @pytest.mark.asyncio
-    async def test_reload_config_no_config_name(self, mock_config, mock_dependencies):
-        """Test config reload with no config name."""
+    async def test_full_reload_no_config_name(self, mock_config, mock_dependencies):
+        """Test full reload with no config name."""
         with (
             patch(
                 "runtime.single_mode.cortex.Fuser",
@@ -484,14 +486,14 @@ class TestCortexRuntimeHotReload:
 
             runtime._stop_current_orchestrators = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             mock_load_config.assert_not_called()
             runtime._stop_current_orchestrators.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_reload_config_failure(self, mock_config, mock_dependencies):
-        """Test config reload failure handling."""
+    async def test_full_reload_failure(self, mock_config, mock_dependencies):
+        """Test full reload failure handling."""
         with (
             patch(
                 "runtime.single_mode.cortex.Fuser",
@@ -522,7 +524,7 @@ class TestCortexRuntimeHotReload:
 
             runtime._stop_current_orchestrators = AsyncMock()
 
-            await runtime._reload_config()
+            await runtime._full_reload()
 
             runtime._stop_current_orchestrators.assert_not_called()
 
@@ -733,3 +735,259 @@ class TestCortexRuntimeHotReload:
 
                 mock_config_watcher.cancel.assert_called_once()
                 mock_gather.assert_called_once()
+
+
+class TestSelectiveHotReload:
+    """Test cases for selective field-based hot reload in CortexRuntime."""
+
+    @pytest.fixture
+    def temp_config_file(self):
+        """Create a temporary config file for testing."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json5", delete=False) as f:
+            f.write('{"test": "config"}')
+            temp_path = f.name
+        yield temp_path
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+
+    def test_detect_changed_fields_safe_only(self):
+        """Only safe fields changed → all in 'safe' set."""
+        old = {"hertz": 1, "system_prompt_base": "old", "agent_inputs": []}
+        new = {"hertz": 2, "system_prompt_base": "new", "agent_inputs": []}
+        result = CortexRuntime._detect_changed_fields(old, new)
+        assert result["safe"] == {"hertz", "system_prompt_base"}
+        assert result["unsafe"] == set()
+
+    def test_detect_changed_fields_unsafe_only(self):
+        """Only unsafe fields changed → all in 'unsafe' set."""
+        old = {"hertz": 1, "agent_inputs": [{"type": "A"}]}
+        new = {"hertz": 1, "agent_inputs": [{"type": "B"}]}
+        result = CortexRuntime._detect_changed_fields(old, new)
+        assert result["safe"] == set()
+        assert result["unsafe"] == {"agent_inputs"}
+
+    def test_detect_changed_fields_mixed(self):
+        """Both safe and unsafe changed → both sets populated."""
+        old = {"hertz": 1, "agent_inputs": [], "system_governance": "old"}
+        new = {"hertz": 2, "agent_inputs": [{"type": "X"}], "system_governance": "new"}
+        result = CortexRuntime._detect_changed_fields(old, new)
+        assert result["safe"] == {"hertz", "system_governance"}
+        assert result["unsafe"] == {"agent_inputs"}
+
+    def test_detect_changed_fields_no_changes(self):
+        """Identical configs → both sets empty."""
+        cfg = {"hertz": 1, "system_prompt_base": "same", "agent_inputs": []}
+        result = CortexRuntime._detect_changed_fields(cfg, cfg.copy())
+        assert result["safe"] == set()
+        assert result["unsafe"] == set()
+
+    def test_detect_changed_fields_new_key_added(self):
+        """A new key appears in the new config."""
+        old = {"hertz": 1}
+        new = {"hertz": 1, "cortex_llm": {"type": "OpenAI"}}
+        result = CortexRuntime._detect_changed_fields(old, new)
+        assert "cortex_llm" in result["unsafe"]
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_prompts(self, mock_config, mock_dependencies):
+        """Safe reload updates prompt fields in-place on RuntimeConfig."""
+        with (
+            patch(
+                "runtime.single_mode.cortex.Fuser",
+                return_value=mock_dependencies["fuser"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.ActionOrchestrator",
+                return_value=mock_dependencies["action_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SimulatorOrchestrator",
+                return_value=mock_dependencies["simulator_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SleepTickerProvider",
+                return_value=mock_dependencies["sleep_ticker_provider"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.BackgroundOrchestrator",
+                return_value=mock_dependencies["background_orchestrator"],
+            ),
+        ):
+            runtime = CortexRuntime(mock_config, "test_config", hot_reload=False)
+            runtime.config.system_prompt_base = "old prompt"
+            runtime.config.system_governance = "old gov"
+
+            new_raw = {
+                "system_prompt_base": "new prompt",
+                "system_governance": "new gov",
+            }
+            await runtime._apply_safe_reload(
+                new_raw, {"system_prompt_base", "system_governance"}
+            )
+
+            assert runtime.config.system_prompt_base == "new prompt"
+            assert runtime.config.system_governance == "new gov"
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_hertz(self, mock_config, mock_dependencies):
+        """Safe reload updates hertz in-place."""
+        with (
+            patch(
+                "runtime.single_mode.cortex.Fuser",
+                return_value=mock_dependencies["fuser"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.ActionOrchestrator",
+                return_value=mock_dependencies["action_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SimulatorOrchestrator",
+                return_value=mock_dependencies["simulator_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SleepTickerProvider",
+                return_value=mock_dependencies["sleep_ticker_provider"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.BackgroundOrchestrator",
+                return_value=mock_dependencies["background_orchestrator"],
+            ),
+        ):
+            runtime = CortexRuntime(mock_config, "test_config", hot_reload=False)
+            runtime.config.hertz = 1.0
+
+            await runtime._apply_safe_reload({"hertz": 5.0}, {"hertz"})
+            assert runtime.config.hertz == 5.0
+
+    @pytest.mark.asyncio
+    async def test_apply_safe_reload_invalid_hertz(self, mock_config, mock_dependencies):
+        """Invalid hertz value is rejected during safe reload."""
+        with (
+            patch(
+                "runtime.single_mode.cortex.Fuser",
+                return_value=mock_dependencies["fuser"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.ActionOrchestrator",
+                return_value=mock_dependencies["action_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SimulatorOrchestrator",
+                return_value=mock_dependencies["simulator_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SleepTickerProvider",
+                return_value=mock_dependencies["sleep_ticker_provider"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.BackgroundOrchestrator",
+                return_value=mock_dependencies["background_orchestrator"],
+            ),
+        ):
+            runtime = CortexRuntime(mock_config, "test_config", hot_reload=False)
+            runtime.config.hertz = 1.0
+
+            # Zero hertz → rejected
+            await runtime._apply_safe_reload({"hertz": 0}, {"hertz"})
+            assert runtime.config.hertz == 1.0
+
+            # Negative hertz → rejected
+            await runtime._apply_safe_reload({"hertz": -5}, {"hertz"})
+            assert runtime.config.hertz == 1.0
+
+    @pytest.mark.asyncio
+    async def test_check_config_safe_change_skips_full_reload(
+        self, mock_config, mock_dependencies, temp_config_file
+    ):
+        """Safe-only field change does NOT trigger _full_reload."""
+        with (
+            patch(
+                "runtime.single_mode.cortex.Fuser",
+                return_value=mock_dependencies["fuser"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.ActionOrchestrator",
+                return_value=mock_dependencies["action_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SimulatorOrchestrator",
+                return_value=mock_dependencies["simulator_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SleepTickerProvider",
+                return_value=mock_dependencies["sleep_ticker_provider"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.BackgroundOrchestrator",
+                return_value=mock_dependencies["background_orchestrator"],
+            ),
+        ):
+            runtime = CortexRuntime(
+                mock_config, "test_config", hot_reload=True, check_interval=0.1
+            )
+            runtime.config_path = temp_config_file
+            runtime.last_modified = 1.0
+            runtime.config.system_prompt_base = "old"
+
+            runtime._last_raw_config = {"system_prompt_base": "old", "hertz": 1}
+            runtime._read_raw_config = Mock(
+                return_value={"system_prompt_base": "new", "hertz": 1}
+            )
+            runtime._full_reload = AsyncMock()
+
+            task = asyncio.create_task(runtime._check_config_changes())
+            try:
+                await asyncio.sleep(0.2)
+                task.cancel()
+                runtime._full_reload.assert_not_called()
+                assert runtime.config.system_prompt_base == "new"
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_check_config_no_field_changes_skips_reload(
+        self, mock_config, mock_dependencies, temp_config_file
+    ):
+        """File touched but content identical → no reload at all."""
+        with (
+            patch(
+                "runtime.single_mode.cortex.Fuser",
+                return_value=mock_dependencies["fuser"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.ActionOrchestrator",
+                return_value=mock_dependencies["action_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SimulatorOrchestrator",
+                return_value=mock_dependencies["simulator_orchestrator"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.SleepTickerProvider",
+                return_value=mock_dependencies["sleep_ticker_provider"],
+            ),
+            patch(
+                "runtime.single_mode.cortex.BackgroundOrchestrator",
+                return_value=mock_dependencies["background_orchestrator"],
+            ),
+        ):
+            runtime = CortexRuntime(
+                mock_config, "test_config", hot_reload=True, check_interval=0.1
+            )
+            runtime.config_path = temp_config_file
+            runtime.last_modified = 1.0
+
+            same_config = {"system_prompt_base": "same", "hertz": 1}
+            runtime._last_raw_config = same_config.copy()
+            runtime._read_raw_config = Mock(return_value=same_config.copy())
+            runtime._full_reload = AsyncMock()
+            runtime._apply_safe_reload = AsyncMock()
+
+            task = asyncio.create_task(runtime._check_config_changes())
+            try:
+                await asyncio.sleep(0.2)
+                task.cancel()
+                runtime._full_reload.assert_not_called()
+                runtime._apply_safe_reload.assert_not_called()
+            except asyncio.CancelledError:
+                pass


### PR DESCRIPTION
## Summary

Implements selective hot-reload for runtime configs as requested in #984. Instead of restarting all orchestrators on every config file change, the system now:

- **Reads the raw JSON5** from disk and compares field-by-field against the previous snapshot
- **Safe fields** (`system_prompt_base`, `system_governance`, `system_prompt_examples`, `hertz`) are updated **in-place** on the live `RuntimeConfig` via `setattr()` — no orchestrator restart needed
- **Structural fields** (`agent_inputs`, `agent_actions`, `cortex_llm`, `simulators`, `backgrounds`, etc.) still trigger the existing full reload path
- **File touched but unchanged** — detected and skipped entirely (no reload at all)

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| Raw JSON5 deep comparison | Avoids model serialization issues; catches nested changes reliably |
| `hertz` validation (must be > 0) | Prevents division-by-zero in the cortex loop |
| No new dependencies | Uses existing `json5` import already in both cortex files |
| No new files | All logic lives in `CortexRuntime` and `ModeCortexRuntime` where `_check_config_changes` already exists |
| Both runtimes covered | Single-mode and multi-mode get the same selective reload |

### Multi-mode specifics

- Top-level safe fields: `system_governance`, `system_prompt_examples`
- Per-mode safe fields: `system_prompt_base`, `system_prompt_examples`, `hertz`, `description`, `display_name`
- Mode added/removed → full reload
- Transition rules changed → full reload
- Changes to inactive modes update `ModeConfig` only; changes to the active mode also patch the live `RuntimeConfig`

### Files changed

- `src/runtime/single_mode/cortex.py` — added `_read_raw_config`, `_detect_changed_fields`, `_apply_safe_reload`; renamed `_reload_config` → `_full_reload`; updated `_check_config_changes` routing logic
- `src/runtime/multi_mode/cortex.py` — same pattern adapted for `ModeSystemConfig` + `ModeConfig` hierarchy
- `tests/runtime/single_mode/test_cortex.py` — updated existing tests + 11 new selective reload tests
- `tests/runtime/multi_mode/test_cortex.py` — updated existing tests + 12 new selective reload tests

## Test plan

- [x] All 62 runtime cortex tests pass (21 new + 41 existing updated)
- [x] Full suite: 1995 passed (2 pre-existing failures unrelated to this PR)
- [x] Safe-only field changes verified to skip `_full_reload`
- [x] Unsafe field changes verified to trigger `_full_reload`
- [x] File-touch-without-content-change verified to skip all reload
- [x] Invalid hertz values (0, negative) rejected with warning
- [x] Per-mode changes on active vs inactive modes handled correctly

Closes #984