### PR TITLE
docs: fix docstring in ActionConnector.connect()

### DIFF
--- a/src/actions/base.py
+++ b/src/actions/base.py
@@ -129,12 +129,12 @@ class ActionConnector(ABC, T.Generic[CT, OT]):
     @abstractmethod
     async def connect(self, output_interface: OT) -> None:
         """
-        Connect the input protocol to the action.
+        Connect the output interface to the action.
 
         Parameters
         ----------
         output_interface : OT
-            The input protocol containing the action details.
+            The output interface containing the action details.
         """
         pass
 


### PR DESCRIPTION
## What
Fixes the docstring in `ActionConnector.connect()` to match the actual parameter name.

## Why
The docstring refers to "input protocol" but the parameter is called `output_interface`. This is misleading for developers implementing custom action connectors.

## Changes
- `src/actions/base.py`: Changed "input protocol" → "output interface" in the `connect()` method docstring (2 lines).