### PR TITLE
fix: multi-mode runtime cross-platform file ops and transition recovery

### DIFF
--- a/src/runtime/multi_mode/cortex.py
+++ b/src/runtime/multi_mode/cortex.py
@@ -186,6 +186,9 @@ class ModeCortexRuntime:
         """
         Handle mode transitions by gracefully stopping current components and starting new ones for the target mode.
 
+        If the transition to the target mode fails, attempts to roll back to the
+        previous mode so the system remains operational.
+
         Parameters
         ----------
         from_mode : str
@@ -212,8 +215,21 @@ class ModeCortexRuntime:
 
         except Exception as e:
             logging.error(f"Error during mode transition {from_mode} -> {to_mode}: {e}")
-            # TODO: Implement fallback/recovery mechanism
-            raise
+            logging.info(f"Attempting to roll back to previous mode: {from_mode}")
+
+            try:
+                await self._initialize_mode(from_mode)
+                await self._start_orchestrators()
+
+                self.mode_manager.state.current_mode = from_mode
+                self.mode_manager.state.mode_start_time = time.time()
+
+                logging.info(f"Successfully rolled back to mode: {from_mode}")
+            except Exception as rollback_error:
+                logging.error(
+                    f"Rollback to '{from_mode}' also failed: {rollback_error}. "
+                    f"System may be in an inconsistent state."
+                )
         finally:
             self._is_reloading = False
 

--- a/src/runtime/multi_mode/manager.py
+++ b/src/runtime/multi_mode/manager.py
@@ -148,7 +148,7 @@ class ModeManager:
             with open(temp_file, "w") as f:
                 json5.dump(runtime_config, f, indent=2)
 
-            os.rename(temp_file, runtime_config_path)
+            os.replace(temp_file, runtime_config_path)
             logging.debug(f"Runtime config file created/updated: {runtime_config_path}")
 
         except Exception:
@@ -531,7 +531,7 @@ class ModeManager:
                 logging.debug(
                     f"Transition already in progress, skipping transition to {target_mode}"
                 )
-                return True
+                return False
 
             self._is_transitioning = True
             from_mode = self.state.current_mode
@@ -942,7 +942,7 @@ class ModeManager:
             with open(temp_file, "w") as f:
                 json.dump(state_data, f, indent=2)
 
-            os.rename(temp_file, state_file)
+            os.replace(temp_file, state_file)
             logging.debug(f"Mode state saved to {state_file}")
 
         except Exception as e:

--- a/tests/runtime/multi_mode/test_cortex_mode_transition.py
+++ b/tests/runtime/multi_mode/test_cortex_mode_transition.py
@@ -834,3 +834,99 @@ def test_available_modes_structure(cortex_runtime):
     assert result["default"]["is_current"] is True
     assert result["advanced"]["is_current"] is False
     assert result["emergency"]["is_current"] is False
+
+
+@pytest.mark.asyncio
+async def test_on_mode_transition_rolls_back_on_initialize_failure(cortex_runtime):
+    """Test that _on_mode_transition rolls back to the previous mode when
+    initialization of the target mode fails."""
+    runtime, components = cortex_runtime
+
+    runtime._stop_current_orchestrators = AsyncMock()
+    runtime._start_orchestrators = AsyncMock()
+
+    call_count = 0
+    original_from_mode = "default"
+    target_mode = "advanced"
+
+    async def mock_initialize(mode):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1 and mode == target_mode:
+            raise RuntimeError("Failed to load advanced mode config")
+
+    runtime._initialize_mode = AsyncMock(side_effect=mock_initialize)
+    runtime.mode_manager = Mock()
+    runtime.mode_manager.state = Mock()
+    runtime.mode_manager.state.current_mode = original_from_mode
+
+    await runtime._on_mode_transition(original_from_mode, target_mode)
+
+    assert runtime._initialize_mode.call_count == 2
+    runtime._initialize_mode.assert_any_call(target_mode)
+    runtime._initialize_mode.assert_any_call(original_from_mode)
+    assert runtime._is_reloading is False
+    assert runtime.mode_manager.state.current_mode == original_from_mode
+
+
+@pytest.mark.asyncio
+async def test_on_mode_transition_rolls_back_on_start_failure(cortex_runtime):
+    """Test that _on_mode_transition rolls back when starting orchestrators fails
+    after a successful mode initialization."""
+    runtime, components = cortex_runtime
+
+    runtime._stop_current_orchestrators = AsyncMock()
+    runtime._initialize_mode = AsyncMock()
+
+    start_call_count = 0
+
+    async def mock_start():
+        nonlocal start_call_count
+        start_call_count += 1
+        if start_call_count == 1:
+            raise RuntimeError("Orchestrator failed to start")
+
+    runtime._start_orchestrators = AsyncMock(side_effect=mock_start)
+    runtime.mode_manager = Mock()
+    runtime.mode_manager.state = Mock()
+    runtime.mode_manager.state.current_mode = "default"
+
+    await runtime._on_mode_transition("default", "advanced")
+
+    assert runtime._start_orchestrators.call_count == 2
+    assert runtime._is_reloading is False
+    assert runtime.mode_manager.state.current_mode == "default"
+
+
+@pytest.mark.asyncio
+async def test_on_mode_transition_reloading_flag_cleared_on_success(cortex_runtime):
+    """Test that _is_reloading is properly cleared after a successful transition."""
+    runtime, components = cortex_runtime
+
+    runtime._stop_current_orchestrators = AsyncMock()
+    runtime._initialize_mode = AsyncMock()
+    runtime._start_orchestrators = AsyncMock()
+
+    runtime._is_reloading = False
+
+    await runtime._on_mode_transition("default", "advanced")
+
+    assert runtime._is_reloading is False
+
+
+@pytest.mark.asyncio
+async def test_on_mode_transition_reloading_flag_cleared_on_total_failure(cortex_runtime):
+    """Test that _is_reloading is cleared even when both the transition and
+    the rollback attempt fail."""
+    runtime, components = cortex_runtime
+
+    runtime._stop_current_orchestrators = AsyncMock()
+    runtime._initialize_mode = AsyncMock(
+        side_effect=RuntimeError("All modes broken")
+    )
+    runtime.mode_manager = Mock()
+    runtime.mode_manager.state = Mock()
+
+    await runtime._on_mode_transition("default", "advanced")
+
+    assert runtime._is_reloading is False

--- a/tests/runtime/multi_mode/test_manager.py
+++ b/tests/runtime/multi_mode/test_manager.py
@@ -1423,3 +1423,93 @@ class TestModeManager:
                 "Updated user context with" in record.message
                 for record in caplog.records
             )
+
+
+class TestFileOperations:
+    """Tests for cross-platform file write operations."""
+
+    @pytest.fixture
+    def mode_manager(self, sample_system_config):
+        with (
+            patch("runtime.multi_mode.manager.open_zenoh_session"),
+            patch("runtime.multi_mode.manager.ModeManager._load_mode_state"),
+        ):
+            return ModeManager(sample_system_config)
+
+    def test_save_mode_state_overwrites_existing_file(self, mode_manager):
+        """Test that saving mode state works when the file already exists."""
+        mode_manager.state.current_mode = "default"
+        mode_manager.state.previous_mode = None
+        mode_manager.state.transition_history = ["init"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_file = os.path.join(temp_dir, "test_state.json5")
+
+            with patch.object(
+                mode_manager, "_get_state_file_path", return_value=state_file
+            ):
+                # First write
+                mode_manager._save_mode_state()
+
+                with open(state_file, "r") as f:
+                    first_data = json.load(f)
+                assert first_data["last_active_mode"] == "default"
+
+                # Transition then second write (overwrite)
+                mode_manager.state.current_mode = "advanced"
+                mode_manager.state.previous_mode = "default"
+                mode_manager.state.transition_history = [
+                    "init",
+                    "default->advanced:manual",
+                ]
+
+                mode_manager._save_mode_state()
+
+                with open(state_file, "r") as f:
+                    second_data = json.load(f)
+                assert second_data["last_active_mode"] == "advanced"
+                assert second_data["previous_mode"] == "default"
+
+    def test_create_runtime_config_file_overwrites_existing(self, mode_manager):
+        """Test that runtime config file creation works when the file already exists."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = os.path.join(temp_dir, ".runtime.json5")
+
+            with patch.object(
+                mode_manager, "_get_runtime_config_path", return_value=config_path
+            ):
+                # First write
+                mode_manager._create_runtime_config_file()
+                assert os.path.exists(config_path)
+
+                # Second write (overwrite)
+                mode_manager._create_runtime_config_file()
+                assert os.path.exists(config_path)
+
+
+class TestTransitionReturnValue:
+    """Tests for _execute_transition return values."""
+
+    @pytest.fixture
+    def mode_manager(self, sample_system_config):
+        with (
+            patch("runtime.multi_mode.manager.open_zenoh_session"),
+            patch("runtime.multi_mode.manager.ModeManager._load_mode_state"),
+        ):
+            return ModeManager(sample_system_config)
+
+    @pytest.mark.asyncio
+    async def test_execute_transition_same_mode_returns_true(self, mode_manager):
+        """Test that transitioning to the same mode returns True."""
+        result = await mode_manager._execute_transition("default", "test")
+        assert result is True
+        assert mode_manager.state.current_mode == "default"
+
+    @pytest.mark.asyncio
+    async def test_execute_transition_valid_target_succeeds(self, mode_manager):
+        """Test that transitioning to a valid target mode succeeds."""
+        with patch.object(mode_manager, "_save_mode_state"):
+            result = await mode_manager._execute_transition("advanced", "test")
+            assert result is True
+            assert mode_manager.state.current_mode == "advanced"
+            assert mode_manager.state.previous_mode == "default"


### PR DESCRIPTION
## Summary

Fixes three bugs in the multi-mode runtime system:

1. **Cross-platform file write failure** (`manager.py`): `os.rename()` fails on Windows when the destination file already exists. The single-mode cortex already uses `os.replace()` correctly, but the multi-mode `ModeManager` still used `os.rename()` in two places — `_create_runtime_config_file` and `_save_mode_state`. Replaced both with `os.replace()` for atomic cross-platform writes.

2. **Incorrect return value for skipped transitions** (`manager.py`): `_execute_transition` returned `True` when a transition was skipped because another transition was already in progress. This is misleading — callers interpret `True` as "transition completed successfully". Changed to return `False` so callers can distinguish between a successful transition and a skipped one.

3. **No recovery on failed mode transitions** (`cortex.py`): `_on_mode_transition` had an explicit `TODO: Implement fallback/recovery mechanism` comment. When the transition to a new mode failed (e.g. bad config, missing plugin), the exception propagated and left the runtime in a broken state — old orchestrators stopped, new ones never started. Implemented rollback logic that attempts to re-initialize the previous mode when the target mode fails, keeping the system operational.

Closes #2202

## Test plan

- [x] Added `TestFileOperations` tests verifying `os.replace` overwrites work correctly
- [x] Added `TestTransitionReturnValue` tests verifying return value semantics for `_execute_transition`
- [x] Added 4 transition recovery tests: rollback on init failure, rollback on start failure, reloading flag cleared on success, reloading flag cleared on total failure