### PR TITLE
fix: correct backward movement comparison in TurtleBot MoveZenohConnector

### DIFF
--- a/src/actions/move_turtle/connector/zenoh.py
+++ b/src/actions/move_turtle/connector/zenoh.py
@@ -387,7 +387,7 @@ class MoveZenohConnector(ActionConnector[MoveZenohConfig, MoveInput]):
                 distance_traveled = math.sqrt(
                     (self.odom.x - s_x) ** 2 + (self.odom.y - s_y) ** 2
                 )
-                remaining = abs(goal_dx - distance_traveled)
+                remaining = abs(abs(goal_dx) - distance_traveled)
                 logging.info(f"remaining advance GAP: {round(remaining,2)}")
 
                 fb = 0
@@ -401,10 +401,10 @@ class MoveZenohConnector(ActionConnector[MoveZenohConfig, MoveInput]):
                     return
 
                 if remaining > self.distance_tolerance:
-                    if distance_traveled < goal_dx:  # keep advancing
+                    if distance_traveled < abs(goal_dx):  # keep advancing
                         logging.debug(f"keep moving. remaining:{remaining} ")
                         self.move(fb * 0.4, 0.0)
-                    elif distance_traveled > goal_dx:  # you moved too far
+                    elif distance_traveled > abs(goal_dx):  # you moved too far
                         logging.debug(
                             f"OVERSHOOT: move other way. remaining:{remaining} "
                         )


### PR DESCRIPTION
## Summary
Clean, single-purpose PR containing only the TurtleBot backward movement fix.

## Problem
`goal_dx` can be negative for backward movement. Comparing `distance_traveled` against raw `goal_dx` causes incorrect movement behavior for reverse targets.

## Fix
- Use `abs(goal_dx)` in movement comparisons.
- Use `abs(abs(goal_dx) - distance_traveled)` for remaining-distance calculation.

## Files changed
- `src/actions/move_turtle/connector/zenoh.py`

## Why this matters
Prevents incorrect stop/overshoot behavior and improves reliability of backward motion commands.

## Test plan
- Verify forward movement (`goal_dx > 0`) is unchanged.
- Verify backward movement (`goal_dx < 0`) now advances/stops correctly.
- Verify connector exits when `remaining <= distance_tolerance`.
