### PR TITLE
fix: recover orchestrators and revert state on failed mode transition

### DIFF
--- a/src/runtime/cortex.py
+++ b/src/runtime/cortex.py
@@ -212,8 +212,17 @@ class ModeCortexRuntime:
 
         except Exception as e:
             logging.error(f"Error during mode transition {from_mode} -> {to_mode}: {e}")
-            # TODO: Implement fallback/recovery mechanism
-            raise
+            logging.info(f"Attempting to recover by restoring mode: {from_mode}")
+            try:
+                await self._initialize_mode(from_mode)
+                await self._start_orchestrators()
+                self.mode_manager.revert_transition_state()
+                logging.info(f"Successfully recovered to mode: {from_mode}")
+            except Exception as recovery_error:
+                logging.critical(
+                    f"Failed to recover to mode {from_mode}: {recovery_error}. "
+                    "Runtime has no active orchestrators."
+                )
         finally:
             self._is_reloading = False
 

--- a/src/runtime/manager.py
+++ b/src/runtime/manager.py
@@ -77,6 +77,7 @@ class ModeManager:
         self._main_event_loop: Optional[asyncio.AbstractEventLoop] = None
         self._transition_lock = asyncio.Lock()
         self._is_transitioning = False
+        self._pre_transition_snapshot: Optional[Dict] = None
 
         # Validate configuration
         if config.default_mode not in config.modes:
@@ -231,6 +232,31 @@ class ModeManager:
                     callback(from_mode, to_mode)
             except Exception as e:
                 logging.error(f"Error in transition callback: {e}")
+
+    def revert_transition_state(self) -> None:
+        """
+        Revert mode state to pre-transition values using the saved snapshot.
+
+        Called by the runtime when a transition callback fails and recovery
+        is performed. Restores all state fields that were modified by
+        _execute_transition and persists the reverted state to disk.
+        """
+        snapshot = self._pre_transition_snapshot
+        if not snapshot:
+            logging.warning("No pre-transition snapshot available for rollback")
+            return
+
+        self.state.current_mode = snapshot["current_mode"]
+        self.state.previous_mode = snapshot["previous_mode"]
+        self.state.mode_start_time = snapshot["mode_start_time"]
+        self.state.last_transition_time = snapshot["last_transition_time"]
+        self.state.transition_history = self.state.transition_history[
+            : snapshot["transition_history_len"]
+        ]
+        self._pre_transition_snapshot = None
+
+        self._save_mode_state()
+        logging.info("Reverted transition state to pre-transition values")
 
     async def check_time_based_transitions(self) -> Optional[str]:
         """
@@ -572,6 +598,15 @@ class ModeManager:
                 )
                 if not global_exit_success:
                     logging.warning("Some global exit hooks failed")
+
+                # Save state snapshot for potential rollback
+                self._pre_transition_snapshot = {
+                    "current_mode": self.state.current_mode,
+                    "previous_mode": self.state.previous_mode,
+                    "mode_start_time": self.state.mode_start_time,
+                    "last_transition_time": self.state.last_transition_time,
+                    "transition_history_len": len(self.state.transition_history),
+                }
 
                 # Update state
                 self.state.previous_mode = from_mode

--- a/tests/runtime/test_cortex.py
+++ b/tests/runtime/test_cortex.py
@@ -211,8 +211,8 @@ class TestModeCortexRuntime:
             await runtime._on_mode_transition("from_mode", "to_mode")
 
     @pytest.mark.asyncio
-    async def test_on_mode_transition_exception(self, cortex_runtime):
-        """Test mode transition with exception handling."""
+    async def test_on_mode_transition_exception_triggers_recovery(self, cortex_runtime):
+        """Test mode transition attempts recovery on failure."""
         runtime, mocks = cortex_runtime
 
         mock_from_mode = Mock()
@@ -222,11 +222,20 @@ class TestModeCortexRuntime:
             "to_mode": mock_to_mode,
         }
 
-        with patch.object(
-            runtime, "_stop_current_orchestrators", side_effect=Exception("Test error")
+        with (
+            patch.object(
+                runtime,
+                "_stop_current_orchestrators",
+                side_effect=Exception("Test error"),
+            ),
+            patch.object(runtime, "_initialize_mode") as mock_init,
+            patch.object(runtime, "_start_orchestrators") as mock_start,
         ):
-            with pytest.raises(Exception, match="Test error"):
-                await runtime._on_mode_transition("from_mode", "to_mode")
+            await runtime._on_mode_transition("from_mode", "to_mode")
+
+            mock_init.assert_called_once_with("from_mode")
+            mock_start.assert_called_once()
+            mocks["mode_manager"].revert_transition_state.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stop_current_orchestrators(self, cortex_runtime):
@@ -805,3 +814,99 @@ class TestHotReloadMultiToSingle:
 
             assert len(new_single_config.modes) == 1
             assert "single_mode" in new_single_config.modes
+
+
+class TestModeTransitionRecovery:
+    """Tests that _on_mode_transition recovers by falling back to the
+    previous mode when initialization or startup of the new mode fails."""
+
+    @pytest.mark.asyncio
+    async def test_init_failure_restarts_previous_mode(self, mock_system_config):
+        """After _initialize_mode fails, the runtime should recover by
+        restarting the previous mode's orchestrators."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(mock_system_config, "test_config")
+            runtime.mode_manager = mock_manager
+
+            call_log = []
+
+            async def log_stop():
+                call_log.append("stop")
+
+            async def log_init(mode):
+                call_log.append(f"init:{mode}")
+                if mode == "advanced":
+                    raise Exception("LLM plugin not found")
+
+            async def log_start():
+                call_log.append("start")
+
+            mock_manager.state.current_mode = "advanced"
+
+            runtime._stop_current_orchestrators = AsyncMock(side_effect=log_stop)
+            runtime._initialize_mode = AsyncMock(side_effect=log_init)
+            runtime._start_orchestrators = AsyncMock(side_effect=log_start)
+
+            await runtime._on_mode_transition("default", "advanced")
+
+            assert "stop" in call_log
+            assert "init:advanced" in call_log
+            assert (
+                "init:default" in call_log
+            ), "Runtime should fall back to previous mode after init failure"
+            assert (
+                call_log[-1] == "start"
+            ), "Orchestrators should be restarted after recovery"
+            mock_manager.revert_transition_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_failure_restarts_previous_mode(self, mock_system_config):
+        """After _start_orchestrators fails, the runtime should recover by
+        reinitializing and restarting the previous mode."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(mock_system_config, "test_config")
+            runtime.mode_manager = mock_manager
+
+            start_call_count = 0
+
+            async def fail_first_start():
+                nonlocal start_call_count
+                start_call_count += 1
+                if start_call_count == 1:
+                    raise Exception("Failed to start input orchestrator")
+
+            runtime._stop_current_orchestrators = AsyncMock()
+            runtime._initialize_mode = AsyncMock()
+            runtime._start_orchestrators = AsyncMock(side_effect=fail_first_start)
+
+            await runtime._on_mode_transition("default", "advanced")
+
+            assert (
+                runtime._initialize_mode.call_count >= 2
+            ), "Should reinitialize with previous mode after start failure"
+            assert (
+                runtime._start_orchestrators.call_count >= 2
+            ), "Should attempt to restart orchestrators after recovery"
+            mock_manager.revert_transition_state.assert_called_once()

--- a/tests/runtime/test_manager.py
+++ b/tests/runtime/test_manager.py
@@ -1423,3 +1423,117 @@ class TestModeManager:
                 "Updated user context with" in record.message
                 for record in caplog.records
             )
+
+
+class TestRevertTransitionState:
+    """Tests that revert_transition_state correctly restores all mode state
+    fields to their pre-transition values using the saved snapshot."""
+
+    @pytest.fixture
+    def transition_manager(self):
+        """ModeManager with two modes for testing state rollback."""
+        mode_configs = {
+            "calm": ModeConfig(
+                version="v1.0.0",
+                name="calm",
+                display_name="Calm",
+                description="Calm mode",
+                system_prompt_base="Calm mode",
+            ),
+            "alert": ModeConfig(
+                version="v1.0.0",
+                name="alert",
+                display_name="Alert",
+                description="Alert mode",
+                system_prompt_base="Alert mode",
+            ),
+        }
+
+        system_config = ModeSystemConfig(
+            version="v1.0.2",
+            name="test",
+            default_mode="calm",
+            config_name="test_config",
+            api_key="test",
+        )
+        system_config.modes = mode_configs
+        system_config.transition_rules = []
+
+        with (
+            patch("runtime.manager.open_zenoh_session"),
+            patch("runtime.manager.ModeManager._load_mode_state"),
+        ):
+            return ModeManager(system_config)
+
+    def test_reverts_all_state_fields(self, transition_manager):
+        """All state fields should be restored to their snapshot values."""
+        manager = transition_manager
+
+        original_previous = manager.state.previous_mode
+        original_start_time = manager.state.mode_start_time
+        original_transition_time = manager.state.last_transition_time
+        original_history = list(manager.state.transition_history)
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": original_previous,
+            "mode_start_time": original_start_time,
+            "last_transition_time": original_transition_time,
+            "transition_history_len": len(original_history),
+        }
+
+        manager.state.current_mode = "alert"
+        manager.state.previous_mode = "calm"
+        manager.state.mode_start_time = time.time() + 100
+        manager.state.last_transition_time = time.time() + 100
+        manager.state.transition_history.append("calm->alert:test")
+
+        manager.revert_transition_state()
+
+        assert manager.state.current_mode == "calm"
+        assert manager.state.previous_mode == original_previous
+        assert manager.state.mode_start_time == original_start_time
+        assert manager.state.last_transition_time == original_transition_time
+        assert manager.state.transition_history == original_history
+
+    def test_clears_snapshot_after_revert(self, transition_manager):
+        """Snapshot should be cleared after a successful revert."""
+        manager = transition_manager
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": None,
+            "mode_start_time": manager.state.mode_start_time,
+            "last_transition_time": manager.state.last_transition_time,
+            "transition_history_len": 0,
+        }
+
+        manager.revert_transition_state()
+
+        assert manager._pre_transition_snapshot is None
+
+    def test_no_snapshot_logs_warning(self, transition_manager, caplog):
+        """Calling revert with no snapshot should log a warning and not crash."""
+        manager = transition_manager
+        manager._pre_transition_snapshot = None
+
+        with caplog.at_level(logging.WARNING):
+            manager.revert_transition_state()
+
+        assert "No pre-transition snapshot" in caplog.text
+
+    def test_persists_reverted_state(self, transition_manager):
+        """revert_transition_state should call _save_mode_state to persist."""
+        manager = transition_manager
+
+        manager._pre_transition_snapshot = {
+            "current_mode": "calm",
+            "previous_mode": None,
+            "mode_start_time": manager.state.mode_start_time,
+            "last_transition_time": manager.state.last_transition_time,
+            "transition_history_len": 0,
+        }
+
+        with patch.object(manager, "_save_mode_state") as mock_save:
+            manager.revert_transition_state()
+            mock_save.assert_called_once()


### PR DESCRIPTION
## Summary

- When `_on_mode_transition` failed during init or startup, the runtime raised the exception with no recovery, leaving orchestrators stopped and the robot unresponsive.
- Now the runtime falls back to the previous mode: reinitializes and restarts orchestrators, and reverts mode manager state using a pre-transition snapshot.

## Changes

- `src/runtime/cortex.py`: Replace `raise` with recovery block in `_on_mode_transition` — reinitialize previous mode + restart orchestrators + revert state
- `src/runtime/manager.py`: Add `_pre_transition_snapshot` field, save snapshot before state update in `_execute_transition`, add `revert_transition_state()` method
- `tests/runtime/test_cortex.py`: Update existing exception test to verify recovery, add `TestModeTransitionRecovery` class with 2 tests
- `tests/runtime/test_manager.py`: Add `TestRevertTransitionState` class with 4 tests