### PR TITLE
fix: correct import path in test_singleton_provider.py

### DIFF
--- a/tests/providers/test_singleton_provider.py
+++ b/tests/providers/test_singleton_provider.py
@@ -1,7 +1,7 @@
 import threading
 import time
 
-from providers.singleton import singleton
+from src.providers.singleton import singleton
 
 
 def test_singleton_basic_functionality():


### PR DESCRIPTION
Update import from `providers.singleton` to `src.providers.singleton` to match the actual module path in the project structure.