### PR TITLE
fix: add missing tts_enabled init and fix broken base_url default in UbTtsConnector

### DIFF
--- a/src/actions/speak/connector/ub_tts.py
+++ b/src/actions/speak/connector/ub_tts.py
@@ -34,8 +34,8 @@ class UbTtsConfig(ActionConfig):
         default=None,
         description="The IP address of the robot.",
     )
-    base_url: str = Field(
-        default=f"http://{robot_ip}:9090/v1/",
+    base_url: Optional[str] = Field(
+        default=None,
         description="The base URL for the UbTTS service.",
     )
 
@@ -57,7 +57,10 @@ class UbTtsConnector(ActionConnector[UbTtsConfig, SpeakInput]):
         """
         super().__init__(config)
 
-        base_url = self.config.base_url
+        base_url = self.config.base_url or f"http://{self.config.robot_ip}:9090/v1/"
+
+        # TTS status
+        self.tts_enabled = True
 
         # Zenoh topics
         self.tts_status_request_topic = "om/tts/request"


### PR DESCRIPTION
## Summary
Two bugs in `src/actions/speak/connector/ub_tts.py`:

**Bug 1: Missing `self.tts_enabled` initialization**
- `connect()` checks `self.tts_enabled` at line 93, but `__init__()` never sets it
- First call to `connect()` raises `AttributeError`
- All sibling TTS connectors (`elevenlabs_tts.py:164`, `kokoro_tts.py:165`, `riva_tts.py:103`) initialize `self.tts_enabled = True`

**Bug 2: `base_url` default evaluates FieldInfo object instead of string**
- `base_url` default is `f"http://{robot_ip}:9090/v1/"` at class definition time
- `robot_ip` in the class body refers to `Field(default=None, ...)` which is a `FieldInfo` object
- Result: `base_url` defaults to `"http://FieldInfo(annotation=NoneType, ...):9090/v1/"` — a broken URL
- Fix: set `base_url` default to `None`, compute URL from `self.config.robot_ip` at init time

## Test plan
- [x] All 12 ub_tts connector tests pass locally
- [x] pre-commit hooks pass