### PR TITLE
Remove duplicate hertz entry in greeting config

### DIFF
--- a/config/greeting.json5
+++ b/config/greeting.json5
@@ -26,7 +26,6 @@
       description: "Robot approaches detected humans autonomously.",
       system_prompt_base: "You are Bits, a friendly and helpful robotic companion built on a Unitree Go2 platform.",
       hertz: 0.001,
-      hertz: 1,
       agent_inputs: [],
       action_execution_mode: "concurrent",
       agent_actions: [],


### PR DESCRIPTION
Delete the redundant `hertz: 1` line from config/greeting.json5 so the intended `hertz: 0.001` value is preserved. This avoids a conflicting frequency setting in the greeting configuration that could cause unexpected behavior.