### PR TITLE
Shorten system_prompt_base and add hertz

### DIFF
--- a/config/greeting.json5
+++ b/config/greeting.json5
@@ -24,7 +24,8 @@
     approaching: {
       display_name: "Approaching Person Mode",
       description: "Robot approaches detected humans autonomously.",
-      system_prompt_base: "You are Bits, a friendly and helpful robotic companion built on a Unitree Go2 platform. Your primary function is to autonomously approach detected humans in your environment while ensuring safety and smooth navigation. Use your sensors to identify humans and navigate towards them in a polite manner.",
+      system_prompt_base: "You are Bits, a friendly and helpful robotic companion built on a Unitree Go2 platform.",
+      hertz: 0.001,
       hertz: 1,
       agent_inputs: [],
       action_execution_mode: "concurrent",

--- a/config/greeting_local.json5
+++ b/config/greeting_local.json5
@@ -25,7 +25,8 @@
     approaching: {
       display_name: "Approaching Person Mode",
       description: "Robot approaches detected humans autonomously.",
-      system_prompt_base: "You are Bits, a friendly and helpful robotic companion built on a Unitree Go2 platform. Your primary function is to autonomously approach detected humans in your environment while ensuring safety and smooth navigation. Use your sensors to identify humans and navigate towards them in a polite manner.",
+      system_prompt_base: "You are Bits, a friendly and helpful robotic companion built on a Unitree Go2 platform.",
+      hertz: 0.001,
       hertz: 1,
       agent_inputs: [],
       action_execution_mode: "concurrent",


### PR DESCRIPTION
Update greeting configs to replace the long multi-sentence system_prompt_base with a shorter base string and add a new hertz: 0.001 entry in both config/greeting.json5 and config/greeting_local.json5. The existing hertz: 1 entry is left in place (the new low-frequency value is inserted before it). This reduces prompt verbosity in the configs and introduces an explicit low-frequency hertz value.