### PR TITLE
docs: clean up Gazebo simulation guide

### DIFF
--- a/docs/simulators/gazebo.md
+++ b/docs/simulators/gazebo.md
@@ -4,7 +4,7 @@ description: "Quadruped Simulation and Control"
 icon: robot
 ---
 
-## System Requirements
+## Minimum System Requirements
 
 | Component | Minimum | Good/Recommended | Ideal |
 |-----------|---------|------------------|-------|
@@ -24,7 +24,7 @@ To get started with **Gazebo** and **Unitree SDK**, please install cyclonedds an
 Install cyclonedds from this [link](https://cyclonedds.io/docs/cyclonedds/latest/installation/installation.html) or follow the instructions below.
 
 ```bash
-sudo apt-get install git cmake gcc
+apt-get install git cmake gcc
 ```
 
 ```bash
@@ -70,56 +70,13 @@ If you don't have uv installed, use the following command to install it on your 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Use this **CycloneDDS** configuration. It uses `lo` as the network interface. We recommend that you export this in your `.bashrc` or equivalent configuration file `cyclonedds.xml`.
-To add it to `cyclonedds.xml`:
-
-```bash
-cd cyclonedds
-vi cyclonedds.xml
-```
-
-Add the following, then save and exit.
-
-```xml
-<CycloneDDS>
-    <Domain>
-        <General>
-            <Interfaces>
-                <NetworkInterface address="127.0.0.1" priority="default" multicast="default" />
-            </Interfaces>
-        </General>
-        <Discovery>
-            <MaxAutoParticipantIndex>200</MaxAutoParticipantIndex>
-        </Discovery>
-    </Domain>
-</CycloneDDS>
-```
-
-Open your bashrc file
+Configure **CycloneDDS** to use `lo` as the network interface. Add the following to your `~/.bashrc`:
 
 ```bash
 vi ~/.bashrc
 ```
 
-Add the following, replacing `/path/to/cyclonedds` with the actual path to your CycloneDDS installation:
-
-```bash
-export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-export CYCLONEDDS_URI=/path/to/cyclonedds/cyclonedds.xml
-```
-
-Apply the changes
-```bash
-source ~/.bashrc
-```
-
-To add the config to your bashrc, run:
-
-```bash
-vim ~/.bashrc
-```
-
-And add the following, replacing `/path/to/cyclonedds` with the actual path to your CycloneDDS installation:
+Add the following lines at the end of the file:
 
 ```bash
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
@@ -138,12 +95,11 @@ export CYCLONEDDS_URI='
 </CycloneDDS>'
 ```
 
-Now run
+Apply the changes:
 
 ```bash
 source ~/.bashrc
 ```
-This will apply the latest changes in the current shell session.
 
 Check if you have rosdep installed by running `rosdep` or `rosdep --version`. If it is not installed, run the following:
 
@@ -156,113 +112,122 @@ Once you've successfully completed above steps, follow the following steps to st
 
 Step 1: Clone the [OM1-ros2-sdk](https://github.com/OpenMind/OM1-ros2-sdk) repository:
 
-```bash
-git clone https://github.com/OpenMind/OM1-ros2-sdk.git
-```
+    ```bash
+    git clone https://github.com/OpenMind/OM1-ros2-sdk.git
+    ```
 
 Step 2: Install all the necessary dependencies:
 
-```bash
-cd OM1-ros2-sdk
-uv venv --python 3.10
-sudo rosdep init
-rosdep update
-rosdep install --from-paths . --ignore-src -r -y
-source .venv/bin/activate
-uv pip install .
-```
+    > **Note:** Python 3.10 is required for compatibility with ROS 2 Humble.
+
+    ```bash
+    cd OM1-ros2-sdk
+    uv venv --python 3.10
+    sudo rosdep init
+    rosdep update
+    rosdep install --from-paths . --ignore-src -r -y
+    source .venv/bin/activate
+    uv pip install .
+    ```
+
+    Export the python path to your virtual environment
+
+    ```bash
+    export PYTHONPATH=$PYTHONPATH:$(pwd)/.venv/lib/python3.10/site-packages
+    ```
 
 Step 3: Build all the packages:
 
-```bash
-colcon build
-```
+    ```bash
+    colcon build
+    ```
 
-Now you should be able to launch the **Gazebo Simulator**.
+    Now you should be able to launch the **Gazebo Simulator**.
 
 Step 4: Open a terminal and run the following commands. You'll now be able to see the Gazebo and RViZ windows launch on your system.
 
-```bash
-source install/setup.bash
-ros2 launch go2_gazebo_sim go2_launch.py
-```
+    ```bash
+    source install/setup.bash
+    ros2 launch go2_gazebo_sim go2_launch.py
+    ```
 
 Step 5: Open a new terminal and run:
 
-```bash
-source install/setup.bash
-ros2 launch go2_sdk sensor_launch.py use_sim:=true
-```
+    ```bash
+    source install/setup.bash
+    ros2 launch go2_sdk sensor_launch.py use_sim:=true
+    ```
 
-This will bring up the `om/path` topic, enabling OM1 to understand the surrounding environment.
+    This will bring up the `om/path` topic, enabling OM1 to understand the surrounding environment.
 
-Step 6: Open a new terminal and run:
+Step 6: Run Zenoh ROS 2 Bridge
 
-```bash
-export PYTHONPATH=$PYTHONPATH:$(pwd)/.venv/lib/python3.10/site-packages
-source install/setup.bash
-ros2 launch orchestrator orchestrator_launch.py use_sim:=true
-```
+    Install the Zenoh ROS 2 bridge. You can find additional details in the [Zenoh ROS 2 Bridge documentation](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds).
 
-This will bring up the `orchestrator`, to consume data collected by `om1_sensor` for SLAM and Navigation.
+    ```bash
+    sudo apt install ros-humble-rmw-zenoh-cpp
+    ```
 
-Step 7: Run Zenoh Ros2 Bridge
+    Alternatively, you can install from the official Zenoh Debian repository:
 
-To run the Zenoh bridge for the Unitree Go2, you need to have the Zenoh ROS 2 bridge installed. You can find the installation instructions in the [Zenoh ROS 2 Bridge documentation](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds)
+    ```bash
+    echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee /etc/apt/sources.list.d/zenoh.list > /dev/null
+    sudo apt update
+    sudo apt install zenoh-bridge-ros2dds
+    ```
 
-After installing the Zenoh ROS 2 bridge, you can run it with the following command:
+    After installing the Zenoh ROS 2 bridge, run it with the following command:
 
-```bash
-zenoh-bridge-ros2dds -c ./zenoh/zenoh_bridge_config.json5
-```
+    ```bash
+    zenoh-bridge-ros2dds -c ./zenoh/zenoh_bridge_config.json5
+    ```
 
-Step 8: Start OM1
+Step 7: Start SLAM mode
 
-Refer to the [Installation Guide](../developing/1_get-started) for detailed instructions.
+    Open a new terminal and run the following to start the SLAM mode for the robot to start mapping the area. Our Gazebo setup includes auto mapping feature, this will let the robot to generate a 2D map for the area which can then be utilised at later stage to make the robot move from point A to point B.
 
-Then add the optional Python CycloneDDS module to OM1, run
+    ```bash
+    source install/setup.bash
+    ros2 launch go2_sdk slam_launch.py use_sim:=true
+    ```
 
-```bash
-uv pip install -r pyproject.toml --extra dds
-```
+Step 8: Save the map
 
-Setup your API key in `.bashrc` file and run your simulation agent:
+    After the SLAM mode is complete, you can save the map by using the following command. Replace `<my_map>` with the name you prefer for saving the map.
 
-Get your API key from the [portal](https://portal.openmind.org), and add it to `bashrc`
+    ```bash
+    source install/setup.bash
+    ros2 run nav2_map_server map_saver_cli -f my_map
+    ```
 
-```bash
-vi ~/.bashrc
-```
+Step 9: Navigate the robot across the map
 
-```bash
-export OM_API_KEY="<your_api_key>"
-```
+    Once you successfully save the map, you can run the following command in a new terminal to enable navigation. After running the command, simply head over to RViz window and press **2D goal pose**. Now click at any new location on the map to make the robot start navigating towards it.
 
-Now, run the simulation agent
+    Make sure the map name is same as the one you set up in the previous step.
 
-```bash
-uv run src/run.py simulation
-```
+    ```bash
+    source install/setup.bash
+    ros2 launch go2_sdk nav2_launch.py use_sim:=true map_yaml_file:=my_map.yaml
+    ```
 
-Step 9: Teleoperate the robot in simulation
+Step 10: Teleoperate the robot in simulation
 
-You can also use teleoperation to control the robot through your keyboard.
+    You can also use teleoperation to control the robot through your keyboard using the following commands in a new terminal.
 
-Switch back to `OM1-ros2-sdk` in a new terminal and run the following commands
+    ```bash
+    source install/setup.bash
+    ros2 run teleop_twist_keyboard teleop_twist_keyboard
+    ```
 
-```bash
-source install/setup.bash
-ros2 run teleop_twist_keyboard teleop_twist_keyboard
-```
+    Use the keyboard controls displayed in the terminal to move the robot:
+    ```
+    i - Move forward
+    , - Move backward
+    j - Turn left
+    l - Turn right
+    k - Stop
+    U/O/M/> - Move diagonally
+    ```
 
-Use the keyboard controls displayed in the terminal to move the robot:
-```
-i - Move forward
-, - Move backward
-j - Turn left
-l - Turn right
-k - Stop
-U/O/M/> - Move diagonally
-```
-
-> **Note**: We don't have auto charging feature supported with Gazebo but it will be launched soon. Stay tuned!
+Note: We don't have auto charging feature supported with Gazebo but it will be launched soon. Stay tuned!


### PR DESCRIPTION
## Summary
Clean up and simplify the Gazebo simulator guide for clarity and consistency.

## Changes
- Consolidate duplicate CycloneDDS configuration guidance
- Standardize editor command usage (`vim`)
- Add clearer prerequisite cue for Python 3.10 virtualenv setup
- Add inline Zenoh bridge installation step for smoother setup flow

## File changed
- `docs/simulators/gazebo.md`

## Scope
Docs-only PR, no code/CI changes.
