### PR TITLE
Remove avahi/dbus mDNS setup from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     pkg-config \
     libssl-dev \
-    avahi-daemon \
-    avahi-utils \
     libnss-mdns \
-    dbus \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -86,13 +83,6 @@ RUN echo '#!/bin/bash' > /entrypoint.sh && \
     echo '  exit 1' >> /entrypoint.sh && \
     echo 'fi' >> /entrypoint.sh && \
     echo 'echo "Audio device default_output_aec is ready."' >> /entrypoint.sh && \
-    echo 'echo "Starting mDNS..."' >> /entrypoint.sh && \
-    echo 'mkdir -p /var/run/dbus' >> /entrypoint.sh && \
-    echo 'dbus-uuidgen > /etc/machine-id 2>/dev/null || true' >> /entrypoint.sh && \
-    echo 'dbus-daemon --system --fork 2>/dev/null || true' >> /entrypoint.sh && \
-    echo 'sleep 0.5' >> /entrypoint.sh && \
-    echo 'avahi-daemon --no-chroot -D 2>/dev/null || true' >> /entrypoint.sh && \
-    echo 'sleep 1' >> /entrypoint.sh && \
     echo 'echo "Starting main command..."' >> /entrypoint.sh && \
     echo 'if [ -n "${OM1_COMMAND}" ]; then' >> /entrypoint.sh && \
     echo '  exec python src/run.py "${OM1_COMMAND}"' >> /entrypoint.sh && \


### PR DESCRIPTION
Remove avahi-daemon, avahi-utils and dbus from the apt install list and drop the entrypoint commands that generated machine-id, started dbus and avahi daemons. This simplifies the image by removing mDNS/dbus runtime setup while keeping libnss-mdns; reduces dependencies and startup complexity.