### PR TITLE
fix: make rf_mapper scan state thread-safe and harden sleep/shutdown

### DIFF
--- a/src/backgrounds/plugins/rf_mapper.py
+++ b/src/backgrounds/plugins/rf_mapper.py
@@ -273,6 +273,7 @@ class RFmapper(Background[RFmapperConfig]):
                 fresh_scan_results: List[RFData] = []
                 with self.scan_lock:
                     if self.scan_results and self.scan_idx > self.scan_last_sent:
+                        fresh_scan_results = list(self.scan_results)
                         self.scan_last_sent = self.scan_idx
                         self.scan_results = []
                         scan_last_sent = self.scan_last_sent


### PR DESCRIPTION
## Problem
`RFmapper` updates scan state from a background thread and reads it from the run loop without synchronization. This can produce inconsistent reads and race conditions.

There are also two runtime reliability issues:
- `self.sleep(1)` is called even though `RFmapper` has no `sleep()` method
- shutdown waits with an unconditional sleep before `join()`

Related issue: #1771

## Changes
- add `threading.Lock()` (`scan_lock`) for shared scan state
- guard `scan_idx`, `scan_results`, and `scan_last_sent` reads/writes with the lock
- replace deprecated `logging.warn` with `logging.warning`
- remove unused `self.seen_names`
- replace `self.sleep(1)` with `time.sleep(1.0)`
- replace stop-time sleep + join with `self.thread.join(timeout=1.0)`

## Validation
- `python3 -m py_compile src/backgrounds/plugins/rf_mapper.py`
