### PR TITLE
improve(config-provider): return explicit error response when runtime config is missing or unreadable

### DIFF
--- a/tests/providers/test_config_provider.py
+++ b/tests/providers/test_config_provider.py
@@ -1,28 +1,32 @@
+"""Tests for ConfigProvider."""
+
 import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from providers.config_provider import ConfigProvider
+from providers.config_provider import ConfigProvider  # pylint: disable=import-error
+from zenoh_msgs import String  # pylint: disable=import-error
 
 
 @pytest.fixture(autouse=True)
 def reset_singleton():
     """Reset singleton instances between tests."""
-    ConfigProvider.reset()  # type: ignore
+    ConfigProvider.reset()  # type: ignore[attr-defined]  # pylint: disable=no-member
     yield
 
     try:
         provider = ConfigProvider()
         provider.stop()
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         pass
 
-    ConfigProvider.reset()  # type: ignore
+    ConfigProvider.reset()  # type: ignore[attr-defined]  # pylint: disable=no-member
 
 
-@pytest.fixture
-def mock_zenoh():
+@pytest.fixture(name="zenoh_mocks")
+def _zenoh_mocks():
+    """Provide mocked Zenoh session, publisher, and subscriber."""
     with patch("providers.config_provider.open_zenoh_session") as mock_session:
         mock_session_instance = MagicMock()
         mock_publisher = MagicMock()
@@ -33,8 +37,9 @@ def mock_zenoh():
         yield mock_session, mock_session_instance, mock_publisher, mock_subscriber
 
 
-def test_initialization(mock_zenoh):
-    mock_session, mock_session_instance, mock_publisher, mock_subscriber = mock_zenoh
+def test_initialization(zenoh_mocks):
+    """Ensure ConfigProvider initializes Zenoh components."""
+    _, mock_session_instance, mock_publisher, mock_subscriber = zenoh_mocks
     provider = ConfigProvider()
 
     assert provider.running
@@ -49,20 +54,24 @@ def test_initialization(mock_zenoh):
 
 
 def test_singleton_pattern():
+    """Ensure ConfigProvider is a singleton."""
     provider1 = ConfigProvider()
     provider2 = ConfigProvider()
     assert provider1 is provider2
 
 
-def test_get_runtime_config_path(mock_zenoh):
+@pytest.mark.usefixtures("zenoh_mocks")
+def test_get_runtime_config_path():
+    """Ensure runtime config path points to memory .runtime.json5."""
     provider = ConfigProvider()
-    config_path = provider._get_runtime_config_path()
+    config_path = provider._get_runtime_config_path()  # pylint: disable=protected-access
 
     assert config_path.endswith(".runtime.json5")
     assert "config/memory" in config_path
 
 
 def test_initialization_failure():
+    """Ensure initialization failure results in a non-running provider."""
     with patch("providers.config_provider.open_zenoh_session") as mock_session:
         mock_session.side_effect = Exception("Connection failed")
         provider = ConfigProvider()
@@ -71,8 +80,9 @@ def test_initialization_failure():
         assert provider.session is None
 
 
-def test_stop(mock_zenoh):
-    _, mock_session_instance, _, _ = mock_zenoh
+def test_stop(zenoh_mocks):
+    """Ensure provider stop closes the Zenoh session."""
+    _, mock_session_instance, _, _ = zenoh_mocks
     provider = ConfigProvider()
 
     provider.stop()
@@ -81,9 +91,9 @@ def test_stop(mock_zenoh):
     mock_session_instance.close.assert_called_once()
 
 
-def test_handle_config_request(mock_zenoh):
+def test_handle_config_request(zenoh_mocks):
     """Test that config request handler is registered correctly."""
-    _, mock_session_instance, _, _ = mock_zenoh
+    _, mock_session_instance, _, _ = zenoh_mocks
     ConfigProvider()
 
     call_args = mock_session_instance.declare_subscriber.call_args
@@ -91,7 +101,8 @@ def test_handle_config_request(mock_zenoh):
     assert callable(call_args[0][1])
 
 
-def test_set_config_uses_unique_temp_file(mock_zenoh, tmp_path):
+@pytest.mark.usefixtures("zenoh_mocks")
+def test_set_config_uses_unique_temp_file(tmp_path):
     """Test that _handle_set_config uses unique temp file names to prevent race condition."""
     provider = ConfigProvider()
     provider.config_path = str(tmp_path / ".runtime.json5")
@@ -105,14 +116,16 @@ def test_set_config_uses_unique_temp_file(mock_zenoh, tmp_path):
 
     with patch("os.rename", side_effect=track_rename):
         with patch.object(provider, "_send_config_response"):
-            from zenoh_msgs import String
-
-            provider._handle_set_config(String("req1"), '{"key": "value1"}')
-            provider._handle_set_config(String("req2"), '{"key": "value2"}')
+            provider._handle_set_config(  # pylint: disable=protected-access
+                String("req1"), '{"key": "value1"}'
+            )
+            provider._handle_set_config(  # pylint: disable=protected-access
+                String("req2"), '{"key": "value2"}'
+            )
 
     assert len(temp_paths_used) == 2
-    assert (
-        temp_paths_used[0] != temp_paths_used[1]
-    ), "Temp files should have unique names"
+    assert temp_paths_used[0] != temp_paths_used[1], (
+        "Temp files should have unique names"
+    )
     assert ".tmp." in temp_paths_used[0], "Temp file should contain .tmp. prefix"
     assert ".tmp." in temp_paths_used[1], "Temp file should contain .tmp. prefix"


### PR DESCRIPTION
**Overview**  
This PR improves ConfigProvider’s diagnostics by returning explicit error responses when the runtime config file can’t be read, instead of silently responding with an empty config.

**Changes**  
1. `src/providers/config_provider.py`:  
   - Return an error response when `_get_config_snapshot` fails.  
   - Improve logging and add explicit file encoding.  
   - Add module docstring and adjust logging formatting.  
   - Add type/pylint ignores for optional dependencies (`json5`, `zenoh`) in this environment.

2. `tests/providers/test_config_provider.py`:  
   - Clean up imports and fixtures for linting.  
   - Add minimal docstrings and pylint annotations for singleton reset usage.  
   - Keep line endings consistent for linting.

**Impact**  
- No runtime behavior changes on success paths.  
- When the config file is missing or unreadable, clients now receive an explicit failure response instead of a misleading success with `{}`.  
- Improves diagnostics without changing control flow.

**Testing**  
ruff check passed

**Additional Information**  
- This PR is intentionally scoped to diagnostics and lint compliance only.