### PR TITLE
fix(tests): avoid mutable default argument in mock_llm_ask

### DIFF
--- a/tests/integration/test_case_runner.py
+++ b/tests/integration/test_case_runner.py
@@ -365,7 +365,8 @@ async def run_test_case(config: Dict[str, Any]) -> Dict[str, Any]:
     # Mock LLM ask method to capture raw response
     original_llm_ask = cortex.config.cortex_llm.ask
 
-    async def mock_llm_ask(prompt: str, messages: List[Dict[str, str]] = []):
+    async def mock_llm_ask(prompt: str, messages: Optional[List[Dict[str, str]]] = None):
+        messages = messages or []
         logging.info(
             f"Generated prompt: {prompt[:200]}..."
         )  # Log first 200 chars of prompt


### PR DESCRIPTION
# Overview
Eliminate mutable default argument in `mock_llm_ask` to prevent shared state across test invocations.

# Change
- Replace `messages=[]` with `messages: Optional[List[Dict[str, str]]] = None`
- Initialize a new list inside the function

# Impact
- No behavior change
- Improves test reliability
- Ruff and Pyright compliant
