### PR TITLE
improve(vlm): surface JSONDecodeError diagnostics in VLMVila handlers

### DIFF
--- a/src/inputs/plugins/vlm_vila.py
+++ b/src/inputs/plugins/vlm_vila.py
@@ -104,7 +104,11 @@ class VLMVila(FuserInput[VLMVilaConfig, Optional[str]]):
                 self.message_buffer.put(vlm_reply)
                 logging.info("Detected VLM message: %s", vlm_reply)
         except json.JSONDecodeError:
-            pass
+            snippet = raw_message[:200]
+            suffix = "…" if len(raw_message) > 200 else ""
+            logging.warning(
+                "Malformed VLM message (invalid JSON): %s%s", snippet, suffix
+            )
 
     async def _poll(self) -> Optional[str]:
         """

--- a/src/inputs/plugins/vlm_vila_rtsp.py
+++ b/src/inputs/plugins/vlm_vila_rtsp.py
@@ -102,7 +102,11 @@ class VLMVilaRTSP(FuserInput[VLMVilaRTSPConfig, Optional[str]]):
                 self.message_buffer.put(vlm_reply)
                 logging.info("Detected VLM message: %s", vlm_reply)
         except json.JSONDecodeError:
-            pass
+            snippet = raw_message[:200]
+            suffix = "…" if len(raw_message) > 200 else ""
+            logging.warning(
+                "Malformed VLM message (invalid JSON): %s%s", snippet, suffix
+            )
 
     async def _poll(self) -> Optional[str]:
         """

--- a/src/inputs/plugins/vlm_vila_zenoh.py
+++ b/src/inputs/plugins/vlm_vila_zenoh.py
@@ -101,7 +101,11 @@ class VLMVilaZenoh(FuserInput[VLMVilaZenohConfig, Optional[str]]):
                 self.message_buffer.put(vlm_reply)
                 logging.info("Detected VLM message: %s", vlm_reply)
         except json.JSONDecodeError:
-            pass
+            snippet = raw_message[:200]
+            suffix = "…" if len(raw_message) > 200 else ""
+            logging.warning(
+                "Malformed VLM message (invalid JSON): %s%s", snippet, suffix
+            )
 
     async def _poll(self) -> Optional[str]:
         """


### PR DESCRIPTION
# Overview
Add diagnostics for malformed JSON in VLMVila input handlers to avoid silent drops.

# Changes
- Log a warning with a truncated payload snippet when VLMVila, VLMVilaRTSP, or VLMVilaZenoh receives invalid JSON.

# Impact
Improves visibility into upstream message corruption or format drift without changing message parsing behavior.

# Testing
all ruff check passed

# Additional Information
None.