### PR TITLE
fix(orchestrator): guard invalid enum conversion in _promise_action

### DIFF
--- a/src/actions/orchestrator.py
+++ b/src/actions/orchestrator.py
@@ -355,7 +355,17 @@ class ActionOrchestrator:
                 if hasattr(expected_type, "__mro__") and any(
                     base.__name__ == "Enum" for base in expected_type.__mro__
                 ):
-                    converted_params[key] = expected_type(value)
+                    try:
+                        converted_params[key] = expected_type(value)
+                    except (ValueError, TypeError) as e:
+                        logging.warning(
+                            "Invalid enum value '%s' for parameter '%s' in action '%s': %s",
+                            value,
+                            key,
+                            agent_action.llm_label,
+                            e,
+                        )
+                        converted_params[key] = value
                 elif expected_type is float:
                     converted_params[key] = float(value)
                 elif expected_type is int:

--- a/tests/actions/test_orchestrator.py
+++ b/tests/actions/test_orchestrator.py
@@ -758,6 +758,34 @@ class TestLLMResultParser:
         assert len(MockConnector.execution_order) == 1
 
     @pytest.mark.asyncio
+    async def test_parse_invalid_enum_value_falls_back_without_crash(
+        self, mock_runtime_config, create_typed_action
+    ):
+        """Test invalid enum value is handled gracefully and does not crash action flow."""
+
+        class Direction(Enum):
+            NORTH = "north"
+            SOUTH = "south"
+
+        @dataclass
+        class EnumInput:
+            direction: Direction
+
+        action = create_typed_action("move", "move", EnumInput)
+        mock_runtime_config.agent_actions = [action]
+        orchestrator = ActionOrchestrator(mock_runtime_config)
+
+        json_value = json.dumps({"direction": "invalid"})
+        actions = [Action(type="move", value=json_value)]
+
+        await orchestrator.promise(actions)
+        done, pending = await orchestrator.flush_promises()
+
+        assert len(done) == 1
+        assert len(pending) == 0
+        assert len(MockConnector.execution_order) == 1
+
+    @pytest.mark.asyncio
     async def test_parse_mixed_types(self, mock_runtime_config, create_typed_action):
         """Test parsing mixed parameter types."""
 


### PR DESCRIPTION
## Summary
Guard enum conversion in `ActionOrchestrator._promise_action` so invalid enum values from LLM output no longer crash action execution.

## Problem
`expected_type(value)` raises `ValueError` for invalid enum values. This exception currently propagates and can break the action promise chain.

## Fix
- Wrap enum conversion in `try/except (ValueError, TypeError)`
- Log a warning with action/parameter context
- Fallback to raw value instead of crashing

## Tests
- Added focused test: invalid enum value is handled gracefully and action flow continues

## Scope
- `src/actions/orchestrator.py`
- `tests/actions/test_orchestrator.py`

This is a minimal defensive fix with no behavior change for valid enum values.
