### PR TITLE
fix: correct 'succession' to 'sequence' in architecture docs

### DIFF
--- a/docs/developing/2_architecture.md
+++ b/docs/developing/2_architecture.md
@@ -70,7 +70,7 @@ Feedback Loop:
 
 ### Hardware Abstraction Layer (HAL)
 
-This layer translates high-level AI decisions into actionable commands for robot hardware. It's responsible for converting a high level decision such as "pick up the red apple with your left hand" into the succession of gripper arm servo commands that results in the apple being picked up. Typical `action` modules handle:
+This layer translates high-level AI decisions into actionable commands for robot hardware. It's responsible for converting a high level decision such as "pick up the red apple with your left hand" into the sequence of gripper arm servo commands that results in the apple being picked up. Typical `action` modules handle:
 
 - Move: Controls robot movement.
 - Sound: Generates auditory signals.


### PR DESCRIPTION
## Overview
Fixed a typo in the architecture documentation where "succession" should be "sequence" for better clarity and accuracy.

(If applicable, linked issue: #2257)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
- Changed "succession of gripper arm servo commands" to "sequence of gripper arm servo commands" in `docs/developing/2_architecture.md` (line 73)
- The word "sequence" is more appropriate in this context as it refers to an ordered series of commands, not a succession (which implies replacement or following in order of position)

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] Local testing completed
- [x] Tests added/updated (if applicable)

## Impact
This is a minor documentation fix with no code changes. It improves clarity and accuracy in the architecture documentation with zero risk to functionality.

## Additional Information
This change was identified while reading through the architecture documentation. The term "sequence" is standard terminology in robotics for ordered command execution.