### PR TITLE
fix(ubtts): use model_validator to build base_url after field resolution

### DIFF
--- a/src/actions/speak/connector/ub_tts.py
+++ b/src/actions/speak/connector/ub_tts.py
@@ -3,7 +3,7 @@ import time
 from typing import Optional
 
 import zenoh
-from pydantic import Field
+from pydantic import Field, model_validator
 
 # Import the necessary base classes and YOUR existing SpeakInput interface
 from actions.base import ActionConfig, ActionConnector
@@ -34,10 +34,17 @@ class UbTtsConfig(ActionConfig):
         default=None,
         description="The IP address of the robot.",
     )
-    base_url: str = Field(
-        default=f"http://{robot_ip}:9090/v1/",
+    base_url: Optional[str] = Field(
+        default=None,
         description="The base URL for the UbTTS service.",
     )
+
+    @model_validator(mode="after")
+    def build_base_url(self) -> "UbTtsConfig":
+        """Build base_url after field values are resolved."""
+        if self.base_url is None and self.robot_ip is not None:
+            self.base_url = f"http://{self.robot_ip}:9090/v1/"
+        return self
 
 
 class UbTtsConnector(ActionConnector[UbTtsConfig, SpeakInput]):


### PR DESCRIPTION
Fixes #2323

- base_url sekarang dibangun setelah robot_ip punya value
- Prevents FieldInfo being evaluated instead of actual value
- Use model_validator(mode='after') untuk build base_url dinamis

## Overview
[Provide a brief overview of the changes in this pull request.]
(If applicable, linked issue: [ ])

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
[Detail the changes you have made in this pull request. Include any new features, bug fixes, or improvements.]

## Checklist

- [ ] Code complies with style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if applicable)
- [ ] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact
[Explain the impact of your changes. Include any potential risks or side effects that reviewers should be aware of.]

## Additional Information
[Include any additional information that may be relevant to reviewers. This could include links to related issues or pull requests, references to documentation, or other context that may help reviewers understand your changes.]
