### PR TITLE
 fix: correct type checking in function schema generation

### DIFF
--- a/src/llm/function_schemas.py
+++ b/src/llm/function_schemas.py
@@ -43,22 +43,22 @@ def generate_function_schema_from_action(action) -> dict:
                 "enum": enum_values,
                 "description": f"The {field_name} to perform. Must be one of: {', '.join(enum_values)}",
             }
-        elif isinstance(field_type, str):
+        elif field_type is str:
             properties[field_name] = {
                 "type": "string",
                 "description": f"The {field_name} parameter",
             }
-        elif isinstance(field_type, int):
+        elif field_type is int:
             properties[field_name] = {
                 "type": "integer",
                 "description": f"The {field_name} parameter",
             }
-        elif isinstance(field_type, float):
+        elif field_type is float:
             properties[field_name] = {
                 "type": "number",
                 "description": f"The {field_name} parameter",
             }
-        elif isinstance(field_type, bool):
+        elif field_type is bool:
             properties[field_name] = {
                 "type": "boolean",
                 "description": f"The {field_name} parameter",


### PR DESCRIPTION
## Overview
Fix incorrect type checking in function schema generation that caused all field types to fall through to string.

## Type of change
- [x] Bug fix

## Changes
Changed `isinstance(field_type, str)` to `field_type is str` (and same for int/float/bool) in `generate_function_schema_from_action()`. The old code always evaluated to False because `field_type` is a type class, not an instance.

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact
OpenAI function schemas now correctly specify `integer`, `number`, and `boolean` types instead of defaulting everything to `string`. This improves LLM parameter validation during function calling.

## Additional Information
File: `src/llm/function_schemas.py`, lines 46-65