### PR TITLE
improve(locations): expose cache freshness diagnostics for Unitree location providers

### DIFF
--- a/src/providers/unitree_g1_locations_provider.py
+++ b/src/providers/unitree_g1_locations_provider.py
@@ -1,168 +1,22 @@
-import json
-import logging
-import threading
-from typing import Dict, List, Optional, Union
+"""Unitree G1 periodic locations provider."""
 
-import requests
-
-from .io_provider import IOProvider
+from .locations_provider_base import LocationsProviderBase
 from .singleton import singleton
 
 
 @singleton
-class UnitreeG1LocationsProvider:
-    """
-    Provider that fetches locations from HTTP API in a background thread for Unitree G1.
-
-    This class implements a singleton pattern to manage:
-        * Periodic background fetching of location data from an HTTP API
-        * Thread-safe access to the location dictionary
-    """
+class UnitreeG1LocationsProvider(LocationsProviderBase):
+    """Fetch and cache navigation locations for Unitree G1."""
 
     def __init__(
         self,
         base_url: str = "http://localhost:5000/maps/locations/list",
         timeout: int = 5,
         refresh_interval: int = 30,
-    ):
-        """
-        Initialize the Unitree G1 Locations Provider with a specific API endpoint and refresh interval.
-
-        Parameters
-        ----------
-        base_url : str, optional
-            The HTTP endpoint to fetch locations from. Default is "http://localhost:5000/maps/locations/list".
-        timeout : int, optional
-            Timeout for HTTP requests in seconds. Default is 5.
-        refresh_interval : int, optional
-            How often to refresh locations in seconds. Default is 30.
-        """
-        self.base_url = base_url
-        self.timeout = timeout
-        self.refresh_interval = refresh_interval
-        self._locations: Dict[str, Dict] = {}
-        self._thread: Optional[threading.Thread] = None
-        self._stop_event = threading.Event()
-        self._lock = threading.Lock()
-        self.io_provider = IOProvider()
-
-    def start(self) -> None:
-        """
-        Start the background fetch thread.
-        """
-        if self._thread and self._thread.is_alive():
-            logging.warning("UnitreeG1LocationsProvider already running")
-            return
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
-        logging.info("UnitreeG1LocationsProvider background thread started")
-
-    def stop(self) -> None:
-        """
-        Stop the background fetch thread.
-        """
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=5)
-
-    def _run(self) -> None:
-        """
-        Background thread that periodically fetches locations.
-        """
-        while not self._stop_event.is_set():
-            try:
-                self._fetch()
-            except Exception:
-                logging.exception("Error fetching locations")
-            self._stop_event.wait(timeout=self.refresh_interval)
-
-    def _fetch(self) -> None:
-        """
-        Fetch locations from the API and update cache.
-        """
-        if not self.base_url:
-            return
-        try:
-            resp = requests.get(self.base_url, timeout=self.timeout)
-            if resp.status_code < 200 or resp.status_code >= 300:
-                logging.error(
-                    f"Location list API returned {resp.status_code}: {resp.text}"
-                )
-                return
-            data = resp.json()
-            raw_message = data.get("message") if isinstance(data, dict) else None
-            if raw_message and isinstance(raw_message, str):
-                try:
-                    locations = json.loads(raw_message)
-                except Exception:
-                    logging.error(
-                        "Failed to parse nested message JSON from location list"
-                    )
-                    return
-            elif isinstance(data, dict) and "message" not in data:
-                locations = data
-            else:
-                logging.error("Unexpected format from location list API")
-                return
-            self._update_locations(locations)
-        except Exception:
-            logging.exception("Error fetching locations")
-
-    def _update_locations(self, locations_raw: Union[Dict, List]) -> None:
-        """
-        Parse and store locations.
-
-        Parameters
-        ----------
-        locations_raw : Dict or List
-            Raw locations data from the API.
-        """
-        parsed = {}
-        if isinstance(locations_raw, dict):
-            for k, v in locations_raw.items():
-                entry = v if isinstance(v, dict) else {"name": k, "pose": {}}
-                entry.setdefault("name", k)
-                parsed[k.strip().lower()] = entry
-        elif isinstance(locations_raw, list):
-            for item in locations_raw:
-                if not isinstance(item, dict):
-                    continue
-                name = (item.get("name") or item.get("label") or "").strip()
-                if not name:
-                    continue
-                parsed[name.lower()] = item
-        with self._lock:
-            self._locations = parsed
-
-    def get_all_locations(self) -> Dict[str, Dict]:
-        """
-        Get all cached locations.
-
-        Returns
-        -------
-        Dict
-            A dictionary of all locations keyed by their labels.
-        """
-        with self._lock:
-            return dict(self._locations)
-
-    def get_location(self, label: str) -> Optional[Dict]:
-        """
-        Get a specific location by label.
-
-        Parameters
-        ----------
-        label : str
-            The label of the location to retrieve.
-
-        Returns
-        -------
-        Dict or None
-            The location data if found, otherwise None.
-        """
-        if not label:
-            return None
-        key = label.strip().lower()
-        with self._lock:
-            return self._locations.get(key)
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            timeout=timeout,
+            refresh_interval=refresh_interval,
+            provider_name="UnitreeG1LocationsProvider",
+        )

--- a/src/providers/unitree_go2_locations_provider.py
+++ b/src/providers/unitree_go2_locations_provider.py
@@ -1,176 +1,22 @@
-import json
-import logging
-import threading
-from typing import Dict, List, Optional, Union
+"""Unitree Go2 periodic locations provider."""
 
-import requests
-
-from .io_provider import IOProvider
+from .locations_provider_base import LocationsProviderBase
 from .singleton import singleton
 
 
 @singleton
-class UnitreeGo2LocationsProvider:
-    """
-    Provider that fetches locations from HTTP API in a background thread.
-    """
+class UnitreeGo2LocationsProvider(LocationsProviderBase):
+    """Fetch and cache navigation locations for Unitree Go2."""
 
     def __init__(
         self,
         base_url: str = "http://localhost:5000/maps/locations/list",
         timeout: int = 5,
         refresh_interval: int = 30,
-    ):
-        """
-        Initialize the provider.
-
-        Parameters
-        ----------
-        base_url : str
-            The HTTP endpoint to fetch locations from. Default is "http://localhost:5000/maps/locations/list".
-        timeout : int
-            Timeout for HTTP requests in seconds.
-        refresh_interval : int
-            How often to refresh locations in seconds.
-        """
-        self.base_url = base_url
-        self.timeout = timeout
-        self.refresh_interval = refresh_interval
-        self._locations: Dict[str, Dict] = {}
-        self._thread: Optional[threading.Thread] = None
-        self._stop_event = threading.Event()
-        self._lock = threading.Lock()
-
-        self.io_provider = IOProvider()
-
-    def start(self) -> None:
-        """
-        Start the background fetch thread.
-        """
-        if self._thread and self._thread.is_alive():
-            logging.warning("UnitreeGo2LocationsProvider already running")
-            return
-
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._run, daemon=True)
-        self._thread.start()
-        logging.info("UnitreeGo2LocationsProvider background thread started")
-
-    def stop(self) -> None:
-        """
-        Stop the background fetch thread.
-        """
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=5)
-
-    def _run(self) -> None:
-        """
-        Background thread that periodically fetches locations.
-        """
-        while not self._stop_event.is_set():
-            try:
-                self._fetch()
-            except Exception:
-                logging.exception("Error fetching locations")
-
-            self._stop_event.wait(timeout=self.refresh_interval)
-
-    def _fetch(self) -> None:
-        """
-        Fetch locations from the API and update cache.
-        """
-        if not self.base_url:
-            return
-
-        try:
-            resp = requests.get(self.base_url, timeout=self.timeout)
-
-            if resp.status_code < 200 or resp.status_code >= 300:
-                logging.error(
-                    f"Location list API returned {resp.status_code}: {resp.text}"
-                )
-                return
-
-            data = resp.json()
-
-            raw_message = data.get("message") if isinstance(data, dict) else None
-            if raw_message and isinstance(raw_message, str):
-                try:
-                    locations = json.loads(raw_message)
-                except Exception:
-                    logging.error(
-                        "Failed to parse nested message JSON from location list"
-                    )
-                    return
-            elif isinstance(data, dict) and "message" not in data:
-                locations = data
-            else:
-                logging.error("Unexpected format from location list API")
-                return
-
-            self._update_locations(locations)
-
-        except Exception:
-            logging.exception("Error fetching locations")
-
-    def _update_locations(self, locations_raw: Union[Dict, List]) -> None:
-        """
-        Parse and store locations.
-
-        Parameters
-        ----------
-        locations_raw : Dict or List
-            Raw locations data from the API.
-        """
-        parsed = {}
-
-        if isinstance(locations_raw, dict):
-            for k, v in locations_raw.items():
-                entry = v if isinstance(v, dict) else {"name": k, "pose": {}}
-                entry.setdefault("name", k)
-                parsed[k.strip().lower()] = entry
-
-        elif isinstance(locations_raw, list):
-            for item in locations_raw:
-                if not isinstance(item, dict):
-                    continue
-                name = (item.get("name") or item.get("label") or "").strip()
-                if not name:
-                    continue
-                parsed[name.lower()] = item
-
-        with self._lock:
-            self._locations = parsed
-
-    def get_all_locations(self) -> Dict[str, Dict]:
-        """
-        Get all cached locations.
-
-        Returns
-        -------
-        Dict
-            A dictionary of all locations keyed by their labels.
-        """
-        with self._lock:
-            return dict(self._locations)
-
-    def get_location(self, label: str) -> Optional[Dict]:
-        """
-        Get a specific location by label.
-
-        Parameters
-        ----------
-        label : str
-            The label of the location to retrieve.
-
-        Returns
-        -------
-        Dict or None
-            The location data if found, otherwise None.
-        """
-        if not label:
-            return None
-        key = label.strip().lower()
-        with self._lock:
-            return self._locations.get(key)
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            timeout=timeout,
+            refresh_interval=refresh_interval,
+            provider_name="UnitreeGo2LocationsProvider",
+        )

--- a/tests/providers/test_unitree_go2_locations_provider.py
+++ b/tests/providers/test_unitree_go2_locations_provider.py
@@ -1,88 +1,45 @@
+"""Focused pylint-friendly tests for UnitreeGo2LocationsProvider."""
+
 import time
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from providers.unitree_go2_locations_provider import UnitreeGo2LocationsProvider
 
 
-@pytest.fixture(autouse=True)
-def reset_singleton():
-    """Reset singleton instances between tests."""
-    UnitreeGo2LocationsProvider.reset()  # type: ignore
-    yield
-
-    try:
-        provider = UnitreeGo2LocationsProvider()
-        provider.stop()
-    except Exception:
-        pass
-
-    UnitreeGo2LocationsProvider.reset()  # type: ignore
-
-
-@pytest.fixture
-def mock_dependencies():
-    """Mock dependencies for UnitreeGo2LocationsProvider."""
-    with (
-        patch("providers.unitree_go2_locations_provider.IOProvider") as mock_io,
-        patch("providers.unitree_go2_locations_provider.requests") as mock_requests,
-    ):
-
-        mock_io_instance = MagicMock()
-        mock_io.return_value = mock_io_instance
-
-        yield {
-            "io": mock_io,
-            "io_instance": mock_io_instance,
-            "requests": mock_requests,
-        }
-
-
-def test_initialization(mock_dependencies):
-    """Test UnitreeGo2LocationsProvider initialization."""
+def test_custom_constructor_values_are_exposed() -> None:
+    """Custom constructor arguments should be reflected by provider fields."""
+    setattr(UnitreeGo2LocationsProvider, "_singleton_instance", None)
     provider = UnitreeGo2LocationsProvider(
-        base_url="http://localhost:5000/locations", timeout=10, refresh_interval=60
+        base_url="http://localhost:5000/custom-go2",
+        timeout=9,
+        refresh_interval=2,
     )
-
-    assert provider.base_url == "http://localhost:5000/locations"
-    assert provider.timeout == 10
-    assert provider.refresh_interval == 60
-    assert provider._locations == {}
-
-
-def test_initialization_defaults(mock_dependencies):
-    """Test initialization with default values."""
-    provider = UnitreeGo2LocationsProvider()
-
-    assert provider.base_url == "http://localhost:5000/maps/locations/list"
-    assert provider.timeout == 5
-    assert provider.refresh_interval == 30
+    try:
+        assert provider.base_url == "http://localhost:5000/custom-go2"
+        assert provider.timeout == 9
+        assert provider.refresh_interval == 2
+    finally:
+        provider.stop()
+        setattr(UnitreeGo2LocationsProvider, "_singleton_instance", None)
 
 
-def test_singleton_pattern(mock_dependencies):
-    """Test that UnitreeGo2LocationsProvider follows singleton pattern."""
-    provider1 = UnitreeGo2LocationsProvider(base_url="http://localhost:5000")
-    provider2 = UnitreeGo2LocationsProvider(base_url="http://localhost:6000")
-    assert provider1 is provider2
+def test_go2_http_failure_sets_freshness_error() -> None:
+    """HTTP failures should increment failure count and preserve empty cache."""
+    response = MagicMock()
+    response.status_code = 503
+    response.text = "Service Unavailable"
 
+    with patch("providers.locations_provider_base.requests.get", return_value=response):
+        setattr(UnitreeGo2LocationsProvider, "_singleton_instance", None)
+        provider = UnitreeGo2LocationsProvider(refresh_interval=1)
+        try:
+            provider.start()
+            time.sleep(0.04)
+        finally:
+            provider.stop()
+            setattr(UnitreeGo2LocationsProvider, "_singleton_instance", None)
 
-def test_start(mock_dependencies):
-    """Test starting the provider."""
-    provider = UnitreeGo2LocationsProvider()
-
-    provider.start()
-
-    assert provider._thread is not None
-    assert provider._thread.is_alive()
-
-
-def test_stop(mock_dependencies):
-    """Test stopping the provider."""
-    provider = UnitreeGo2LocationsProvider()
-
-    provider.start()
-    provider.stop()
-
-    time.sleep(0.1)
-    assert provider._stop_event.is_set()
+    freshness = provider.get_cache_freshness()
+    assert freshness["has_cache"] is False
+    assert freshness["consecutive_fetch_failures"] >= 1
+    assert freshness["last_fetch_error"] == "HTTP 503"


### PR DESCRIPTION
## Overview

This PR improves diagnostics around cached location data used by Unitree Go2 and G1 location providers.

Previously, repeated fetch failures could leave stale cached locations appearing valid without any observable signal. This change introduces explicit freshness visibility so operators and developers can distinguish between up-to-date data and stale cache state.

Runtime location behavior remains unchanged.

---

## Changes

### Freshness observability
- Adds cache freshness diagnostics exposed via `get_cache_freshness()`:
  - `has_cache`
  - `last_success_age_sec`
  - `consecutive_fetch_failures`
  - `last_fetch_error`

### Provider consistency
- Aligns Go2 and G1 location providers around shared freshness tracking logic
- Reduces duplicated freshness-handling paths while preserving existing behavior

### Tests
- Updates provider tests to validate freshness and stale-cache scenarios:
  - `tests/providers/test_unitree_go2_locations_provider.py`
  - `tests/providers/test_unitree_g1_locations_provider.py`

---

## Impact

- Makes stale cache conditions observable during repeated fetch failures
- Prevents stale state from being indistinguishable from healthy state
- Improves debugging and operational visibility
- No changes to existing location retrieval APIs or runtime control flow

---

## Testing

- `ruff check` passed on modified files
- `pylint` clean for affected providers and tests
- Python compilation checks passed

---

## Additional Information

- No schema changes
- No CI/workflow modifications
- No new dependencies introduced
- Diagnostics are additive and do not alter runtime behavior
