### PR TITLE
docs: clarify speak action behavior in agent_actions

### DIFF
--- a/docs/developing/3_configuration.md
+++ b/docs/developing/3_configuration.md
@@ -190,7 +190,11 @@ Lists the simulation modules used by the agent. Here is an example configuration
 
 ## Agent Actions (`agent_actions`)
 
-Defines the agent's available capabilities, including action names, their implementation, and the connector used to execute them. Here is an example configuration for the `agent_actions` section:
+Defines the agent's available capabilities, including action names, their implementation, and the connector used to execute them.
+
+**Important:** Only actions explicitly listed in `agent_actions` are available to the LLM. For example, if you want the agent to produce speech output via TTS, you must include the `speak` action. Without it, the LLM has no way to trigger speech execution.
+
+Here is a basic example with `move` and `speak`:
 
 ```python
   "agent_actions": [
@@ -207,6 +211,34 @@ Defines the agent's available capabilities, including action names, their implem
       "connector": "ros2"
     }
   ]
+```
+
+Here is a more complete example combining `speak`, `move`, and `emotion` with concurrent execution:
+
+```json5
+  action_execution_mode: "concurrent",
+  agent_actions: [
+    {
+      name: "speak",
+      llm_label: "speak",
+      connector: "elevenlabs_tts",
+      config: {
+        voice_id: "TbMNBJ27fH2U0VgpSNko",
+        silence_rate: 20,
+      },
+    },
+    {
+      name: "move",
+      llm_label: "move",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      connector: "avatar",
+    },
+  ],
 ```
 
 You can customize the actions following the [Action Plugin Guide](6_actions.md)

--- a/docs/developing/6_actions.md
+++ b/docs/developing/6_actions.md
@@ -30,8 +30,68 @@ This plugin is an example of how to directly connect to the Unitree python SDK t
 
 The Speech and TTS action plugin allows agents to speak using a text-to-speech (TTS) system.
 
+**Important:** The `speak` action must be explicitly included in your `agent_actions` configuration for the agent to produce speech output. If `speak` is not listed, the LLM may still generate text responses, but they will not be converted to audio.
+
+The following TTS connectors are available:
+
+| Connector | Description |
+|-----------|-------------|
+| `elevenlabs_tts` | Cloud-based TTS via ElevenLabs. Supports `voice_id` and `silence_rate` config options. |
+| `kokoro_tts` | Local TTS using Kokoro. |
+| `riva_tts` | NVIDIA Riva TTS. |
+| `ub_tts` | UbTech robot TTS. |
+| `zenoh` | TTS over Zenoh middleware. |
+| `ros2` | TTS over ROS2. |
+
 [**Code**](https://github.com/OpenMind/OM1/blob/main/src/actions/speak/connector/elevenlabs_tts.py)
 
+## Emotion / Face
+
+The Emotion action allows agents to express emotions through facial expressions or LED indicators. Available emotions: `happy`, `sad`, `mad`, `curious`.
+
+| Connector | Description |
+|-----------|-------------|
+| `avatar` | Web-based avatar facial expressions (used with WebSim). |
+| `ros2` | Emotion display over ROS2. |
+| `unitree_sdk` | Unitree robot LED color mapping. |
+
+[**Code**](https://github.com/OpenMind/OM1/tree/main/src/actions/emotion)
+
+## Combining speak, move, and emotion
+
+Actions can be executed together so the agent can speak, move, and show emotion simultaneously. To enable this, list all desired actions in `agent_actions` and set `action_execution_mode` to `"concurrent"`:
+
+```json5
+{
+  action_execution_mode: "concurrent",
+  agent_actions: [
+    {
+      name: "speak",
+      llm_label: "speak",
+      connector: "elevenlabs_tts",
+      config: {
+        voice_id: "TbMNBJ27fH2U0VgpSNko",
+        silence_rate: 20,
+      },
+    },
+    {
+      name: "move",
+      llm_label: "move",
+      implementation: "passthrough",
+      connector: "ros2",
+    },
+    {
+      name: "face",
+      llm_label: "emotion",
+      connector: "avatar",
+    },
+  ],
+}
+```
+
+With this configuration, the LLM can produce function calls for all three actions in a single response, and they will be executed at the same time.
+
+> **Note:** Only actions listed in `agent_actions` are available to the LLM. If you want the agent to speak, `speak` must be explicitly included. The same applies to `move` and `emotion`.
 
 ## Adding New Actions
 


### PR DESCRIPTION
## Summary
- Clarify that `speak` must be explicitly listed in `agent_actions` for TTS/speech output to work
- Add TTS connector reference table (ElevenLabs, Kokoro, Riva, UbTech, Zenoh, ROS2)
- Add Emotion/Face action documentation with available connectors
- Add combined `speak` + `move` + `emotion` configuration example with concurrent execution

Closes #2176

## Files changed
- `docs/developing/6_actions.md` — added speak requirement note, TTS connector table, emotion docs, and combined action example
- `docs/developing/3_configuration.md` — added explicit action declaration note and combined action config example

## Test plan
- [x] pre-commit hooks pass (trailing-whitespace, end-of-file, typos)
- [ ] Verify docs render correctly on GitBook