### PR TITLE
Use hostname for local server

### DIFF
--- a/config/greeting_local.json5
+++ b/config/greeting_local.json5
@@ -16,7 +16,7 @@
     config: {
       agent_name: "Bits",
       history_length: 1,
-      base_url: "http://192.168.0.83:8860/v1",
+      base_url: "http://omr2.local:8860/v1",
       model: "nvidia/nemotron-3-nano",
     },
   },
@@ -59,7 +59,7 @@
           connector: "greeting_conversation_kokoro",
           config: {
             model_id: "mlx-community/Kokoro-82M-bf16",
-            base_url: "http://192.168.0.83:8880/v1",
+            base_url: "http://omr2.local:8880/v1",
           },
         },
       ],
@@ -72,7 +72,7 @@
             tts_provider: "kokoro",
             message: "Hello! I'm Bits, how can I help you today?",
             model_id: "mlx-community/Kokoro-82M-bf16",
-            base_url: "http://192.168.0.83:8880/v1",
+            base_url: "http://omr2.local:8880/v1",
           },
         },
         {
@@ -82,7 +82,7 @@
             tts_provider: "kokoro",
             message: "Hello! I'm Bits, how can I help you today?",
             model_id: "mlx-community/Kokoro-82M-bf16",
-            base_url: "http://192.168.0.83:8880/v1",
+            base_url: "http://omr2.local:8880/v1",
           },
         },
         {
@@ -92,7 +92,7 @@
             tts_provider: "kokoro",
             message: "It was great chatting with you! Have a wonderful day!",
             model_id: "mlx-community/Kokoro-82M-bf16",
-            base_url: "http://192.168.0.83:8880/v1",
+            base_url: "http://omr2.local:8880/v1",
           },
         },
       ],


### PR DESCRIPTION
This pull request updates the `base_url` values in the `config/greeting_local.json5` configuration file to use the hostname `omr2.local` instead of the previous IP address. This change ensures that all relevant services reference the updated host for both the main agent and the Kokoro model endpoints.

Configuration updates:

* Changed `base_url` for the main agent configuration to use `http://omr2.local:8860/v1` instead of the previous IP address.
* Updated all Kokoro-related `base_url` entries (for both connector and TTS provider configurations) to use `http://omr2.local:8880/v1`. [[1]](diffhunk://#diff-7e89f7da3835977c223e16a4500fd6d1fe4edac87f459efbd6d9a282ba71780eL62-R62) [[2]](diffhunk://#diff-7e89f7da3835977c223e16a4500fd6d1fe4edac87f459efbd6d9a282ba71780eL75-R75) [[3]](diffhunk://#diff-7e89f7da3835977c223e16a4500fd6d1fe4edac87f459efbd6d9a282ba71780eL85-R85) [[4]](diffhunk://#diff-7e89f7da3835977c223e16a4500fd6d1fe4edac87f459efbd6d9a282ba71780eL95-R95)