### PR TITLE
test: add unit tests for 14 background plugins

### DIFF
--- a/tests/backgrounds/plugins/test_d435.py
+++ b/tests/backgrounds/plugins/test_d435.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.base import BackgroundConfig
+from backgrounds.plugins.d435 import D435
+
+
+class TestD435:
+    """Test cases for D435 background plugin."""
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        assert background.config is config
+        assert background.d435_provider == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            D435(config)
+
+        assert "Initiated D435 Provider in background" in caplog.text
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_provider_attribute(self, mock_provider_class):
+        """Test that d435_provider attribute is set correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        assert background.d435_provider is mock_provider
+
+    @patch("backgrounds.plugins.d435.D435Provider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = D435(config)
+
+        assert background.config is config

--- a/tests/backgrounds/plugins/test_elevenlabs_tts.py
+++ b/tests/backgrounds/plugins/test_elevenlabs_tts.py
@@ -1,0 +1,181 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.elevenlabs_tts import ElevenLabsTTS, ElevenLabsTTSConfig
+
+
+class TestElevenLabsTTSConfig:
+    """Test cases for ElevenLabsTTSConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = ElevenLabsTTSConfig()
+        assert config.api_key is None
+        assert config.elevenlabs_api_key is None
+        assert config.voice_id == "JBFqnCBsd6RMkjVDRZzb"
+        assert config.model_id == "eleven_flash_v2_5"
+        assert config.output_format == "mp3_44100_128"
+
+    def test_custom_api_key(self):
+        """Test custom api_key configuration."""
+        config = ElevenLabsTTSConfig(api_key="test-om-key")
+        assert config.api_key == "test-om-key"
+
+    def test_custom_elevenlabs_api_key(self):
+        """Test custom elevenlabs_api_key configuration."""
+        config = ElevenLabsTTSConfig(elevenlabs_api_key="test-el-key")
+        assert config.elevenlabs_api_key == "test-el-key"
+
+    def test_custom_voice_id(self):
+        """Test custom voice_id configuration."""
+        config = ElevenLabsTTSConfig(voice_id="custom_voice")
+        assert config.voice_id == "custom_voice"
+
+    def test_custom_model_id(self):
+        """Test custom model_id configuration."""
+        config = ElevenLabsTTSConfig(model_id="eleven_turbo_v2")
+        assert config.model_id == "eleven_turbo_v2"
+
+    def test_custom_output_format(self):
+        """Test custom output_format configuration."""
+        config = ElevenLabsTTSConfig(output_format="pcm_16000")
+        assert config.output_format == "pcm_16000"
+
+    def test_all_custom_values(self):
+        """Test configuration with all custom values."""
+        config = ElevenLabsTTSConfig(
+            api_key="om-key",
+            elevenlabs_api_key="el-key",
+            voice_id="voice123",
+            model_id="model456",
+            output_format="wav_44100",
+        )
+        assert config.api_key == "om-key"
+        assert config.elevenlabs_api_key == "el-key"
+        assert config.voice_id == "voice123"
+        assert config.model_id == "model456"
+        assert config.output_format == "wav_44100"
+
+
+class TestElevenLabsTTS:
+    """Test cases for ElevenLabsTTS background plugin."""
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider, starts, and configures it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig()
+        background = ElevenLabsTTS(config)
+
+        assert background.config is config
+        assert background.tts == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+        mock_provider.configure.assert_called_once()
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_provider_initialized_with_correct_params(self, mock_provider_class):
+        """Test that provider is initialized with correct parameters."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig(
+            api_key="om-key",
+            elevenlabs_api_key="el-key",
+            voice_id="voice123",
+            model_id="model456",
+            output_format="wav_44100",
+        )
+        ElevenLabsTTS(config)
+
+        mock_provider_class.assert_called_once_with(
+            url="https://api.openmind.org/api/core/elevenlabs/tts",
+            api_key="om-key",
+            elevenlabs_api_key="el-key",
+            voice_id="voice123",
+            model_id="model456",
+            output_format="wav_44100",
+        )
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_provider_configure_called_with_correct_params(self, mock_provider_class):
+        """Test that provider.configure() is called with correct parameters."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig(
+            api_key="om-key",
+            elevenlabs_api_key="el-key",
+            voice_id="voice123",
+            model_id="model456",
+            output_format="wav_44100",
+        )
+        ElevenLabsTTS(config)
+
+        mock_provider.configure.assert_called_once_with(
+            url="https://api.openmind.org/api/core/elevenlabs/tts",
+            api_key="om-key",
+            elevenlabs_api_key="el-key",
+            voice_id="voice123",
+            model_id="model456",
+            output_format="wav_44100",
+        )
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig()
+        with caplog.at_level("INFO"):
+            ElevenLabsTTS(config)
+
+        assert "Eleven Labs TTS Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_start_called_before_configure(self, mock_provider_class):
+        """Test that start() is called before configure()."""
+        call_order = []
+        mock_provider = MagicMock()
+        mock_provider.start.side_effect = lambda: call_order.append("start")
+        mock_provider.configure.side_effect = lambda **kwargs: call_order.append(
+            "configure"
+        )
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig()
+        ElevenLabsTTS(config)
+
+        assert call_order == ["start", "configure"]
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_default_config_params_passed_to_provider(self, mock_provider_class):
+        """Test that default config params are passed to provider."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig()
+        ElevenLabsTTS(config)
+
+        mock_provider_class.assert_called_once_with(
+            url="https://api.openmind.org/api/core/elevenlabs/tts",
+            api_key=None,
+            elevenlabs_api_key=None,
+            voice_id="JBFqnCBsd6RMkjVDRZzb",
+            model_id="eleven_flash_v2_5",
+            output_format="mp3_44100_128",
+        )
+
+    @patch("backgrounds.plugins.elevenlabs_tts.ElevenLabsTTSProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = ElevenLabsTTSConfig(api_key="test-key")
+        background = ElevenLabsTTS(config)
+
+        assert background.config is config
+        assert background.config.api_key == "test-key"

--- a/tests/backgrounds/plugins/test_gps.py
+++ b/tests/backgrounds/plugins/test_gps.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.gps import Gps, GpsConfig
+
+
+class TestGpsConfig:
+    """Test cases for GpsConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = GpsConfig()
+        assert config.serial_port is None
+
+    def test_custom_serial_port(self):
+        """Test custom serial port configuration."""
+        config = GpsConfig(serial_port="/dev/ttyUSB0")
+        assert config.serial_port == "/dev/ttyUSB0"
+
+
+class TestGps:
+    """Test cases for Gps background plugin."""
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_initialization_with_port(self, mock_provider_class):
+        """Test background initialization with valid serial port."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = GpsConfig(serial_port="/dev/ttyUSB0")
+        background = Gps(config)
+
+        assert background.config is config
+        assert background.gps_provider == mock_provider
+        mock_provider_class.assert_called_once_with(serial_port="/dev/ttyUSB0")
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_initialization_logging_with_port(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message with port."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = GpsConfig(serial_port="/dev/ttyUSB0")
+        with caplog.at_level("INFO"):
+            Gps(config)
+
+        assert (
+            "Initiated GPS Provider with serial port: /dev/ttyUSB0 in background"
+            in caplog.text
+        )
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_initialization_with_none_port_early_return(self, mock_provider_class):
+        """Test that None port causes early return without creating provider."""
+        config = GpsConfig()
+        background = Gps(config)
+
+        mock_provider_class.assert_not_called()
+        assert not hasattr(background, "gps_provider")
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_initialization_with_none_port_error_log(self, mock_provider_class, caplog):
+        """Test that None port logs an error message."""
+        config = GpsConfig()
+        with caplog.at_level("ERROR"):
+            Gps(config)
+
+        assert "GPS serial port not specified in config" in caplog.text
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_no_start_called(self, mock_provider_class):
+        """Test that start() is NOT called on provider (GPS has no start)."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = GpsConfig(serial_port="/dev/ttyUSB0")
+        Gps(config)
+
+        mock_provider.start.assert_not_called()
+
+    @patch("backgrounds.plugins.gps.GpsProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = GpsConfig(serial_port="/dev/ttyUSB1")
+        background = Gps(config)
+
+        assert background.config is config
+        assert background.config.serial_port == "/dev/ttyUSB1"

--- a/tests/backgrounds/plugins/test_rf_mapper.py
+++ b/tests/backgrounds/plugins/test_rf_mapper.py
@@ -1,0 +1,531 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.rf_mapper import RFmapper, RFmapperConfig
+
+
+class TestRFmapperConfig:
+    """Test cases for RFmapperConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = RFmapperConfig()
+        assert config.name == "RFmapper"
+        assert config.api_key is None
+        assert config.URID is None
+        assert config.unitree_ethernet is None
+
+    def test_custom_name(self):
+        """Test custom name configuration."""
+        config = RFmapperConfig(name="CustomMapper")
+        assert config.name == "CustomMapper"
+
+    def test_custom_api_key(self):
+        """Test custom api_key configuration."""
+        config = RFmapperConfig(api_key="test-api-key")
+        assert config.api_key == "test-api-key"
+
+    def test_custom_urid(self):
+        """Test custom URID configuration."""
+        config = RFmapperConfig(URID="robot-001")
+        assert config.URID == "robot-001"
+
+    def test_custom_unitree_ethernet(self):
+        """Test custom unitree_ethernet configuration."""
+        config = RFmapperConfig(unitree_ethernet="eth0")
+        assert config.unitree_ethernet == "eth0"
+
+    def test_all_custom_values(self):
+        """Test configuration with all custom values."""
+        config = RFmapperConfig(
+            name="Mapper1",
+            api_key="key-123",
+            URID="robot-002",
+            unitree_ethernet="enp2s0",
+        )
+        assert config.name == "Mapper1"
+        assert config.api_key == "key-123"
+        assert config.URID == "robot-002"
+        assert config.unitree_ethernet == "enp2s0"
+
+
+class TestRFmapper:
+    """Test cases for RFmapper background plugin."""
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_initialization(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test background initialization creates all providers."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+
+        mock_odom = MagicMock()
+        mock_odom_class.return_value = mock_odom
+
+        mock_fds = MagicMock()
+        mock_fds_class.return_value = mock_fds
+
+        mock_thread = MagicMock()
+        mock_thread_class.return_value = mock_thread
+
+        config = RFmapperConfig(api_key="test-key", URID="robot-001")
+        background = RFmapper(config)
+
+        assert background.name == "RFmapper"
+        assert background.api_key == "test-key"
+        assert background.URID == "robot-001"
+        assert background.gps == mock_gps
+        assert background.rtk == mock_rtk
+        assert background.odom == mock_odom
+        assert background.fds == mock_fds
+
+        mock_gps_class.assert_called_once()
+        mock_rtk_class.assert_called_once()
+        mock_odom_class.assert_called_once()
+        mock_fds_class.assert_called_once_with(
+            api_key="test-key", write_to_local_file=True
+        )
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_initialization_logging(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+        caplog,
+    ):
+        """Test that initialization logs config and provider info."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig()
+        with caplog.at_level("INFO"):
+            RFmapper(config)
+
+        assert "Mapper config:" in caplog.text
+        assert "Mapper Gps Provider:" in caplog.text
+        assert "Mapper Rtk Provider:" in caplog.text
+        assert "Mapper Odom Provider:" in caplog.text
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_thread_started_on_init(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that thread.start() is called during __init__ via self.start()."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+
+        mock_thread = MagicMock()
+        mock_thread_class.return_value = mock_thread
+
+        config = RFmapperConfig()
+        RFmapper(config)
+
+        mock_thread.start.assert_called_once()
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_initial_state_values(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that initial state values are set to defaults."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig()
+        background = RFmapper(config)
+
+        assert background.scan_results == []
+        assert background.scan_idx == 0
+        assert background.scan_last_sent == 0
+        assert background.payload_idx == 0
+        assert background.odom_x == 0.0
+        assert background.odom_y == 0.0
+        assert background.gps_lat == 0.0
+        assert background.gps_lon == 0.0
+        assert background.rtk_lat == 0.0
+        assert background.rtk_lon == 0.0
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_gps_on_reflects_provider_running(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that gps_on reflects the GPS provider's running state."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig()
+        background = RFmapper(config)
+
+        assert background.gps_on is True
+        assert background.rtk_on is False
+
+    @patch("backgrounds.plugins.rf_mapper.time.sleep")
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_stop(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+        mock_sleep,
+    ):
+        """Test stop method sets running to False and joins thread."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+
+        mock_thread = MagicMock()
+        mock_thread_class.return_value = mock_thread
+
+        config = RFmapperConfig()
+        background = RFmapper(config)
+
+        background.stop()
+
+        assert background.running is False
+        mock_sleep.assert_called_with(1)
+        mock_thread.join.assert_called_once()
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_run_parses_gps_data(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that run() parses GPS data from provider."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps.data = {
+            "gps_unix_ts": 1234567890.0,
+            "gps_lat": 40.7128,
+            "gps_lon": -74.0060,
+            "gps_alt": 10.5,
+            "yaw_mag_0_360": 180.0,
+            "gps_qua": 4,
+            "ble_scan": None,
+        }
+        mock_gps_class.return_value = mock_gps
+
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk.data = None
+        mock_rtk_class.return_value = mock_rtk
+
+        mock_odom = MagicMock()
+        mock_odom.position = None
+        mock_odom_class.return_value = mock_odom
+
+        mock_fds = MagicMock()
+        mock_fds_class.return_value = mock_fds
+
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig(URID="robot-001")
+        background = RFmapper(config)
+        # Enable running so the while loop enters, then stop after one iteration
+        background.running = True
+
+        def stop_after_one_iteration(duration):
+            background.running = False
+
+        background.sleep = stop_after_one_iteration  # type: ignore[assignment]
+
+        background.run()
+
+        assert background.gps_lat == 40.7128
+        assert background.gps_lon == -74.0060
+        assert background.gps_alt == 10.5
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_run_parses_odom_data(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that run() parses odometry data from provider."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps.data = None
+        mock_gps_class.return_value = mock_gps
+
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk.data = None
+        mock_rtk_class.return_value = mock_rtk
+
+        mock_odom = MagicMock()
+        mock_odom.position = {
+            "odom_x": 1.5,
+            "odom_y": 2.5,
+            "odom_rockchip_ts": 100.0,
+            "odom_subscriber_ts": 101.0,
+            "odom_yaw_0_360": 90.0,
+            "odom_yaw_m180_p180": 90.0,
+        }
+        mock_odom_class.return_value = mock_odom
+
+        mock_fds = MagicMock()
+        mock_fds_class.return_value = mock_fds
+
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig()
+        background = RFmapper(config)
+        background.running = True
+
+        def stop_after_one_iteration(duration):
+            background.running = False
+
+        background.sleep = stop_after_one_iteration  # type: ignore[assignment]
+
+        background.run()
+
+        assert background.odom_x == 1.5
+        assert background.odom_y == 2.5
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_run_submits_fabric_data(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that run() submits data to FabricDataSubmitter."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps.data = None
+        mock_gps_class.return_value = mock_gps
+
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk.data = None
+        mock_rtk_class.return_value = mock_rtk
+
+        mock_odom = MagicMock()
+        mock_odom.position = None
+        mock_odom_class.return_value = mock_odom
+
+        mock_fds = MagicMock()
+        mock_fds_class.return_value = mock_fds
+
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig(URID="robot-001")
+        background = RFmapper(config)
+        background.running = True
+
+        def stop_after_one_iteration(duration):
+            background.running = False
+
+        background.sleep = stop_after_one_iteration  # type: ignore[assignment]
+
+        background.run()
+
+        mock_fds.share_data.assert_called_once()
+        call_args = mock_fds.share_data.call_args[0][0]
+        assert call_args.machine_id == "robot-001"
+        assert call_args.payload_idx == 0
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_run_with_no_urid_uses_unknown(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that run() uses 'Unknown' when URID is None."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps.data = None
+        mock_gps_class.return_value = mock_gps
+
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk.data = None
+        mock_rtk_class.return_value = mock_rtk
+
+        mock_odom = MagicMock()
+        mock_odom.position = None
+        mock_odom_class.return_value = mock_odom
+
+        mock_fds = MagicMock()
+        mock_fds_class.return_value = mock_fds
+
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig()
+        background = RFmapper(config)
+        background.running = True
+
+        def stop_after_one_iteration(duration):
+            background.running = False
+
+        background.sleep = stop_after_one_iteration  # type: ignore[assignment]
+
+        background.run()
+
+        call_args = mock_fds.share_data.call_args[0][0]
+        assert call_args.machine_id == "Unknown"
+
+    @patch("backgrounds.plugins.rf_mapper.threading.Thread")
+    @patch("backgrounds.plugins.rf_mapper.FabricDataSubmitter")
+    @patch("backgrounds.plugins.rf_mapper.UnitreeGo2OdomProvider")
+    @patch("backgrounds.plugins.rf_mapper.RtkProvider")
+    @patch("backgrounds.plugins.rf_mapper.GpsProvider")
+    @patch("backgrounds.plugins.rf_mapper.asyncio.new_event_loop")
+    def test_config_stored(
+        self,
+        mock_event_loop,
+        mock_gps_class,
+        mock_rtk_class,
+        mock_odom_class,
+        mock_fds_class,
+        mock_thread_class,
+    ):
+        """Test that config is stored correctly."""
+        mock_gps = MagicMock()
+        mock_gps.running = True
+        mock_gps_class.return_value = mock_gps
+        mock_rtk = MagicMock()
+        mock_rtk.running = False
+        mock_rtk_class.return_value = mock_rtk
+        mock_odom_class.return_value = MagicMock()
+        mock_fds_class.return_value = MagicMock()
+        mock_thread_class.return_value = MagicMock()
+
+        config = RFmapperConfig(name="TestMapper", api_key="key-123")
+        background = RFmapper(config)
+
+        assert background.config is config
+        assert background.name == "TestMapper"
+        assert background.api_key == "key-123"

--- a/tests/backgrounds/plugins/test_rtk.py
+++ b/tests/backgrounds/plugins/test_rtk.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.rtk import Rtk, RtkConfig
+
+
+class TestRtkConfig:
+    """Test cases for RtkConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = RtkConfig()
+        assert config.serial_port is None
+
+    def test_custom_serial_port(self):
+        """Test custom serial port configuration."""
+        config = RtkConfig(serial_port="/dev/ttyUSB0")
+        assert config.serial_port == "/dev/ttyUSB0"
+
+
+class TestRtk:
+    """Test cases for Rtk background plugin."""
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_initialization_with_port(self, mock_provider_class):
+        """Test background initialization with valid serial port."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = RtkConfig(serial_port="/dev/ttyUSB0")
+        background = Rtk(config)
+
+        assert background.config is config
+        assert background.rtk == mock_provider
+        mock_provider_class.assert_called_once_with(serial_port="/dev/ttyUSB0")
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_initialization_logging_with_port(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message with port."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = RtkConfig(serial_port="/dev/ttyUSB0")
+        with caplog.at_level("INFO"):
+            Rtk(config)
+
+        assert (
+            "Initiated RTK Provider with serial port: /dev/ttyUSB0 in background"
+            in caplog.text
+        )
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_initialization_with_none_port_early_return(self, mock_provider_class):
+        """Test that None port causes early return without creating provider."""
+        config = RtkConfig()
+        background = Rtk(config)
+
+        mock_provider_class.assert_not_called()
+        assert not hasattr(background, "rtk")
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_initialization_with_none_port_error_log(self, mock_provider_class, caplog):
+        """Test that None port logs an error message."""
+        config = RtkConfig()
+        with caplog.at_level("ERROR"):
+            Rtk(config)
+
+        assert "RTK serial port not specified in config" in caplog.text
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_no_start_called(self, mock_provider_class):
+        """Test that start() is NOT called on provider (RTK has no start)."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = RtkConfig(serial_port="/dev/ttyUSB0")
+        Rtk(config)
+
+        mock_provider.start.assert_not_called()
+
+    @patch("backgrounds.plugins.rtk.RtkProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = RtkConfig(serial_port="/dev/ttyUSB1")
+        background = Rtk(config)
+
+        assert background.config is config
+        assert background.config.serial_port == "/dev/ttyUSB1"

--- a/tests/backgrounds/plugins/test_unitree_g1_locations.py
+++ b/tests/backgrounds/plugins/test_unitree_g1_locations.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.unitree_g1_locations import (
+    UnitreeG1Locations,
+    UnitreeG1LocationsConfig,
+)
+
+
+class TestUnitreeG1LocationsConfig:
+    """Test cases for UnitreeG1LocationsConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = UnitreeG1LocationsConfig()
+        assert config.base_url == "http://localhost:5000/maps/locations/list"
+        assert config.timeout == 5
+        assert config.refresh_interval == 30
+
+    def test_custom_base_url(self):
+        """Test custom base_url configuration."""
+        config = UnitreeG1LocationsConfig(base_url="http://example.com/locations")
+        assert config.base_url == "http://example.com/locations"
+
+    def test_custom_timeout(self):
+        """Test custom timeout configuration."""
+        config = UnitreeG1LocationsConfig(timeout=10)
+        assert config.timeout == 10
+
+    def test_custom_refresh_interval(self):
+        """Test custom refresh_interval configuration."""
+        config = UnitreeG1LocationsConfig(refresh_interval=60)
+        assert config.refresh_interval == 60
+
+    def test_all_custom_values(self):
+        """Test configuration with all custom values."""
+        config = UnitreeG1LocationsConfig(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+        assert config.base_url == "http://custom:8080/api"
+        assert config.timeout == 15
+        assert config.refresh_interval == 120
+
+
+class TestUnitreeG1Locations:
+    """Test cases for UnitreeG1Locations background plugin."""
+
+    @patch("backgrounds.plugins.unitree_g1_locations.UnitreeG1LocationsProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1LocationsConfig()
+        background = UnitreeG1Locations(config)
+
+        assert background.config is config
+        assert background.locations_provider == mock_provider
+        mock_provider_class.assert_called_once_with(
+            base_url="http://localhost:5000/maps/locations/list",
+            timeout=5,
+            refresh_interval=30,
+        )
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_g1_locations.UnitreeG1LocationsProvider")
+    def test_initialization_with_custom_config(self, mock_provider_class):
+        """Test initialization with custom configuration parameters."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1LocationsConfig(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+        UnitreeG1Locations(config)
+
+        mock_provider_class.assert_called_once_with(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+
+    @patch("backgrounds.plugins.unitree_g1_locations.UnitreeG1LocationsProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1LocationsConfig()
+        with caplog.at_level("INFO"):
+            UnitreeG1Locations(config)
+
+        assert "G1 Locations Provider initialized in background" in caplog.text
+        assert "base_url: http://localhost:5000/maps/locations/list" in caplog.text
+        assert "refresh: 30s" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_g1_locations.UnitreeG1LocationsProvider")
+    def test_provider_start_called(self, mock_provider_class):
+        """Test that provider.start() is called during initialization."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1LocationsConfig()
+        UnitreeG1Locations(config)
+
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_g1_locations.UnitreeG1LocationsProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1LocationsConfig(timeout=10)
+        background = UnitreeG1Locations(config)
+
+        assert background.config is config
+        assert background.config.timeout == 10

--- a/tests/backgrounds/plugins/test_unitree_g1_navigation.py
+++ b/tests/backgrounds/plugins/test_unitree_g1_navigation.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.base import BackgroundConfig
+from backgrounds.plugins.unitree_g1_navigation import UnitreeG1Navigation
+
+
+class TestUnitreeG1Navigation:
+    """Test cases for UnitreeG1Navigation background plugin."""
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        assert background.config is config
+        assert background.unitree_g1_navigation_provider == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeG1Navigation(config)
+
+        assert "Unitree G1 Navigation Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_provider_attribute(self, mock_provider_class):
+        """Test that provider attribute is set correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        assert background.unitree_g1_navigation_provider is mock_provider
+
+    @patch("backgrounds.plugins.unitree_g1_navigation.UnitreeG1NavigationProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeG1Navigation(config)
+
+        assert background.config is config

--- a/tests/backgrounds/plugins/test_unitree_g1_odom.py
+++ b/tests/backgrounds/plugins/test_unitree_g1_odom.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.unitree_g1_odom import UnitreeG1Odom, UnitreeG1OdomConfig
+
+
+class TestUnitreeG1OdomConfig:
+    """Test cases for UnitreeG1OdomConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = UnitreeG1OdomConfig()
+        assert config.unitree_ethernet is None
+
+    def test_custom_unitree_ethernet(self):
+        """Test custom unitree_ethernet configuration."""
+        config = UnitreeG1OdomConfig(unitree_ethernet="eth0")
+        assert config.unitree_ethernet == "eth0"
+
+    def test_config_inherits_from_background_config(self):
+        """Test that config properly inherits from BackgroundConfig."""
+        config = UnitreeG1OdomConfig(unitree_ethernet="eth1")
+        assert hasattr(config, "unitree_ethernet")
+        assert config.unitree_ethernet == "eth1"
+
+
+class TestUnitreeG1Odom:
+    """Test cases for UnitreeG1Odom background plugin."""
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1OdomConfig(unitree_ethernet="eth0")
+        background = UnitreeG1Odom(config)
+
+        assert background.config is config
+        assert background.odom_provider == mock_provider
+        mock_provider_class.assert_called_once_with("eth0")
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_initialization_with_none_ethernet(self, mock_provider_class):
+        """Test background initialization with None unitree_ethernet."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1OdomConfig()
+        background = UnitreeG1Odom(config)
+
+        assert background.config.unitree_ethernet is None
+        assert background.odom_provider == mock_provider
+        mock_provider_class.assert_called_once_with(None)
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1OdomConfig(unitree_ethernet="eth2")
+        with caplog.at_level("INFO"):
+            UnitreeG1Odom(config)
+
+        assert "Initialized Unitree G1 Odom Provider: eth2" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_initialization_logging_with_none(self, mock_provider_class, caplog):
+        """Test that initialization logs correctly with None ethernet."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1OdomConfig()
+        with caplog.at_level("INFO"):
+            UnitreeG1Odom(config)
+
+        assert "Initialized Unitree G1 Odom Provider: None" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_config_stored_correctly(self, mock_provider_class):
+        """Test that config is stored correctly in the background instance."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeG1OdomConfig(unitree_ethernet="wlan0")
+        background = UnitreeG1Odom(config)
+
+        assert background.config is config
+        assert background.config.unitree_ethernet == "wlan0"
+
+    @patch("backgrounds.plugins.unitree_g1_odom.UnitreeG1OdomProvider")
+    def test_multiple_instances_with_different_ethernet(self, mock_provider_class):
+        """Test multiple instances with different ethernet channels."""
+        mock_provider1 = MagicMock()
+        mock_provider2 = MagicMock()
+        mock_provider_class.side_effect = [mock_provider1, mock_provider2]
+
+        config1 = UnitreeG1OdomConfig(unitree_ethernet="eth0")
+        config2 = UnitreeG1OdomConfig(unitree_ethernet="eth1")
+
+        background1 = UnitreeG1Odom(config1)
+        background2 = UnitreeG1Odom(config2)
+
+        assert background1.config.unitree_ethernet == "eth0"
+        assert background2.config.unitree_ethernet == "eth1"
+        assert background1.odom_provider == mock_provider1
+        assert background2.odom_provider == mock_provider2
+
+        assert mock_provider_class.call_count == 2
+        mock_provider_class.assert_any_call("eth0")
+        mock_provider_class.assert_any_call("eth1")

--- a/tests/backgrounds/plugins/test_unitree_go2_amcl.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_amcl.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.base import BackgroundConfig
+from backgrounds.plugins.unitree_go2_amcl import UnitreeGo2AMCL
+
+
+class TestUnitreeGo2AMCL:
+    """Test cases for UnitreeGo2AMCL background plugin."""
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        assert background.config is config
+        assert background.unitree_go2_amcl_provider == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2AMCL(config)
+
+        assert "Unitree Go2 AMCL Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_provider_attribute(self, mock_provider_class):
+        """Test that provider attribute is set correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        assert background.unitree_go2_amcl_provider is mock_provider
+
+    @patch("backgrounds.plugins.unitree_go2_amcl.UnitreeGo2AMCLProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2AMCL(config)
+
+        assert background.config is config

--- a/tests/backgrounds/plugins/test_unitree_go2_frontier_exploration.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_frontier_exploration.py
@@ -1,0 +1,150 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.unitree_go2_frontier_exploration import (
+    UnitreeGo2FrontierExploration,
+    UnitreeGo2FrontierExplorationConfig,
+)
+
+
+class TestUnitreeGo2FrontierExplorationConfig:
+    """Test cases for UnitreeGo2FrontierExplorationConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = UnitreeGo2FrontierExplorationConfig()
+        assert config.topic == "explore/status"
+        assert config.context_aware_text == '{"exploration_done": true}'
+
+    def test_custom_topic(self):
+        """Test custom topic configuration."""
+        config = UnitreeGo2FrontierExplorationConfig(topic="custom/topic")
+        assert config.topic == "custom/topic"
+
+    def test_custom_context_aware_text(self):
+        """Test custom context_aware_text configuration."""
+        config = UnitreeGo2FrontierExplorationConfig(
+            context_aware_text='{"key": "value"}'
+        )
+        assert config.context_aware_text == '{"key": "value"}'
+
+
+class TestUnitreeGo2FrontierExploration:
+    """Test cases for UnitreeGo2FrontierExploration background plugin."""
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization with valid JSON config."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig()
+        background = UnitreeGo2FrontierExploration(config)
+
+        assert background.config is config
+        assert background.unitree_go2_frontier_exploration_provider == mock_provider
+        mock_provider_class.assert_called_once_with(
+            topic="explore/status",
+            context_aware_text={"exploration_done": True},
+        )
+        mock_provider.start.assert_called_once()
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_initialization_with_custom_config(self, mock_provider_class):
+        """Test initialization with custom topic and context."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig(
+            topic="nav/explore",
+            context_aware_text='{"done": false, "progress": 50}',
+        )
+        UnitreeGo2FrontierExploration(config)
+
+        mock_provider_class.assert_called_once_with(
+            topic="nav/explore",
+            context_aware_text={"done": False, "progress": 50},
+        )
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_initialization_with_invalid_json_fallback(self, mock_provider_class):
+        """Test that invalid JSON falls back to default dict."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig(
+            context_aware_text="not valid json{{{",
+        )
+        UnitreeGo2FrontierExploration(config)
+
+        mock_provider_class.assert_called_once_with(
+            topic="explore/status",
+            context_aware_text={"exploration_done": True},
+        )
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_initialization_with_invalid_json_logs_error(
+        self, mock_provider_class, caplog
+    ):
+        """Test that invalid JSON logs an error message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig(
+            context_aware_text="not valid json",
+        )
+        with caplog.at_level("ERROR"):
+            UnitreeGo2FrontierExploration(config)
+
+        assert "Error decoding context_aware_text JSON" in caplog.text
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2FrontierExploration(config)
+
+        assert (
+            "Unitree Go2 Frontier Exploration Provider initialized in background"
+            in caplog.text
+        )
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_provider_start_called(self, mock_provider_class):
+        """Test that provider.start() is called during initialization."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig()
+        UnitreeGo2FrontierExploration(config)
+
+        mock_provider.start.assert_called_once()
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_frontier_exploration.UnitreeGo2FrontierExplorationProvider"
+    )
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2FrontierExplorationConfig(topic="test/topic")
+        background = UnitreeGo2FrontierExploration(config)
+
+        assert background.config is config
+        assert background.config.topic == "test/topic"

--- a/tests/backgrounds/plugins/test_unitree_go2_lidar_localization.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_lidar_localization.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.base import BackgroundConfig
+from backgrounds.plugins.unitree_go2_lidar_localization import (
+    UnitreeGo2LidarLocalization,
+)
+
+
+class TestUnitreeGo2LidarLocalization:
+    """Test cases for UnitreeGo2LidarLocalization background plugin."""
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        assert background.config is config
+        assert background.unitree_go2_lidar_localization_provider == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2LidarLocalization(config)
+
+        assert (
+            "Unitree Go2 Lidar Localization Provider initialized in background"
+            in caplog.text
+        )
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_provider_attribute(self, mock_provider_class):
+        """Test that provider attribute is set correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        assert background.unitree_go2_lidar_localization_provider is mock_provider
+
+    @patch(
+        "backgrounds.plugins.unitree_go2_lidar_localization.UnitreeGo2LidarLocalizationProvider"
+    )
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2LidarLocalization(config)
+
+        assert background.config is config

--- a/tests/backgrounds/plugins/test_unitree_go2_locations.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_locations.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.plugins.unitree_go2_locations import (
+    UnitreeGo2Locations,
+    UnitreeGo2LocationsConfig,
+)
+
+
+class TestUnitreeGo2LocationsConfig:
+    """Test cases for UnitreeGo2LocationsConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = UnitreeGo2LocationsConfig()
+        assert config.base_url == "http://localhost:5000/maps/locations/list"
+        assert config.timeout == 5
+        assert config.refresh_interval == 30
+
+    def test_custom_base_url(self):
+        """Test custom base_url configuration."""
+        config = UnitreeGo2LocationsConfig(base_url="http://example.com/locations")
+        assert config.base_url == "http://example.com/locations"
+
+    def test_custom_timeout(self):
+        """Test custom timeout configuration."""
+        config = UnitreeGo2LocationsConfig(timeout=10)
+        assert config.timeout == 10
+
+    def test_custom_refresh_interval(self):
+        """Test custom refresh_interval configuration."""
+        config = UnitreeGo2LocationsConfig(refresh_interval=60)
+        assert config.refresh_interval == 60
+
+    def test_all_custom_values(self):
+        """Test configuration with all custom values."""
+        config = UnitreeGo2LocationsConfig(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+        assert config.base_url == "http://custom:8080/api"
+        assert config.timeout == 15
+        assert config.refresh_interval == 120
+
+
+class TestUnitreeGo2Locations:
+    """Test cases for UnitreeGo2Locations background plugin."""
+
+    @patch("backgrounds.plugins.unitree_go2_locations.UnitreeGo2LocationsProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2LocationsConfig()
+        background = UnitreeGo2Locations(config)
+
+        assert background.config is config
+        assert background.locations_provider == mock_provider
+        mock_provider_class.assert_called_once_with(
+            base_url="http://localhost:5000/maps/locations/list",
+            timeout=5,
+            refresh_interval=30,
+        )
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_go2_locations.UnitreeGo2LocationsProvider")
+    def test_initialization_with_custom_config(self, mock_provider_class):
+        """Test initialization with custom configuration parameters."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2LocationsConfig(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+        UnitreeGo2Locations(config)
+
+        mock_provider_class.assert_called_once_with(
+            base_url="http://custom:8080/api",
+            timeout=15,
+            refresh_interval=120,
+        )
+
+    @patch("backgrounds.plugins.unitree_go2_locations.UnitreeGo2LocationsProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2LocationsConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2Locations(config)
+
+        assert "Locations Provider initialized in background" in caplog.text
+        assert "base_url: http://localhost:5000/maps/locations/list" in caplog.text
+        assert "refresh: 30s" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_go2_locations.UnitreeGo2LocationsProvider")
+    def test_provider_start_called(self, mock_provider_class):
+        """Test that provider.start() is called during initialization."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2LocationsConfig()
+        UnitreeGo2Locations(config)
+
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_go2_locations.UnitreeGo2LocationsProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2LocationsConfig(timeout=10)
+        background = UnitreeGo2Locations(config)
+
+        assert background.config is config
+        assert background.config.timeout == 10

--- a/tests/backgrounds/plugins/test_unitree_go2_navigation.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_navigation.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+from backgrounds.base import BackgroundConfig
+from backgrounds.plugins.unitree_go2_navigation import UnitreeGo2Navigation
+
+
+class TestUnitreeGo2Navigation:
+    """Test cases for UnitreeGo2Navigation background plugin."""
+
+    @patch("backgrounds.plugins.unitree_go2_navigation.UnitreeGo2NavigationProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization creates provider and starts it."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2Navigation(config)
+
+        assert background.config is config
+        assert background.unitree_go2_navigation_provider == mock_provider
+        mock_provider_class.assert_called_once()
+        mock_provider.start.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_go2_navigation.UnitreeGo2NavigationProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        with caplog.at_level("INFO"):
+            UnitreeGo2Navigation(config)
+
+        assert (
+            "Unitree Go2 Navigation Provider initialized in background" in caplog.text
+        )
+
+    @patch("backgrounds.plugins.unitree_go2_navigation.UnitreeGo2NavigationProvider")
+    def test_provider_attribute(self, mock_provider_class):
+        """Test that provider attribute is set correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2Navigation(config)
+
+        assert background.unitree_go2_navigation_provider is mock_provider
+
+    @patch("backgrounds.plugins.unitree_go2_navigation.UnitreeGo2NavigationProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = BackgroundConfig()
+        background = UnitreeGo2Navigation(config)
+
+        assert background.config is config

--- a/tests/backgrounds/plugins/test_unitree_go2_state.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_state.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backgrounds.plugins.unitree_go2_state import (
+    UnitreeGo2State,
+    UnitreeGo2StateConfig,
+)
+
+
+class TestUnitreeGo2StateConfig:
+    """Test cases for UnitreeGo2StateConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = UnitreeGo2StateConfig()
+        assert config.unitree_ethernet is None
+
+    def test_custom_unitree_ethernet(self):
+        """Test custom unitree_ethernet configuration."""
+        config = UnitreeGo2StateConfig(unitree_ethernet="eth0")
+        assert config.unitree_ethernet == "eth0"
+
+
+class TestUnitreeGo2State:
+    """Test cases for UnitreeGo2State background plugin."""
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_initialization(self, mock_provider_class):
+        """Test background initialization with valid ethernet."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2StateConfig(unitree_ethernet="eth0")
+        background = UnitreeGo2State(config)
+
+        assert background.config is config
+        assert background.unitree_go2_state_provider == mock_provider
+        mock_provider_class.assert_called_once()
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_initialization_logging(self, mock_provider_class, caplog):
+        """Test that initialization logs the correct message."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2StateConfig(unitree_ethernet="eth0")
+        with caplog.at_level("INFO"):
+            UnitreeGo2State(config)
+
+        assert "Unitree Go2 State Provider initialized in background" in caplog.text
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_initialization_with_none_ethernet_raises_value_error(
+        self, mock_provider_class
+    ):
+        """Test that None ethernet raises ValueError."""
+        config = UnitreeGo2StateConfig()
+
+        with pytest.raises(
+            ValueError,
+            match="Unitree Go2 Ethernet channel must be specified",
+        ):
+            UnitreeGo2State(config)
+
+        mock_provider_class.assert_not_called()
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_initialization_with_none_ethernet_error_log(
+        self, mock_provider_class, caplog
+    ):
+        """Test that None ethernet logs an error before raising."""
+        config = UnitreeGo2StateConfig()
+
+        with caplog.at_level("ERROR"):
+            with pytest.raises(ValueError):
+                UnitreeGo2State(config)
+
+        assert (
+            "Unitree Go2 Ethernet channel is not set in the configuration"
+            in caplog.text
+        )
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_initialization_with_empty_string_raises_value_error(
+        self, mock_provider_class
+    ):
+        """Test that empty string ethernet raises ValueError."""
+        config = UnitreeGo2StateConfig(unitree_ethernet="")
+
+        with pytest.raises(ValueError):
+            UnitreeGo2State(config)
+
+        mock_provider_class.assert_not_called()
+
+    @patch("backgrounds.plugins.unitree_go2_state.UnitreeGo2StateProvider")
+    def test_config_stored(self, mock_provider_class):
+        """Test that config is stored correctly."""
+        mock_provider = MagicMock()
+        mock_provider_class.return_value = mock_provider
+
+        config = UnitreeGo2StateConfig(unitree_ethernet="eth0")
+        background = UnitreeGo2State(config)
+
+        assert background.config is config
+        assert background.config.unitree_ethernet == "eth0"


### PR DESCRIPTION
## Summary
- Add unit tests for all 14 previously untested background plugins
- Tests cover: d435, gps, rtk, elevenlabs_tts, rf_mapper, unitree_g1_navigation, unitree_g1_odom, unitree_g1_locations, unitree_go2_navigation, unitree_go2_amcl, unitree_go2_state, unitree_go2_lidar_localization, unitree_go2_locations, unitree_go2_frontier_exploration
- 114 new tests across 14 test files