### PR TITLE
fix: runtime recovery on mode transition/reload failure and wildcard cooldown bypass

### DIFF
--- a/src/runtime/cortex.py
+++ b/src/runtime/cortex.py
@@ -216,7 +216,7 @@ class ModeCortexRuntime:
             try:
                 await self._initialize_mode(from_mode)
                 await self._start_orchestrators()
-                self.mode_manager.state.current_mode = from_mode
+                self.mode_manager.revert_transition_state()
                 logging.info(f"Successfully recovered to mode: {from_mode}")
             except Exception as recovery_error:
                 logging.critical(

--- a/src/runtime/manager.py
+++ b/src/runtime/manager.py
@@ -77,6 +77,7 @@ class ModeManager:
         self._main_event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._transition_lock = asyncio.Lock()
         self._is_transitioning = False
+        self._pre_transition_snapshot: Optional[Dict] = None
 
         # Validate configuration
         if config.default_mode not in config.modes:
@@ -231,6 +232,31 @@ class ModeManager:
                     callback(from_mode, to_mode)
             except Exception as e:
                 logging.error(f"Error in transition callback: {e}")
+
+    def revert_transition_state(self) -> None:
+        """
+        Revert mode state to pre-transition values using the saved snapshot.
+
+        Called by the runtime when a transition callback fails and recovery
+        is performed. Restores all state fields that were modified by
+        _execute_transition and persists the reverted state to disk.
+        """
+        snapshot = self._pre_transition_snapshot
+        if not snapshot:
+            logging.warning("No pre-transition snapshot available for rollback")
+            return
+
+        self.state.current_mode = snapshot["current_mode"]
+        self.state.previous_mode = snapshot["previous_mode"]
+        self.state.mode_start_time = snapshot["mode_start_time"]
+        self.state.last_transition_time = snapshot["last_transition_time"]
+        self.state.transition_history = self.state.transition_history[
+            : snapshot["transition_history_len"]
+        ]
+        self._pre_transition_snapshot = None
+
+        self._save_mode_state()
+        logging.info("Reverted transition state to pre-transition values")
 
     async def check_time_based_transitions(self) -> Optional[str]:
         """
@@ -575,6 +601,15 @@ class ModeManager:
                 )
                 if not global_exit_success:
                     logging.warning("Some global exit hooks failed")
+
+                # Save state snapshot for potential rollback
+                self._pre_transition_snapshot = {
+                    "current_mode": self.state.current_mode,
+                    "previous_mode": self.state.previous_mode,
+                    "mode_start_time": self.state.mode_start_time,
+                    "last_transition_time": self.state.last_transition_time,
+                    "transition_history_len": len(self.state.transition_history),
+                }
 
                 # Update state
                 self.state.previous_mode = from_mode

--- a/tests/runtime/test_cortex.py
+++ b/tests/runtime/test_cortex.py
@@ -235,6 +235,7 @@ class TestModeCortexRuntime:
 
             mock_init.assert_called_once_with("from_mode")
             mock_start.assert_called_once()
+            mocks["mode_manager"].revert_transition_state.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stop_current_orchestrators(self, cortex_runtime):
@@ -867,9 +868,7 @@ class TestModeTransitionRecovery:
             assert (
                 call_log[-1] == "start"
             ), "Orchestrators should be restarted after recovery"
-            assert (
-                mock_manager.state.current_mode == "default"
-            ), "Mode manager state should be reverted to previous mode"
+            mock_manager.revert_transition_state.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_start_failure_restarts_previous_mode(self, mock_system_config):
@@ -910,6 +909,7 @@ class TestModeTransitionRecovery:
             assert (
                 runtime._start_orchestrators.call_count >= 2
             ), "Should attempt to restart orchestrators after recovery"
+            mock_manager.revert_transition_state.assert_called_once()
 
 
 class TestHotReloadRecovery:

--- a/tests/runtime/test_manager.py
+++ b/tests/runtime/test_manager.py
@@ -1530,3 +1530,117 @@ class TestWildcardCooldown:
         manager.transition_cooldowns["calm->alert"] = time.time()
         result = manager._can_transition(specific_rule)
         assert result is False
+
+
+class TestRevertTransitionState:
+    """Tests that revert_transition_state correctly restores all mode state
+    fields to their pre-transition values using the saved snapshot."""
+
+    @pytest.fixture
+    def transition_manager(self):
+        """ModeManager with two modes for testing state rollback."""
+        mode_configs = {
+            "calm": ModeConfig(
+                version="v1.0.0",
+                name="calm",
+                display_name="Calm",
+                description="Calm mode",
+                system_prompt_base="Calm mode",
+            ),
+            "alert": ModeConfig(
+                version="v1.0.0",
+                name="alert",
+                display_name="Alert",
+                description="Alert mode",
+                system_prompt_base="Alert mode",
+            ),
+        }
+
+        system_config = ModeSystemConfig(
+            version="v1.0.2",
+            name="test",
+            default_mode="calm",
+            config_name="test_config",
+            api_key="test",
+        )
+        system_config.modes = mode_configs
+        system_config.transition_rules = []
+
+        with (
+            patch("runtime.manager.open_zenoh_session"),
+            patch("runtime.manager.ModeManager._load_mode_state"),
+        ):
+            return ModeManager(system_config)
+
+    def test_reverts_all_state_fields(self, transition_manager):
+        """All state fields should be restored to their snapshot values."""
+        manager = transition_manager
+
+        original_previous = manager.state.previous_mode
+        original_start_time = manager.state.mode_start_time
+        original_transition_time = manager.state.last_transition_time
+        original_history = list(manager.state.transition_history)
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": original_previous,
+            "mode_start_time": original_start_time,
+            "last_transition_time": original_transition_time,
+            "transition_history_len": len(original_history),
+        }
+
+        manager.state.current_mode = "alert"
+        manager.state.previous_mode = "calm"
+        manager.state.mode_start_time = time.time() + 100
+        manager.state.last_transition_time = time.time() + 100
+        manager.state.transition_history.append("calm->alert:test")
+
+        manager.revert_transition_state()
+
+        assert manager.state.current_mode == "calm"
+        assert manager.state.previous_mode == original_previous
+        assert manager.state.mode_start_time == original_start_time
+        assert manager.state.last_transition_time == original_transition_time
+        assert manager.state.transition_history == original_history
+
+    def test_clears_snapshot_after_revert(self, transition_manager):
+        """Snapshot should be cleared after a successful revert."""
+        manager = transition_manager
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": None,
+            "mode_start_time": manager.state.mode_start_time,
+            "last_transition_time": manager.state.last_transition_time,
+            "transition_history_len": 0,
+        }
+
+        manager.revert_transition_state()
+
+        assert manager._pre_transition_snapshot is None
+
+    def test_no_snapshot_logs_warning(self, transition_manager, caplog):
+        """Calling revert with no snapshot should log a warning and not crash."""
+        manager = transition_manager
+        manager._pre_transition_snapshot = None
+
+        with caplog.at_level(logging.WARNING):
+            manager.revert_transition_state()
+
+        assert "No pre-transition snapshot" in caplog.text
+
+    def test_persists_reverted_state(self, transition_manager):
+        """revert_transition_state should call _save_mode_state to persist."""
+        manager = transition_manager
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": None,
+            "mode_start_time": manager.state.mode_start_time,
+            "last_transition_time": manager.state.last_transition_time,
+            "transition_history_len": 0,
+        }
+
+        with patch.object(manager, "_save_mode_state") as mock_save:
+            manager.revert_transition_state()
+            mock_save.assert_called_once()


### PR DESCRIPTION
## Summary

- **Mode transition recovery**: `_on_mode_transition` now falls back to the previous mode when initialization or startup of the new mode fails, instead of leaving orchestrators permanently dead
- **Full state rollback on recovery**: `ModeManager` saves a pre-transition state snapshot before modifying state fields. On failed transition recovery, all state fields (`current_mode`, `previous_mode`, `mode_start_time`, `last_transition_time`, `transition_history`) are reverted and persisted to disk via `revert_transition_state()`
- **Hot-reload recovery**: `_reload_config` now restarts orchestrators with the previous configuration when loading or initializing the new config fails, instead of silently swallowing the error with dead orchestrators
- **Wildcard cooldown bypass**: `_can_transition` now uses the actual current mode for wildcard rule (`from_mode='*'`) cooldown key lookup, matching what `_execute_transition` sets, so cooldown is correctly enforced

## Changes

| File | Change |
|------|--------|
| `src/runtime/cortex.py` | Recovery logic in `_on_mode_transition` and `_reload_config` |
| `src/runtime/manager.py` | Wildcard cooldown key fix in `_can_transition`, snapshot/rollback mechanism in `_execute_transition` and `revert_transition_state()` |
| `tests/runtime/test_cortex.py` | 4 new tests + 1 updated test |
| `tests/runtime/test_manager.py` | 8 new tests |

12 new regression tests added.

## Known limitation

`_execute_transition` runs lifecycle hooks (`on_exit`, `on_enter`) before invoking the transition callback. If the callback fails and recovery is triggered, these hook side effects cannot be undone. This is a pre-existing architectural pattern in the manager's transition flow, not introduced by this PR.