### PR TITLE
improve(inputs): surface queue drop diagnostics for face and gallery callbacks

### DIFF
--- a/src/inputs/plugins/face_presence_input.py
+++ b/src/inputs/plugins/face_presence_input.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 from collections import deque
 from queue import Empty, Queue
@@ -100,6 +101,7 @@ class FacePresence(FuserInput[FacePresenceConfig, Optional[str]]):
         try:
             self.message_buffer.put_nowait(text_line)
         except Exception:
+            logging.debug("FacePresence queue full; dropping oldest message to enqueue")
             try:
                 _ = self.message_buffer.get_nowait()
             except Empty:
@@ -107,6 +109,9 @@ class FacePresence(FuserInput[FacePresenceConfig, Optional[str]]):
             try:
                 self.message_buffer.put_nowait(text_line)
             except Exception:
+                logging.warning(
+                    "FacePresence queue still full; dropping latest message"
+                )
                 pass
 
     async def _poll(self) -> Optional[str]:

--- a/src/inputs/plugins/gallery_identities_input.py
+++ b/src/inputs/plugins/gallery_identities_input.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 from collections import deque
 from queue import Empty, Queue
@@ -91,6 +92,9 @@ class GalleryIdentities(FuserInput[GalleryIdentitiesConfig, Optional[str]]):
         try:
             self.message_buffer.put_nowait(text_line)
         except Exception:
+            logging.debug(
+                "GalleryIdentities queue full; dropping oldest message to enqueue"
+            )
             try:
                 _ = self.message_buffer.get_nowait()
             except Empty:
@@ -98,6 +102,9 @@ class GalleryIdentities(FuserInput[GalleryIdentitiesConfig, Optional[str]]):
             try:
                 self.message_buffer.put_nowait(text_line)
             except Exception:
+                logging.warning(
+                    "GalleryIdentities queue still full; dropping latest message"
+                )
                 pass
 
     async def _poll(self) -> Optional[str]:


### PR DESCRIPTION
# Overview
Improve diagnostics for input queue backpressure in face presence and gallery identities inputs.

# Changes
- Add logging on queue full to surface dropped messages in `FacePresence`.
- Add logging on queue full to surface dropped messages in `GalleryIdentities`.

# Impact
No behavior changes to queueing strategy or message flow; only additional debug/warn logs for visibility.

# Testing
all ruff check passed

# Additional Information
None.