### PR TITLE
docs(get-started): add macOS camera permission note for Spot

### DIFF
--- a/docs/developing/1_get-started.md
+++ b/docs/developing/1_get-started.md
@@ -134,6 +134,8 @@ Run the following command to start the Spot Agent:
 uv run src/run.py spot
 ```
 
+> **macOS note:** If Spot cannot read webcam input, grant Camera access to your terminal/Python process in **System Settings → Privacy & Security → Camera**.
+
 > **Note:** Agent configuration names are only required when switching between different agents. Once an agent has been run, it becomes the default for subsequent executions.
 
 Spot is just an example agent configuration.


### PR DESCRIPTION
## Summary\nAdd a short macOS-specific note in the Getting Started guide reminding users to grant Camera permission to their terminal/Python process when running Spot.\n\n## Why\nOn macOS, Spot can appear to run normally while receiving no webcam input if Camera access is not granted. This note reduces first-run confusion for new contributors.\n\n## Scope\n- Docs-only change in \n\nCloses #1176