### PR TITLE
Init dbus machine-id and tweak avahi startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,11 @@ RUN echo '#!/bin/bash' > /entrypoint.sh && \
     echo 'fi' >> /entrypoint.sh && \
     echo 'echo "Audio device default_output_aec is ready."' >> /entrypoint.sh && \
     echo 'echo "Starting mDNS..."' >> /entrypoint.sh && \
-    echo 'mkdir -p /var/run/dbus && dbus-daemon --system --fork 2>/dev/null || true' >> /entrypoint.sh && \
-    echo 'avahi-daemon --daemonize --no-chroot 2>/dev/null || true' >> /entrypoint.sh && \
+    echo 'mkdir -p /var/run/dbus' >> /entrypoint.sh && \
+    echo 'dbus-uuidgen > /etc/machine-id 2>/dev/null || true' >> /entrypoint.sh && \
+    echo 'dbus-daemon --system --fork 2>/dev/null || true' >> /entrypoint.sh && \
+    echo 'sleep 0.5' >> /entrypoint.sh && \
+    echo 'avahi-daemon --no-chroot -D 2>/dev/null || true' >> /entrypoint.sh && \
     echo 'sleep 1' >> /entrypoint.sh && \
     echo 'echo "Starting main command..."' >> /entrypoint.sh && \
     echo 'if [ -n "${OM1_COMMAND}" ]; then' >> /entrypoint.sh && \


### PR DESCRIPTION
Generate a dbus machine-id and adjust the mDNS startup in the entrypoint. The Dockerfile now creates /var/run/dbus, runs `dbus-uuidgen > /etc/machine-id` before launching `dbus-daemon`, adds a short sleep, and starts `avahi-daemon` with `--no-chroot -D`. This reorders and hardens dbus/avahi startup to reduce race conditions and ensure proper service initialization.