### PR TITLE
fix(llm): avoid mutable default messages argument across ask() methods

### DIFF
--- a/src/llm/function_schemas.py
+++ b/src/llm/function_schemas.py
@@ -41,7 +41,10 @@ def generate_function_schema_from_action(action) -> dict:
             properties[field_name] = {
                 "type": "string",
                 "enum": enum_values,
-                "description": f"The {field_name} to perform. Must be one of: {', '.join(enum_values)}",
+                "description": (
+                    f"The {field_name} to perform. Must be one of: "
+                    f"{', '.join(enum_values)}"
+                ),
             }
         elif isinstance(field_type, str):
             properties[field_name] = {
@@ -108,11 +111,11 @@ def generate_function_schemas_from_actions(actions: list) -> list[dict]:
                 schema = generate_function_schema_from_action(action)
                 schemas.append(schema)
                 logging.debug(
-                    f"Generated function schema for {action.llm_label}: {schema}"
+                    "Generated function schema for %s: %s", action.llm_label, schema
                 )
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-exception-caught
                 logging.error(
-                    f"Error generating function schema for {action.llm_label}: {e}"
+                    "Error generating function schema for %s: %s", action.llm_label, e
                 )
 
     return schemas
@@ -145,7 +148,7 @@ def convert_function_calls_to_actions(function_calls: list[dict]) -> list[Action
                     args = json.loads(function_args)
                 except json.JSONDecodeError:
                     logging.error(
-                        f"Failed to parse function arguments: {function_args}"
+                        "Failed to parse function arguments: %s", function_args
                     )
                     continue
             else:
@@ -169,11 +172,14 @@ def convert_function_calls_to_actions(function_calls: list[dict]) -> list[Action
             actions.append(action)
 
             logging.info(
-                f"Converted function call {function_name}({args}) to action: {action}"
+                "Converted function call %s(%s) to action: %s",
+                function_name,
+                args,
+                action,
             )
 
-        except Exception as e:
-            logging.error(f"Error converting function call to action: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.error("Error converting function call to action: %s", e)
             continue
 
     return actions

--- a/src/llm/output_model.py
+++ b/src/llm/output_model.py
@@ -1,3 +1,5 @@
+"""Pydantic models for LLM action outputs."""
+
 from pydantic import BaseModel, Field
 
 

--- a/src/llm/plugins/openai_llm.py
+++ b/src/llm/plugins/openai_llm.py
@@ -1,3 +1,6 @@
+"""OpenAI-backed LLM implementation."""
+# pylint: disable=duplicate-code
+
 import logging
 import time
 import typing as T
@@ -30,7 +33,7 @@ class OpenAIModel(str, Enum):
     GPT_5_2 = "gpt-5.2"
 
 
-class OpenAIConfig(LLMConfig):
+class OpenAIConfig(LLMConfig):  # pylint: disable=too-few-public-methods
     """OpenAI-specific configuration with model enum."""
 
     base_url: T.Optional[str] = Field(
@@ -43,7 +46,7 @@ class OpenAIConfig(LLMConfig):
     )
 
 
-class OpenAILLM(LLM[R]):
+class OpenAILLM(LLM[R]):  # pylint: disable=too-few-public-methods
     """
     An OpenAI-based Language Learning Model implementation with function call support.
 
@@ -85,7 +88,7 @@ class OpenAILLM(LLM[R]):
     @AvatarLLMState.trigger_thinking()
     @LLMHistoryManager.update_history()
     async def ask(
-        self, prompt: str, messages: T.List[T.Dict[str, str]] = []
+        self, prompt: str, messages: T.Optional[T.List[T.Dict[str, str]]] = None
     ) -> T.Optional[R]:
         """
         Send a prompt to the OpenAI API and get a structured response.
@@ -103,9 +106,12 @@ class OpenAILLM(LLM[R]):
             Parsed response matching the output_model structure, or None if
             parsing fails.
         """
+        if messages is None:
+            messages = []
+
         try:
-            logging.info(f"OpenAI input: {prompt}")
-            logging.info(f"OpenAI messages: {messages}")
+            logging.info("OpenAI input: %s", prompt)
+            logging.info("OpenAI messages: %s", messages)
 
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
@@ -132,8 +138,10 @@ class OpenAILLM(LLM[R]):
             self.io_provider.llm_end_time = time.time()
 
             if message.tool_calls:
-                logging.info(f"Received {len(message.tool_calls)} function calls")
-                logging.info(f"Function calls: {message.tool_calls}")
+                logging.info(
+                    "Received %d function calls", len(message.tool_calls)
+                )
+                logging.info("Function calls: %s", message.tool_calls)
 
                 function_call_data = [
                     {
@@ -152,6 +160,6 @@ class OpenAILLM(LLM[R]):
 
             return None
 
-        except Exception as e:
-            logging.error(f"OpenAI API error: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.error("OpenAI API error: %s", e)
             return None

--- a/src/llm/plugins/qwen_llm.py
+++ b/src/llm/plugins/qwen_llm.py
@@ -1,3 +1,6 @@
+"""Qwen-backed LLM implementation."""
+# pylint: disable=duplicate-code
+
 import json
 import logging
 import re
@@ -51,12 +54,12 @@ def _parse_qwen_tool_calls(text: str) -> list:
                         },
                     }
                 )
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             continue
     return tool_calls
 
 
-class QwenLLM(LLM[R]):
+class QwenLLM(LLM[R]):  # pylint: disable=too-few-public-methods
     """
     Local Qwen LLM implementation using OpenAI-compatible API.
 
@@ -112,7 +115,7 @@ class QwenLLM(LLM[R]):
     @AvatarLLMState.trigger_thinking()
     @LLMHistoryManager.update_history()
     async def ask(
-        self, prompt: str, messages: T.List[T.Dict[str, T.Any]] = []
+        self, prompt: str, messages: T.Optional[T.List[T.Dict[str, T.Any]]] = None
     ) -> R | None:
         """
         Send prompt to local Qwen model and get structured response.
@@ -129,9 +132,12 @@ class QwenLLM(LLM[R]):
         R or None
             Parsed response with actions, or None if parsing fails.
         """
+        if messages is None:
+            messages = []
+
         try:
-            logging.info(f"Qwen input: {prompt}")
-            logging.info(f"Qwen messages: {messages}")
+            logging.info("Qwen input: %s", prompt)
+            logging.info("Qwen messages: %s", messages)
 
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
@@ -173,8 +179,8 @@ class QwenLLM(LLM[R]):
                 tool_calls = _parse_qwen_tool_calls(message.content)
 
             if tool_calls:
-                logging.info(f"Received {len(tool_calls)} function calls")
-                logging.info(f"Function calls: {tool_calls}")
+                logging.info("Received %d function calls", len(tool_calls))
+                logging.info("Function calls: %s", tool_calls)
 
                 function_call_data = [
                     {
@@ -198,6 +204,6 @@ class QwenLLM(LLM[R]):
                 return T.cast(R, result)
 
             return None
-        except Exception as e:
-            logging.error(f"Qwen LLM error: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.error("Qwen LLM error: %s", e)
             return None

--- a/src/llm/plugins/rag_multi_llm.py
+++ b/src/llm/plugins/rag_multi_llm.py
@@ -107,7 +107,10 @@
 #                             if rag_tools:
 #                                 logging.info(f"RAG tools data: {rag_tools}")
 #                                 tools_lines = [
-#                                     "\n\nThe following tools were used to gather this information:"
+#                                     (
+#                                         "\n\nThe following tools were used to gather "
+#                                         "this information:"
+#                                     )
 #                                 ]
 #                                 tools_lines += [
 #                                     f"- {tool.get('tool_name', 'Unknown tool')}"

--- a/src/llm/plugins/xai_llm.py
+++ b/src/llm/plugins/xai_llm.py
@@ -1,3 +1,6 @@
+"""XAI-backed LLM implementation."""
+# pylint: disable=duplicate-code
+
 import logging
 import time
 import typing as T
@@ -24,7 +27,7 @@ class XAIModel(str, Enum):
     GROK_4 = "grok-4"
 
 
-class XAIConfig(LLMConfig):
+class XAIConfig(LLMConfig):  # pylint: disable=too-few-public-methods
     """XAI-specific configuration with model enum."""
 
     base_url: T.Optional[str] = Field(
@@ -37,7 +40,7 @@ class XAIConfig(LLMConfig):
     )
 
 
-class XAILLM(LLM[R]):
+class XAILLM(LLM[R]):  # pylint: disable=too-few-public-methods
     """
     XAI LLM implementation using OpenAI-compatible API.
 
@@ -77,7 +80,7 @@ class XAILLM(LLM[R]):
     @AvatarLLMState.trigger_thinking()
     @LLMHistoryManager.update_history()
     async def ask(
-        self, prompt: str, messages: T.List[T.Dict[str, str]] = []
+        self, prompt: str, messages: T.Optional[T.List[T.Dict[str, str]]] = None
     ) -> T.Optional[R]:
         """
         Execute LLM query and parse response.
@@ -95,9 +98,12 @@ class XAILLM(LLM[R]):
             Parsed response matching the output_model structure, or None if
             parsing fails.
         """
+        if messages is None:
+            messages = []
+
         try:
-            logging.debug(f"XAI LLM input: {prompt}")
-            logging.debug(f"XAI LLM messages: {messages}")
+            logging.debug("XAI LLM input: %s", prompt)
+            logging.debug("XAI LLM messages: %s", messages)
 
             self.io_provider.llm_start_time = time.time()
             self.io_provider.set_llm_prompt(prompt)
@@ -124,8 +130,10 @@ class XAILLM(LLM[R]):
             self.io_provider.llm_end_time = time.time()
 
             if message.tool_calls:
-                logging.info(f"Received {len(message.tool_calls)} function calls")
-                logging.info(f"Function calls: {message.tool_calls}")
+                logging.info(
+                    "Received %d function calls", len(message.tool_calls)
+                )
+                logging.info("Function calls: %s", message.tool_calls)
 
                 function_call_data = [
                     {
@@ -140,10 +148,10 @@ class XAILLM(LLM[R]):
                 actions = convert_function_calls_to_actions(function_call_data)
 
                 result = CortexOutputModel(actions=actions)
-                logging.info(f"XAI LLM function call output: {result}")
+                logging.info("XAI LLM function call output: %s", result)
                 return T.cast(R, result)
 
             return None
-        except Exception as e:
-            logging.error(f"XAI API error: {e}")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logging.error("XAI API error: %s", e)
             return None


### PR DESCRIPTION
# Overview
Cleaned up LLM module/plugin linting issues and made the `ask` signatures safe from mutable default leakage, while keeping runtime behavior unchanged.

# Changes
- Replaced mutable default `messages=[]` with `messages: Optional[...] = None` and guarded initialization across LLM base and plugins.
- Standardized logging to lazy formatting and added explicit exception chaining where pylint requested it.
- Added missing module docstrings and scoped pylint disables for known/acceptable patterns (duplicate-code, too-few-public-methods, broad-exception-caught, too-many-locals/branches).
- Wrapped overlong commented lines and normalized line endings to eliminate mixed-line-ending warnings.

# Impact
- Reduces risk of cross-request message state leakage in long-lived processes.
- Improves lint signal quality and keeps strict CI green without altering behavior.

# Testing
all check passed

# Additional Information
- Changes are diagnostic/maintenance-only; no new features or behavior changes were introduced.