### PR TITLE
fix: add memory resource limits to docker-compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,4 +44,10 @@ services:
       - apparmor:unconfined
     group_add:
       - audio
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 512M
     command: ["${OM1_COMMAND:-unitree_go2_modes}"]


### PR DESCRIPTION
## Summary
- Add `deploy.resources` to the `om1` service in `docker-compose.yml`
- Without resource limits, a memory leak or runaway process can consume all host memory and crash the host system
- Sets a 4G memory limit with 512M reservation, which is sufficient for LLM inference and vision processing while protecting the host

## Test plan
- [ ] `docker compose config` validates the compose file
- [ ] Container starts normally within the memory limit
- [ ] `docker stats om1` shows the memory limit applied