### PR TITLE
fix(logging): warn on invalid log level fallback

### DIFF
--- a/src/runtime/logging.py
+++ b/src/runtime/logging.py
@@ -52,7 +52,10 @@ def setup_logging(
         log_level = logging_config.log_level
         log_to_file = logging_config.log_to_file
 
-    level = getattr(logging, log_level.upper(), logging.INFO)
+    requested_level = (log_level or "INFO").upper()
+    allowed_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+    invalid_log_level = requested_level not in allowed_levels
+    level = getattr(logging, requested_level, logging.INFO)
 
     logging.getLogger().handlers.clear()
 
@@ -80,6 +83,12 @@ def setup_logging(
         handlers.append(file_handler)
 
     logging.basicConfig(level=level, handlers=handlers)
+
+    if invalid_log_level:
+        logging.warning(
+            "Invalid log level '%s'; falling back to INFO.",
+            log_level,
+        )
 
 
 def get_logging_config() -> LoggingConfig:

--- a/tests/runtime/test_logging.py
+++ b/tests/runtime/test_logging.py
@@ -35,6 +35,15 @@ class TestSetupLogging:
         setup_logging("test_config", log_level="DEBUG")
         assert logging.getLogger().level == logging.DEBUG
 
+    def test_invalid_level_warns_and_falls_back_to_info(self):
+        with patch("runtime.logging.logging.warning") as mock_warning:
+            setup_logging("test_config", log_level="VERBOSE")
+            assert logging.getLogger().level == logging.INFO
+            mock_warning.assert_called_once_with(
+                "Invalid log level '%s'; falling back to INFO.",
+                "VERBOSE",
+            )
+
     def test_with_config_object(self):
         config_obj = LoggingConfig(log_level="WARNING", log_to_file=True)
         setup_logging("test_config", logging_config=config_obj)


### PR DESCRIPTION
## Summary
Adds explicit validation feedback when an invalid log level is provided to `setup_logging`.

## What changed
- Detects unsupported log levels (e.g. `VERBOSE`)
- Keeps current behavior of falling back to `INFO`
- Adds a warning log so fallback is visible instead of silent
- Adds a focused test for invalid-level behavior

## Why
Previously, invalid levels silently defaulted to INFO, making misconfiguration hard to spot.

## Scope
- `src/runtime/logging.py`
- `tests/runtime/test_logging.py`

No runtime behavior change for valid levels.
