### PR TITLE
improve(hooks): log ignored lifecycle hook failures for better observability

### DIFF
--- a/src/runtime/multi_mode/hook.py
+++ b/src/runtime/multi_mode/hook.py
@@ -677,7 +677,11 @@ async def execute_lifecycle_hooks(
                         )
                         return False
                     if hook.on_failure == "ignore":
-                        pass
+                        logging.warning(
+                            "Lifecycle hook failed and was ignored: type=%s handler=%s",
+                            hook.hook_type.value,
+                            hook.handler_type,
+                        )
             else:
                 logging.error(
                     f"Failed to create handler for lifecycle hook: {hook.handler_type}"


### PR DESCRIPTION
# Overview
Surface ignored lifecycle hook failures to improve diagnostics without changing behavior.

# Changes
- Log a warning when a lifecycle hook returns `False` and `on_failure="ignore"` in `src/runtime/multi_mode/hook.py`.

# Impact
Makes silent hook failures visible while preserving existing control flow and failure handling.

# Testing
all ruff check passed

# Additional Information
None.