### PR TITLE
fix: add missing OM1_COMMAND to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,6 @@ TWITTER_ACCESS_TOKEN_SECRET=
 
 # Robot IP address fallback (used when not specified in config file)
 ROBOT_IP=
+
+# Command to run (e.g., unitree_go2_modes). Used by Docker.
+OM1_COMMAND=


### PR DESCRIPTION
## What
Adds the missing `OM1_COMMAND` environment variable to `.env.example`.

## Why
`OM1_COMMAND` is used in both `Dockerfile` (lines 82-83) and `docker-compose.yml` (line 48) but was not listed in `.env.example`, making it undiscoverable for new users setting up Docker deployments.

## Changes
- Added `OM1_COMMAND=` with descriptive comment to `.env.example`

Same pattern as #2153.