### PR TITLE
test(config): keep strict connector import failure with clearer diagnostics

### DIFF
--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -80,8 +80,11 @@ def assert_action_classes_exist(action_config):
         assert (
             connector is not None
         ), f"No connector found for action {action_config['name']}"
-    except (ImportError, ModuleNotFoundError):
-        assert False, f"Connector module not found for action {action_config['name']}"
+    except (ImportError, ModuleNotFoundError) as e:
+        assert False, (
+            f"Connector import failed for action {action_config['name']}: "
+            f"{type(e).__name__}: {e}"
+        )
 
 
 def find_subclass_in_module(module, parent_class: Type) -> Optional[Type]:


### PR DESCRIPTION
## Summary
Follow-up after maintainer feedback on #2285.

This keeps the intended strict behavior (connector import failure still fails the test), and only improves the failure message to include the underlying exception type/message.

## Why
When import fails, the prior message was generic. Including the original error makes it faster to identify missing modules vs path/import mistakes without changing test policy.

## Scope
- test-only change in 
- no skip behavior
- no runtime changes