### PR TITLE
feat: add Prometheus metrics and HTML dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "dimo-python-sdk @ git+https://github.com/openminddev/dimo-python-sdk.git@6b47fcd28654a4145cedee649a0999a8eb08a2f6",
     "nest-asyncio==1.6.0",
     "tf-keras==2.18.0",
-    "prometheus-client>=0.20.0",
+    "prometheus-client==0.24.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dds = [
     "cyclonedds==0.10.2"
 ]
 macos = ["osascript"]
+metrics = ["prometheus-client>=0.20.0"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "dimo-python-sdk @ git+https://github.com/openminddev/dimo-python-sdk.git@6b47fcd28654a4145cedee649a0999a8eb08a2f6",
     "nest-asyncio==1.6.0",
     "tf-keras==2.18.0",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.optional-dependencies]
@@ -47,7 +48,6 @@ dds = [
     "cyclonedds==0.10.2"
 ]
 macos = ["osascript"]
-metrics = ["prometheus-client>=0.20.0"]
 
 [dependency-groups]
 dev = [

--- a/src/actions/orchestrator.py
+++ b/src/actions/orchestrator.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 from actions.base import AgentAction
 from llm.output_model import Action
 from runtime.config import RuntimeConfig
+from runtime.metrics import ACTION_ERRORS_TOTAL, ACTION_EXECUTIONS_TOTAL, ACTION_STATUS
 
 
 class ActionOrchestrator:
@@ -99,12 +100,15 @@ class ActionOrchestrator:
         action : AgentAction
             The agent action whose connector should be run in the loop.
         """
+        ACTION_STATUS.labels(name=action.llm_label).set(1)
         while not self._stop_event.is_set():
             try:
                 action.connector.tick()
             except Exception:
+                ACTION_ERRORS_TOTAL.labels(name=action.llm_label).inc()
                 logging.exception(f"Error in connector {action.llm_label}")
                 self._stop_event.wait(timeout=0.1)
+        ACTION_STATUS.labels(name=action.llm_label).set(0)
 
     async def flush_promises(self) -> tuple[list[T.Any], list[asyncio.Task[T.Any]]]:
         """
@@ -378,6 +382,7 @@ class ActionOrchestrator:
 
         input_interface = input_type(**converted_params)
 
+        ACTION_EXECUTIONS_TOTAL.labels(name=agent_action.llm_label).inc()
         await agent_action.connector.connect(input_interface)
 
         return input_interface
@@ -393,6 +398,7 @@ class ActionOrchestrator:
         self._stop_event.set()
 
         for agent_action in self._action_instances:
+            ACTION_STATUS.labels(name=agent_action.llm_label).set(0)
             try:
                 agent_action.connector.stop()
             except Exception:

--- a/src/backgrounds/orchestrator.py
+++ b/src/backgrounds/orchestrator.py
@@ -5,6 +5,11 @@ from concurrent.futures import ThreadPoolExecutor
 
 from backgrounds.base import Background
 from runtime.config import RuntimeConfig
+from runtime.metrics import (
+    BACKGROUND_ERRORS_TOTAL,
+    BACKGROUND_RUNS_TOTAL,
+    BACKGROUND_STATUS,
+)
 
 
 class BackgroundOrchestrator:
@@ -77,12 +82,16 @@ class BackgroundOrchestrator:
         background : Background
             The background task to run.
         """
+        BACKGROUND_STATUS.labels(name=background.name).set(1)
         while not self._stop_event.is_set():
             try:
+                BACKGROUND_RUNS_TOTAL.labels(name=background.name).inc()
                 background.run()
             except Exception:
+                BACKGROUND_ERRORS_TOTAL.labels(name=background.name).inc()
                 logging.exception(f"Error in background {background.name}")
                 self._stop_event.wait(timeout=0.1)
+        BACKGROUND_STATUS.labels(name=background.name).set(0)
 
     def stop(self):
         """
@@ -96,6 +105,7 @@ class BackgroundOrchestrator:
         self._stop_event.set()
 
         for background in self._background_instances:
+            BACKGROUND_STATUS.labels(name=background.name).set(0)
             try:
                 background.stop()
             except Exception:

--- a/src/inputs/orchestrator.py
+++ b/src/inputs/orchestrator.py
@@ -3,6 +3,7 @@ import logging
 from collections.abc import Sequence
 
 from inputs.base import Sensor
+from runtime.metrics import INPUT_ERRORS_TOTAL, INPUT_EVENTS_TOTAL, INPUT_STATUS
 
 
 class InputOrchestrator:
@@ -56,14 +57,19 @@ class InputOrchestrator:
             Input source to listen to
         """
         input_name = type(input).__name__
+        INPUT_STATUS.labels(name=input_name).set(1)
         try:
             async for event in input.listen():
                 try:
+                    INPUT_EVENTS_TOTAL.labels(name=input_name).inc()
                     await input.raw_to_text(event)
                 except Exception as e:
+                    INPUT_ERRORS_TOTAL.labels(name=input_name).inc()
                     logging.error(
                         f"Error processing event in {input_name}: {e}", exc_info=True
                     )
         except Exception as e:
+            INPUT_STATUS.labels(name=input_name).set(-1)
+            INPUT_ERRORS_TOTAL.labels(name=input_name).inc()
             logging.error(f"Input {input_name} listener failed: {e}", exc_info=True)
             raise

--- a/src/run.py
+++ b/src/run.py
@@ -11,6 +11,7 @@ import typer
 from runtime.config import load_mode_config
 from runtime.cortex import ModeCortexRuntime
 from runtime.logging import setup_logging
+from runtime.metrics import start_metrics_server
 
 app = typer.Typer()
 
@@ -93,6 +94,7 @@ def start(
     """
     config_name, config_path = setup_config_file(config_name)
     setup_logging(config_name, log_level, log_to_file)
+    start_metrics_server()
 
     try:
         mode_config = load_mode_config(config_name)

--- a/src/runtime/cortex.py
+++ b/src/runtime/cortex.py
@@ -18,6 +18,12 @@ from runtime.config import (
     load_mode_config,
 )
 from runtime.manager import ModeManager
+from runtime.metrics import (
+    CORTEX_TICK_DURATION,
+    CORTEX_TICKS_TOTAL,
+    MODE_CURRENT,
+    MODE_TRANSITIONS_TOTAL,
+)
 from simulators.orchestrator import SimulatorOrchestrator
 
 
@@ -140,6 +146,7 @@ class ModeCortexRuntime:
         self.background_orchestrator = BackgroundOrchestrator(self.current_config)
 
         logging.info(f"Mode '{mode_name}' initialized successfully")
+        MODE_CURRENT.labels(mode=mode_name).set(1)
 
     async def _handle_mode_transitions(self):
         """
@@ -208,6 +215,9 @@ class ModeCortexRuntime:
             # Start new orchestrators
             await self._start_orchestrators()
 
+            MODE_CURRENT.labels(mode=from_mode).set(0)
+            MODE_CURRENT.labels(mode=to_mode).set(1)
+            MODE_TRANSITIONS_TOTAL.labels(from_mode=from_mode, to_mode=to_mode).inc()
             logging.info(f"Successfully transitioned to mode: {to_mode}")
 
         except Exception as e:
@@ -527,45 +537,52 @@ class ModeCortexRuntime:
             logging.debug("Skipping tick during config reload")
             return
 
-        tick_num = self.io_provider.increment_tick()
-        logging.debug(f"Processing tick #{tick_num}")
+        tick_start = time.time()
+        try:
+            tick_num = self.io_provider.increment_tick()
+            CORTEX_TICKS_TOTAL.inc()
+            logging.debug(f"Processing tick #{tick_num}")
 
-        finished_promises, _ = await self.action_orchestrator.flush_promises()
+            finished_promises, _ = await self.action_orchestrator.flush_promises()
 
-        prompt = self.fuser.fuse(self.current_config.agent_inputs, finished_promises)
-        if prompt is None:
-            logging.debug("No prompt to fuse")
-            return
-
-        with self.io_provider.mode_transition_input():
-            last_input = self.io_provider.get_mode_transition_input()
-
-        transition_result = await self.mode_manager.process_tick(last_input)
-        if transition_result:
-            new_mode, transition_reason = transition_result
-
-            # Schedule the transition asynchronously
-            self._pending_mode_transition = new_mode
-            self._pending_transition_reason = transition_reason
-            self._mode_transition_event.set()
-            logging.info(
-                f"Scheduled mode transition to: {new_mode} (reason: {transition_reason})"
+            prompt = self.fuser.fuse(
+                self.current_config.agent_inputs, finished_promises
             )
-            return
+            if prompt is None:
+                logging.debug("No prompt to fuse")
+                return
 
-        output = await self.current_config.cortex_llm.ask(prompt)
-        if output is None:
-            logging.debug("No output from LLM")
-            return
+            with self.io_provider.mode_transition_input():
+                last_input = self.io_provider.get_mode_transition_input()
 
-        if self._is_reloading:
-            logging.debug("Skipping tick during config reload")
-            return
+            transition_result = await self.mode_manager.process_tick(last_input)
+            if transition_result:
+                new_mode, transition_reason = transition_result
 
-        if self.simulator_orchestrator:
-            await self.simulator_orchestrator.promise(output.actions)
+                # Schedule the transition asynchronously
+                self._pending_mode_transition = new_mode
+                self._pending_transition_reason = transition_reason
+                self._mode_transition_event.set()
+                logging.info(
+                    f"Scheduled mode transition to: {new_mode} (reason: {transition_reason})"
+                )
+                return
 
-        await self.action_orchestrator.promise(output.actions)
+            output = await self.current_config.cortex_llm.ask(prompt)
+            if output is None:
+                logging.debug("No output from LLM")
+                return
+
+            if self._is_reloading:
+                logging.debug("Skipping tick during config reload")
+                return
+
+            if self.simulator_orchestrator:
+                await self.simulator_orchestrator.promise(output.actions)
+
+            await self.action_orchestrator.promise(output.actions)
+        finally:
+            CORTEX_TICK_DURATION.observe(time.time() - tick_start)
 
     def get_mode_info(self) -> dict:
         """

--- a/src/runtime/metrics.py
+++ b/src/runtime/metrics.py
@@ -16,6 +16,7 @@ Endpoints:
 import logging
 import os
 import threading
+from html import escape
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Union
 
@@ -95,7 +96,7 @@ def _render_dashboard() -> str:
             for sample_name, col_label in matched:
                 for labels, value in samples[sample_name]:
                     label_parts = [v for k, v in sorted(labels.items()) if k != "le"]
-                    label_str = ", ".join(label_parts) if label_parts else "-"
+                    label_str = escape(", ".join(label_parts)) if label_parts else "-"
                     if is_status:
                         if value == 1:
                             val_cell = '<span class="dot green"></span> running'
@@ -108,7 +109,7 @@ def _render_dashboard() -> str:
                             f"{value:.4f}" if value != int(value) else str(int(value))
                         )
                     rows.append(
-                        f"<tr><td>{col_label}</td>"
+                        f"<tr><td>{escape(col_label)}</td>"
                         f"<td>{label_str}</td>"
                         f"<td>{val_cell}</td></tr>"
                     )
@@ -280,7 +281,11 @@ try:
 
     def start_metrics_server() -> None:
         """Start the metrics HTTP server with dashboard and Prometheus endpoints."""
-        port = int(os.environ.get("METRICS_PORT", "9464"))
+        try:
+            port = int(os.environ.get("METRICS_PORT", "9464"))
+        except ValueError:
+            logging.warning("Invalid METRICS_PORT value, using default 9464")
+            port = 9464
         try:
             server = HTTPServer(("", port), _MetricsHandler)
             t = threading.Thread(target=server.serve_forever, daemon=True)

--- a/src/runtime/metrics.py
+++ b/src/runtime/metrics.py
@@ -19,10 +19,6 @@ import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Union
 
-# ---------------------------------------------------------------------------
-# Metric category definitions for the HTML dashboard
-# ---------------------------------------------------------------------------
-
 _CATEGORIES: dict[str, dict[str, str]] = {
     "Inputs": {
         "om1_input_status": "Status",
@@ -54,10 +50,6 @@ _CATEGORIES: dict[str, dict[str, str]] = {
     },
 }
 
-# ---------------------------------------------------------------------------
-# HTML dashboard renderer
-# ---------------------------------------------------------------------------
-
 _STATUS_METRICS = {
     "om1_input_status",
     "om1_action_status",
@@ -66,7 +58,6 @@ _STATUS_METRICS = {
     "om1_mode_current",
 }
 
-# Suffixes to skip when collecting samples (histogram buckets, counter created)
 _SKIP_SUFFIXES = ("_bucket", "_created")
 
 
@@ -74,8 +65,6 @@ def _render_dashboard() -> str:
     """Collect metrics from the registry and return an HTML dashboard string."""
     from prometheus_client import REGISTRY
 
-    # Collect all om1_* samples keyed by sample name.
-    # Each entry: [(labels_dict, value), ...]
     samples: dict[str, list[tuple[dict[str, str], float]]] = {}
     for metric in REGISTRY.collect():
         for sample in metric.samples:
@@ -87,14 +76,10 @@ def _render_dashboard() -> str:
                 (dict(sample.labels), sample.value)
             )
 
-    # Build category sections
     sections: list[str] = []
     for cat_title, metric_map in _CATEGORIES.items():
         rows: list[str] = []
         for metric_name, display_name in metric_map.items():
-            # Resolve matching sample names.
-            # Gauges/Counters: direct match.
-            # Histograms: base name won't exist; look for _count and _sum.
             matched: list[tuple[str, str]] = []
             if metric_name in samples:
                 matched.append((metric_name, display_name))
@@ -158,11 +143,6 @@ def _render_dashboard() -> str:
     )
 
 
-# ---------------------------------------------------------------------------
-# No-op stub used when prometheus_client is not installed
-# ---------------------------------------------------------------------------
-
-
 class _NoOp:
     """Drop-in stub that silently ignores all metric operations."""
 
@@ -178,10 +158,6 @@ class _NoOp:
     def observe(self, _value: float) -> None:
         return None
 
-
-# ---------------------------------------------------------------------------
-# Metric definitions + HTTP server
-# ---------------------------------------------------------------------------
 
 try:
     from prometheus_client import Counter, Gauge, Histogram, generate_latest

--- a/src/runtime/metrics.py
+++ b/src/runtime/metrics.py
@@ -7,11 +7,156 @@ prometheus_client is not installed.
 Start the metrics HTTP server with ``start_metrics_server()``.
 The server port is controlled by the ``METRICS_PORT`` environment variable
 (default 9464).
+
+Endpoints:
+- ``/`` — Human-readable HTML dashboard (auto-refreshes every 5s)
+- ``/metrics`` — Prometheus scrape endpoint (raw text format)
 """
 
 import logging
 import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Union
+
+# ---------------------------------------------------------------------------
+# Metric category definitions for the HTML dashboard
+# ---------------------------------------------------------------------------
+
+_CATEGORIES: dict[str, dict[str, str]] = {
+    "Inputs": {
+        "om1_input_status": "Status",
+        "om1_input_events_total": "Events",
+        "om1_input_errors_total": "Errors",
+    },
+    "Actions": {
+        "om1_action_status": "Status",
+        "om1_action_executions_total": "Executions",
+        "om1_action_errors_total": "Errors",
+    },
+    "Backgrounds": {
+        "om1_background_status": "Status",
+        "om1_background_runs_total": "Runs",
+        "om1_background_errors_total": "Errors",
+    },
+    "Simulators": {
+        "om1_simulator_status": "Status",
+        "om1_simulator_ticks_total": "Ticks",
+        "om1_simulator_errors_total": "Errors",
+    },
+    "Cortex": {
+        "om1_cortex_ticks_total": "Ticks",
+        "om1_cortex_tick_duration_seconds": "Tick Duration (s)",
+    },
+    "Mode": {
+        "om1_mode_current": "Current Mode",
+        "om1_mode_transitions_total": "Transitions",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# HTML dashboard renderer
+# ---------------------------------------------------------------------------
+
+_STATUS_METRICS = {
+    "om1_input_status",
+    "om1_action_status",
+    "om1_background_status",
+    "om1_simulator_status",
+    "om1_mode_current",
+}
+
+# Suffixes to skip when collecting samples (histogram buckets, counter created)
+_SKIP_SUFFIXES = ("_bucket", "_created")
+
+
+def _render_dashboard() -> str:
+    """Collect metrics from the registry and return an HTML dashboard string."""
+    from prometheus_client import REGISTRY
+
+    # Collect all om1_* samples keyed by sample name.
+    # Each entry: [(labels_dict, value), ...]
+    samples: dict[str, list[tuple[dict[str, str], float]]] = {}
+    for metric in REGISTRY.collect():
+        for sample in metric.samples:
+            if not sample.name.startswith("om1_"):
+                continue
+            if sample.name.endswith(_SKIP_SUFFIXES):
+                continue
+            samples.setdefault(sample.name, []).append(
+                (dict(sample.labels), sample.value)
+            )
+
+    # Build category sections
+    sections: list[str] = []
+    for cat_title, metric_map in _CATEGORIES.items():
+        rows: list[str] = []
+        for metric_name, display_name in metric_map.items():
+            # Resolve matching sample names.
+            # Gauges/Counters: direct match.
+            # Histograms: base name won't exist; look for _count and _sum.
+            matched: list[tuple[str, str]] = []
+            if metric_name in samples:
+                matched.append((metric_name, display_name))
+            else:
+                count_key = metric_name + "_count"
+                sum_key = metric_name + "_sum"
+                if count_key in samples:
+                    matched.append((count_key, display_name + " Count"))
+                if sum_key in samples:
+                    matched.append((sum_key, display_name + " Sum"))
+
+            is_status = metric_name in _STATUS_METRICS
+            for sample_name, col_label in matched:
+                for labels, value in samples[sample_name]:
+                    label_parts = [v for k, v in sorted(labels.items()) if k != "le"]
+                    label_str = ", ".join(label_parts) if label_parts else "-"
+                    if is_status:
+                        if value == 1:
+                            val_cell = '<span class="dot green"></span> running'
+                        elif value == -1:
+                            val_cell = '<span class="dot red"></span> failed'
+                        else:
+                            val_cell = '<span class="dot gray"></span> stopped'
+                    else:
+                        val_cell = (
+                            f"{value:.4f}" if value != int(value) else str(int(value))
+                        )
+                    rows.append(
+                        f"<tr><td>{col_label}</td>"
+                        f"<td>{label_str}</td>"
+                        f"<td>{val_cell}</td></tr>"
+                    )
+        if rows:
+            sections.append(
+                f"<h2>{cat_title}</h2>"
+                f"<table><tr><th>Metric</th><th>Labels</th><th>Value</th></tr>"
+                f"{''.join(rows)}</table>"
+            )
+
+    body = "".join(sections) if sections else "<p>No om1 metrics recorded yet.</p>"
+
+    return (
+        "<!DOCTYPE html><html><head><meta charset='utf-8'>"
+        "<meta http-equiv='refresh' content='5'>"
+        "<title>OM1 Metrics</title>"
+        "<style>"
+        "body{font-family:system-ui,sans-serif;margin:2rem;background:#f8f9fa}"
+        "h1{color:#1a1a2e}"
+        "h2{color:#16213e;margin-top:1.5rem}"
+        "table{border-collapse:collapse;width:100%;margin-bottom:1rem}"
+        "th,td{text-align:left;padding:.4rem .8rem;border:1px solid #dee2e6}"
+        "th{background:#e9ecef}"
+        "tr:nth-child(even){background:#f1f3f5}"
+        ".dot{display:inline-block;width:10px;height:10px;border-radius:50%;"
+        "margin-right:6px;vertical-align:middle}"
+        ".green{background:#2ecc71}.red{background:#e74c3c}.gray{background:#95a5a6}"
+        "</style></head><body>"
+        "<h1>OM1 Metrics Dashboard</h1>"
+        f"{body}"
+        "</body></html>"
+    )
+
 
 # ---------------------------------------------------------------------------
 # No-op stub used when prometheus_client is not installed
@@ -39,7 +184,33 @@ class _NoOp:
 # ---------------------------------------------------------------------------
 
 try:
-    from prometheus_client import Counter, Gauge, Histogram, start_http_server
+    from prometheus_client import Counter, Gauge, Histogram, generate_latest
+
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+    class _MetricsHandler(BaseHTTPRequestHandler):
+        """Serves HTML dashboard on ``/`` and Prometheus format on ``/metrics``."""
+
+        def do_GET(self) -> None:
+            if self.path == "/metrics":
+                data = generate_latest()
+                self.send_response(200)
+                self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+            elif self.path == "/":
+                html = _render_dashboard().encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(html)))
+                self.end_headers()
+                self.wfile.write(html)
+            else:
+                self.send_error(404)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+            """Suppress default stderr access logs."""
 
     # -- Input metrics --
     INPUT_STATUS: Union[Gauge, _NoOp] = Gauge(
@@ -132,11 +303,16 @@ try:
     )
 
     def start_metrics_server() -> None:
-        """Start the Prometheus metrics HTTP server."""
+        """Start the metrics HTTP server with dashboard and Prometheus endpoints."""
         port = int(os.environ.get("METRICS_PORT", "9464"))
         try:
-            start_http_server(port)
-            logging.info(f"Metrics server started on port {port}")
+            server = HTTPServer(("", port), _MetricsHandler)
+            t = threading.Thread(target=server.serve_forever, daemon=True)
+            t.start()
+            logging.info(
+                f"Metrics server started on port {port} "
+                f"(dashboard: http://localhost:{port}/)"
+            )
         except OSError as e:
             logging.warning(f"Failed to start metrics server on port {port}: {e}")
 

--- a/src/runtime/metrics.py
+++ b/src/runtime/metrics.py
@@ -1,0 +1,170 @@
+"""Prometheus metrics for OM1 runtime monitoring.
+
+Provides metric definitions for inputs, actions, backgrounds, simulators,
+cortex ticks, and mode transitions. Falls back to no-op stubs when
+prometheus_client is not installed.
+
+Start the metrics HTTP server with ``start_metrics_server()``.
+The server port is controlled by the ``METRICS_PORT`` environment variable
+(default 9090).
+"""
+
+import logging
+import os
+from typing import Union
+
+# ---------------------------------------------------------------------------
+# No-op stub used when prometheus_client is not installed
+# ---------------------------------------------------------------------------
+
+
+class _NoOp:
+    """Drop-in stub that silently ignores all metric operations."""
+
+    def labels(self, **_kwargs: str) -> "_NoOp":
+        return self
+
+    def inc(self, _amount: float = 1) -> None:
+        return None
+
+    def set(self, _value: float) -> None:
+        return None
+
+    def observe(self, _value: float) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Metric definitions + HTTP server
+# ---------------------------------------------------------------------------
+
+try:
+    from prometheus_client import Counter, Gauge, Histogram, start_http_server
+
+    # -- Input metrics --
+    INPUT_STATUS: Union[Gauge, _NoOp] = Gauge(
+        "om1_input_status",
+        "Input status (1=running, -1=failed)",
+        ["name"],
+    )
+    INPUT_EVENTS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_input_events_total",
+        "Total input events processed",
+        ["name"],
+    )
+    INPUT_ERRORS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_input_errors_total",
+        "Total input errors",
+        ["name"],
+    )
+
+    # -- Action metrics --
+    ACTION_STATUS: Union[Gauge, _NoOp] = Gauge(
+        "om1_action_status",
+        "Action connector status (1=running, 0=stopped)",
+        ["name"],
+    )
+    ACTION_EXECUTIONS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_action_executions_total",
+        "Total action connect() calls",
+        ["name"],
+    )
+    ACTION_ERRORS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_action_errors_total",
+        "Total action errors",
+        ["name"],
+    )
+
+    # -- Background metrics --
+    BACKGROUND_STATUS: Union[Gauge, _NoOp] = Gauge(
+        "om1_background_status",
+        "Background task status (1=running, 0=stopped)",
+        ["name"],
+    )
+    BACKGROUND_RUNS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_background_runs_total",
+        "Total background run() calls",
+        ["name"],
+    )
+    BACKGROUND_ERRORS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_background_errors_total",
+        "Total background errors",
+        ["name"],
+    )
+
+    # -- Simulator metrics --
+    SIMULATOR_STATUS: Union[Gauge, _NoOp] = Gauge(
+        "om1_simulator_status",
+        "Simulator status (1=running, 0=stopped)",
+        ["name"],
+    )
+    SIMULATOR_TICKS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_simulator_ticks_total",
+        "Total simulator tick() calls",
+        ["name"],
+    )
+    SIMULATOR_ERRORS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_simulator_errors_total",
+        "Total simulator errors",
+        ["name"],
+    )
+
+    # -- Cortex metrics --
+    CORTEX_TICKS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_cortex_ticks_total",
+        "Total cortex tick count",
+    )
+    CORTEX_TICK_DURATION: Union[Histogram, _NoOp] = Histogram(
+        "om1_cortex_tick_duration_seconds",
+        "Cortex tick duration in seconds",
+    )
+
+    # -- Mode metrics --
+    MODE_CURRENT: Union[Gauge, _NoOp] = Gauge(
+        "om1_mode_current",
+        "Currently active mode (1=active)",
+        ["mode"],
+    )
+    MODE_TRANSITIONS_TOTAL: Union[Counter, _NoOp] = Counter(
+        "om1_mode_transitions_total",
+        "Total mode transitions",
+        ["from_mode", "to_mode"],
+    )
+
+    def start_metrics_server() -> None:
+        """Start the Prometheus metrics HTTP server."""
+        port = int(os.environ.get("METRICS_PORT", "9090"))
+        try:
+            start_http_server(port)
+            logging.info(f"Metrics server started on port {port}")
+        except OSError as e:
+            logging.warning(f"Failed to start metrics server on port {port}: {e}")
+
+except ImportError:
+    _noop = _NoOp()
+
+    INPUT_STATUS = _noop
+    INPUT_EVENTS_TOTAL = _noop
+    INPUT_ERRORS_TOTAL = _noop
+
+    ACTION_STATUS = _noop
+    ACTION_EXECUTIONS_TOTAL = _noop
+    ACTION_ERRORS_TOTAL = _noop
+
+    BACKGROUND_STATUS = _noop
+    BACKGROUND_RUNS_TOTAL = _noop
+    BACKGROUND_ERRORS_TOTAL = _noop
+
+    SIMULATOR_STATUS = _noop
+    SIMULATOR_TICKS_TOTAL = _noop
+    SIMULATOR_ERRORS_TOTAL = _noop
+
+    CORTEX_TICKS_TOTAL = _noop
+    CORTEX_TICK_DURATION = _noop
+
+    MODE_CURRENT = _noop
+    MODE_TRANSITIONS_TOTAL = _noop
+
+    def start_metrics_server() -> None:
+        """No-op when prometheus_client is not installed."""
+        logging.info("prometheus_client not installed, metrics server disabled")

--- a/src/runtime/metrics.py
+++ b/src/runtime/metrics.py
@@ -6,7 +6,7 @@ prometheus_client is not installed.
 
 Start the metrics HTTP server with ``start_metrics_server()``.
 The server port is controlled by the ``METRICS_PORT`` environment variable
-(default 9090).
+(default 9464).
 """
 
 import logging
@@ -133,7 +133,7 @@ try:
 
     def start_metrics_server() -> None:
         """Start the Prometheus metrics HTTP server."""
-        port = int(os.environ.get("METRICS_PORT", "9090"))
+        port = int(os.environ.get("METRICS_PORT", "9464"))
         try:
             start_http_server(port)
             logging.info(f"Metrics server started on port {port}")

--- a/src/simulators/orchestrator.py
+++ b/src/simulators/orchestrator.py
@@ -6,6 +6,11 @@ from concurrent.futures import ThreadPoolExecutor
 
 from llm.output_model import Action
 from runtime.config import RuntimeConfig
+from runtime.metrics import (
+    SIMULATOR_ERRORS_TOTAL,
+    SIMULATOR_STATUS,
+    SIMULATOR_TICKS_TOTAL,
+)
 from simulators.base import Simulator
 
 
@@ -70,12 +75,16 @@ class SimulatorOrchestrator:
         simulator : Simulator
             The simulator to run
         """
+        SIMULATOR_STATUS.labels(name=simulator.name).set(1)
         while not self._stop_event.is_set():
             try:
+                SIMULATOR_TICKS_TOTAL.labels(name=simulator.name).inc()
                 simulator.tick()
             except Exception:
+                SIMULATOR_ERRORS_TOTAL.labels(name=simulator.name).inc()
                 logging.exception(f"Error in simulator {simulator.name}")
                 self._stop_event.wait(timeout=0.1)
+        SIMULATOR_STATUS.labels(name=simulator.name).set(0)
 
     async def flush_promises(self) -> tuple[list[T.Any], list[asyncio.Task[T.Any]]]:
         """
@@ -143,6 +152,7 @@ class SimulatorOrchestrator:
         self._stop_event.set()
 
         for simulator in self._simulator_instances:
+            SIMULATOR_STATUS.labels(name=simulator.name).set(0)
             try:
                 simulator.stop()
             except Exception:

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -124,7 +124,7 @@ class TestStartMetricsServer:
         mock_start = MagicMock()
         with patch("runtime.metrics.start_http_server", mock_start):
             start_metrics_server()
-        mock_start.assert_called_once_with(9090)
+        mock_start.assert_called_once_with(9464)
 
     def test_custom_port_from_env(self):
         mock_start = MagicMock()

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -121,23 +121,27 @@ class TestStartMetricsServer:
     """Test start_metrics_server behavior."""
 
     def test_successful_start(self):
-        mock_start = MagicMock()
-        with patch("runtime.metrics.start_http_server", mock_start):
+        mock_server = MagicMock()
+        mock_cls = MagicMock(return_value=mock_server)
+        with patch("runtime.metrics.HTTPServer", mock_cls):
             start_metrics_server()
-        mock_start.assert_called_once_with(9464)
+        mock_cls.assert_called_once()
+        assert mock_cls.call_args[0][0] == ("", 9464)
+        mock_server.serve_forever.assert_called_once()
 
     def test_custom_port_from_env(self):
-        mock_start = MagicMock()
+        mock_server = MagicMock()
+        mock_cls = MagicMock(return_value=mock_server)
         with (
-            patch("runtime.metrics.start_http_server", mock_start),
+            patch("runtime.metrics.HTTPServer", mock_cls),
             patch.dict("os.environ", {"METRICS_PORT": "8888"}),
         ):
             start_metrics_server()
-        mock_start.assert_called_once_with(8888)
+        assert mock_cls.call_args[0][0] == ("", 8888)
 
     def test_port_in_use_logs_warning_not_crash(self):
-        mock_start = MagicMock(side_effect=OSError("Address already in use"))
-        with patch("runtime.metrics.start_http_server", mock_start):
+        mock_cls = MagicMock(side_effect=OSError("Address already in use"))
+        with patch("runtime.metrics.HTTPServer", mock_cls):
             # Should not raise
             start_metrics_server()
 

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -139,6 +139,16 @@ class TestStartMetricsServer:
             start_metrics_server()
         assert mock_cls.call_args[0][0] == ("", 8888)
 
+    def test_invalid_port_env_uses_default(self):
+        mock_server = MagicMock()
+        mock_cls = MagicMock(return_value=mock_server)
+        with (
+            patch("runtime.metrics.HTTPServer", mock_cls),
+            patch.dict("os.environ", {"METRICS_PORT": "not_a_number"}),
+        ):
+            start_metrics_server()
+        assert mock_cls.call_args[0][0] == ("", 9464)
+
     def test_port_in_use_logs_warning_not_crash(self):
         mock_cls = MagicMock(side_effect=OSError("Address already in use"))
         with patch("runtime.metrics.HTTPServer", mock_cls):

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -1,0 +1,194 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from runtime.metrics import (
+    ACTION_ERRORS_TOTAL,
+    ACTION_EXECUTIONS_TOTAL,
+    ACTION_STATUS,
+    BACKGROUND_ERRORS_TOTAL,
+    BACKGROUND_RUNS_TOTAL,
+    BACKGROUND_STATUS,
+    CORTEX_TICK_DURATION,
+    CORTEX_TICKS_TOTAL,
+    INPUT_ERRORS_TOTAL,
+    INPUT_EVENTS_TOTAL,
+    INPUT_STATUS,
+    MODE_CURRENT,
+    MODE_TRANSITIONS_TOTAL,
+    SIMULATOR_ERRORS_TOTAL,
+    SIMULATOR_STATUS,
+    SIMULATOR_TICKS_TOTAL,
+    _NoOp,
+    start_metrics_server,
+)
+
+
+class TestNoOp:
+    """Test that the _NoOp stub silently ignores all metric operations."""
+
+    def test_labels_returns_self(self):
+        noop = _NoOp()
+        result = noop.labels(name="test")
+        assert result is noop
+
+    def test_labels_chaining(self):
+        noop = _NoOp()
+        result = noop.labels(name="test").labels(foo="bar")
+        assert result is noop
+
+    def test_inc_returns_none(self):
+        noop = _NoOp()
+        assert noop.inc() is None
+        assert noop.inc(5) is None
+
+    def test_set_returns_none(self):
+        noop = _NoOp()
+        assert noop.set(1) is None
+        assert noop.set(-1) is None
+
+    def test_observe_returns_none(self):
+        noop = _NoOp()
+        assert noop.observe(0.5) is None
+
+    def test_labels_then_inc(self):
+        """Test the full chain: metric.labels(name=x).inc() -- the real usage pattern."""
+        noop = _NoOp()
+        noop.labels(name="my_input").inc()
+
+    def test_labels_then_set(self):
+        noop = _NoOp()
+        noop.labels(name="my_input").set(1)
+
+    def test_labels_then_observe(self):
+        noop = _NoOp()
+        noop.labels(name="my_input").observe(0.123)
+
+
+class TestMetricTypes:
+    """Test that metrics are real prometheus types when the library is installed."""
+
+    def test_gauges_are_gauge_type(self):
+        assert isinstance(INPUT_STATUS, Gauge)
+        assert isinstance(ACTION_STATUS, Gauge)
+        assert isinstance(BACKGROUND_STATUS, Gauge)
+        assert isinstance(SIMULATOR_STATUS, Gauge)
+        assert isinstance(MODE_CURRENT, Gauge)
+
+    def test_counters_are_counter_type(self):
+        assert isinstance(INPUT_EVENTS_TOTAL, Counter)
+        assert isinstance(INPUT_ERRORS_TOTAL, Counter)
+        assert isinstance(ACTION_EXECUTIONS_TOTAL, Counter)
+        assert isinstance(ACTION_ERRORS_TOTAL, Counter)
+        assert isinstance(BACKGROUND_RUNS_TOTAL, Counter)
+        assert isinstance(BACKGROUND_ERRORS_TOTAL, Counter)
+        assert isinstance(SIMULATOR_TICKS_TOTAL, Counter)
+        assert isinstance(SIMULATOR_ERRORS_TOTAL, Counter)
+        assert isinstance(CORTEX_TICKS_TOTAL, Counter)
+        assert isinstance(MODE_TRANSITIONS_TOTAL, Counter)
+
+    def test_histograms_are_histogram_type(self):
+        assert isinstance(CORTEX_TICK_DURATION, Histogram)
+
+
+class TestMetricOperations:
+    """Test that real metric operations work without errors."""
+
+    def test_labeled_gauge_set(self):
+        INPUT_STATUS.labels(name="test_sensor").set(1)
+        INPUT_STATUS.labels(name="test_sensor").set(-1)
+
+    def test_labeled_counter_inc(self):
+        INPUT_EVENTS_TOTAL.labels(name="test_sensor").inc()
+        ACTION_EXECUTIONS_TOTAL.labels(name="test_action").inc()
+
+    def test_unlabeled_counter_inc(self):
+        CORTEX_TICKS_TOTAL.inc()
+
+    def test_histogram_observe(self):
+        CORTEX_TICK_DURATION.observe(0.05)
+
+    def test_mode_gauge_set(self):
+        MODE_CURRENT.labels(mode="patrol").set(1)
+        MODE_CURRENT.labels(mode="patrol").set(0)
+
+    def test_mode_transition_counter(self):
+        MODE_TRANSITIONS_TOTAL.labels(from_mode="idle", to_mode="patrol").inc()
+
+
+class TestStartMetricsServer:
+    """Test start_metrics_server behavior."""
+
+    def test_successful_start(self):
+        mock_start = MagicMock()
+        with patch("runtime.metrics.start_http_server", mock_start):
+            start_metrics_server()
+        mock_start.assert_called_once_with(9090)
+
+    def test_custom_port_from_env(self):
+        mock_start = MagicMock()
+        with (
+            patch("runtime.metrics.start_http_server", mock_start),
+            patch.dict("os.environ", {"METRICS_PORT": "8888"}),
+        ):
+            start_metrics_server()
+        mock_start.assert_called_once_with(8888)
+
+    def test_port_in_use_logs_warning_not_crash(self):
+        mock_start = MagicMock(side_effect=OSError("Address already in use"))
+        with patch("runtime.metrics.start_http_server", mock_start):
+            # Should not raise
+            start_metrics_server()
+
+
+class TestNoOpFallback:
+    """Test that when prometheus_client is missing, the module still loads."""
+
+    def test_module_loads_without_prometheus(self):
+        """Simulate prometheus_client not being installed via import patching."""
+        saved_metrics = sys.modules.get("runtime.metrics")
+        saved_prom_modules = {
+            k: sys.modules[k]
+            for k in list(sys.modules)
+            if k.startswith("prometheus_client")
+        }
+
+        # Remove prometheus_client and runtime.metrics from sys.modules
+        for key in list(sys.modules):
+            if key.startswith("prometheus_client"):
+                del sys.modules[key]
+        if "runtime.metrics" in sys.modules:
+            del sys.modules["runtime.metrics"]
+
+        builtins_import = __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "prometheus_client" or name.startswith("prometheus_client."):
+                raise ImportError("mocked: no prometheus_client")
+            return builtins_import(name, *args, **kwargs)
+
+        try:
+            with patch("builtins.__import__", side_effect=mock_import):
+                import runtime.metrics as m
+
+                # Use the reloaded module's _NoOp (different class identity after reload)
+                noop_cls = m._NoOp
+                assert isinstance(m.INPUT_STATUS, noop_cls)
+                assert isinstance(m.CORTEX_TICKS_TOTAL, noop_cls)
+                assert isinstance(m.MODE_CURRENT, noop_cls)
+
+                # All operations should work silently
+                m.INPUT_STATUS.labels(name="test").set(1)
+                m.CORTEX_TICKS_TOTAL.inc()
+                m.CORTEX_TICK_DURATION.observe(0.5)
+                m.MODE_TRANSITIONS_TOTAL.labels(from_mode="a", to_mode="b").inc()
+
+                # start_metrics_server should be a no-op
+                m.start_metrics_server()
+        finally:
+            if "runtime.metrics" in sys.modules:
+                del sys.modules["runtime.metrics"]
+            if saved_metrics is not None:
+                sys.modules["runtime.metrics"] = saved_metrics
+            sys.modules.update(saved_prom_modules)

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -146,6 +146,136 @@ class TestStartMetricsServer:
             start_metrics_server()
 
 
+class TestRenderDashboard:
+    """Test the HTML dashboard renderer."""
+
+    def test_empty_dashboard(self):
+        from runtime.metrics import _render_dashboard
+
+        html = _render_dashboard()
+        assert "<!DOCTYPE html>" in html
+        assert "OM1 Metrics Dashboard" in html
+        assert "content='5'" in html
+
+    def test_dashboard_shows_status_dots(self):
+        from runtime.metrics import _render_dashboard
+
+        INPUT_STATUS.labels(name="cam").set(1)
+        INPUT_STATUS.labels(name="mic").set(-1)
+        INPUT_STATUS.labels(name="lidar").set(0)
+
+        html = _render_dashboard()
+        assert "dot green" in html
+        assert "running" in html
+        assert "dot red" in html
+        assert "failed" in html
+        assert "dot gray" in html
+        assert "stopped" in html
+
+    def test_dashboard_shows_counter_values(self):
+        from runtime.metrics import _render_dashboard
+
+        INPUT_EVENTS_TOTAL.labels(name="cam").inc()
+
+        html = _render_dashboard()
+        assert "cam" in html
+        assert "<h2>Inputs</h2>" in html
+
+    def test_dashboard_shows_histogram_count_and_sum(self):
+        from runtime.metrics import _render_dashboard
+
+        CORTEX_TICK_DURATION.observe(0.5)
+
+        html = _render_dashboard()
+        assert "Tick Duration (s) Count" in html
+        assert "Tick Duration (s) Sum" in html
+
+    def test_dashboard_filters_python_metrics(self):
+        from runtime.metrics import _render_dashboard
+
+        html = _render_dashboard()
+        assert "python_gc" not in html
+        assert "python_info" not in html
+
+    def test_dashboard_shows_all_categories(self):
+        from runtime.metrics import _render_dashboard
+
+        INPUT_STATUS.labels(name="x").set(1)
+        ACTION_STATUS.labels(name="x").set(1)
+        BACKGROUND_STATUS.labels(name="x").set(1)
+        SIMULATOR_STATUS.labels(name="x").set(1)
+        CORTEX_TICKS_TOTAL.inc()
+        MODE_CURRENT.labels(mode="x").set(1)
+
+        html = _render_dashboard()
+        for cat in ["Inputs", "Actions", "Backgrounds", "Simulators", "Cortex", "Mode"]:
+            assert f"<h2>{cat}</h2>" in html
+
+    def test_dashboard_formats_float_values(self):
+        from runtime.metrics import _render_dashboard
+
+        CORTEX_TICK_DURATION.observe(0.1234)
+
+        html = _render_dashboard()
+        assert "0.1234" in html or "Tick Duration" in html
+
+
+class TestMetricsHandler:
+    """Test the custom HTTP handler via a real server."""
+
+    def _start_server(self):
+        import threading
+        from http.server import HTTPServer
+
+        from runtime.metrics import _MetricsHandler
+
+        server = HTTPServer(("127.0.0.1", 0), _MetricsHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        return server, port
+
+    def test_metrics_endpoint(self):
+        import urllib.request
+
+        server, port = self._start_server()
+        try:
+            resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics")
+            assert resp.status == 200
+            assert "text/plain" in resp.headers["Content-Type"]
+            body = resp.read().decode()
+            assert "om1_" in body
+        finally:
+            server.shutdown()
+
+    def test_dashboard_endpoint(self):
+        import urllib.request
+
+        server, port = self._start_server()
+        try:
+            resp = urllib.request.urlopen(f"http://127.0.0.1:{port}/")
+            assert resp.status == 200
+            assert "text/html" in resp.headers["Content-Type"]
+            body = resp.read().decode()
+            assert "OM1 Metrics Dashboard" in body
+        finally:
+            server.shutdown()
+
+    def test_404_for_unknown_path(self):
+        import urllib.error
+        import urllib.request
+
+        server, port = self._start_server()
+        try:
+            try:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/unknown")
+                assert False, "Expected 404"
+            except urllib.error.HTTPError as e:
+                assert e.code == 404
+        finally:
+            server.shutdown()
+
+
 class TestNoOpFallback:
     """Test that when prometheus_client is missing, the module still loads."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -2698,6 +2698,9 @@ dds = [
 macos = [
     { name = "osascript" },
 ]
+metrics = [
+    { name = "prometheus-client" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2734,6 +2737,7 @@ requires-dist = [
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "osascript", marker = "extra == 'macos'" },
     { name = "pillow", specifier = "==12.1.1" },
+    { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
     { name = "py-mjpeg", specifier = "==1.0.1" },
     { name = "pyaudio", specifier = "==0.2.14" },
     { name = "pycdr2", specifier = "==1.0.0" },
@@ -2752,7 +2756,7 @@ requires-dist = [
     { name = "web3", specifier = "==7.6.0" },
     { name = "websockets", specifier = "==13.1" },
 ]
-provides-extras = ["dds", "macos"]
+provides-extras = ["dds", "macos", "metrics"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3116,6 +3120,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/13/b62d075317d8686071eb843f0bb1f195eb332f48869d3c31a4c6f1e063ac/pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4", size = 193330, upload-time = "2025-01-20T18:31:48.681Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/b3/df14c580d82b9627d173ceea305ba898dca135feb360b6d84019d0803d3b/pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b", size = 220560, upload-time = "2025-01-20T18:31:47.319Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2672,6 +2672,7 @@ dependencies = [
     { name = "openai" },
     { name = "opencv-python" },
     { name = "pillow" },
+    { name = "prometheus-client" },
     { name = "py-mjpeg" },
     { name = "pyaudio" },
     { name = "pycdr2" },
@@ -2697,9 +2698,6 @@ dds = [
 ]
 macos = [
     { name = "osascript" },
-]
-metrics = [
-    { name = "prometheus-client" },
 ]
 
 [package.dev-dependencies]
@@ -2737,7 +2735,7 @@ requires-dist = [
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "osascript", marker = "extra == 'macos'" },
     { name = "pillow", specifier = "==12.1.1" },
-    { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20.0" },
+    { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "py-mjpeg", specifier = "==1.0.1" },
     { name = "pyaudio", specifier = "==0.2.14" },
     { name = "pycdr2", specifier = "==1.0.0" },
@@ -2756,7 +2754,7 @@ requires-dist = [
     { name = "web3", specifier = "==7.6.0" },
     { name = "websockets", specifier = "==13.1" },
 ]
-provides-extras = ["dds", "macos", "metrics"]
+provides-extras = ["dds", "macos"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -2735,7 +2735,7 @@ requires-dist = [
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "osascript", marker = "extra == 'macos'" },
     { name = "pillow", specifier = "==12.1.1" },
-    { name = "prometheus-client", specifier = ">=0.20.0" },
+    { name = "prometheus-client", specifier = "==0.24.1" },
     { name = "py-mjpeg", specifier = "==1.0.1" },
     { name = "pyaudio", specifier = "==0.2.14" },
     { name = "pycdr2", specifier = "==1.0.0" },


### PR DESCRIPTION

<img width="1028" height="635" alt="Screenshot 2026-02-19 at 22 53 37" src="https://github.com/user-attachments/assets/1ec22e0e-4cef-4166-aca0-f5ed16642078" />


## Summary

- Add `prometheus_client` based runtime metrics for inputs, actions, backgrounds, simulators, cortex ticks, and mode transitions
- Add human-readable HTML dashboard on `/` with auto-refresh (5s), colored status dots, and categorized tables
- Keep Prometheus scrape endpoint on `/metrics` unchanged
- Fall back to no-op stubs when `prometheus_client` is not installed
- Default port `9464` (configurable via `METRICS_PORT` env var)