### PR TITLE
feat(cortex): add selective hot-reload for config fields

### DIFF
--- a/src/runtime/cortex.py
+++ b/src/runtime/cortex.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import time
-from typing import List, Optional, Union
+from typing import List, Optional, Set, Union
 
 from actions.orchestrator import ActionOrchestrator
 from backgrounds.orchestrator import BackgroundOrchestrator
@@ -13,12 +13,33 @@ from providers.io_provider import IOProvider
 from providers.sleep_ticker_provider import SleepTickerProvider
 from runtime.config import (
     LifecycleHookType,
+    ModeConfig,
     ModeSystemConfig,
     RuntimeConfig,
     load_mode_config,
 )
 from runtime.manager import ModeManager
 from simulators.orchestrator import SimulatorOrchestrator
+
+# Fields that can be updated in-place without restarting orchestrators.
+# These fields are read dynamically at each tick, so updating them on the
+# config object is sufficient for the change to take effect.
+_MODE_HOT_RELOAD_FIELDS: frozenset = frozenset(
+    {
+        "system_prompt_base",
+        "hertz",
+        "name",
+    }
+)
+
+_SYSTEM_HOT_RELOAD_FIELDS: frozenset = frozenset(
+    {
+        "system_governance",
+        "system_prompt_examples",
+    }
+)
+
+_ALL_HOT_RELOAD_FIELDS: frozenset = _MODE_HOT_RELOAD_FIELDS | _SYSTEM_HOT_RELOAD_FIELDS
 
 
 class ModeCortexRuntime:
@@ -647,12 +668,127 @@ class ModeCortexRuntime:
                 logging.error(f"Error checking config changes: {e}")
                 await asyncio.sleep(10)  # Wait before retrying
 
+    def _get_changed_fields(
+        self,
+        old_mode: ModeConfig,
+        new_mode: ModeConfig,
+        old_system: ModeSystemConfig,
+        new_system: ModeSystemConfig,
+    ) -> Set[str]:
+        """
+        Compare two configurations and return the set of changed field names.
+
+        Compares mode-level hot-reloadable fields (e.g., system_prompt_base),
+        system-level hot-reloadable fields (e.g., system_governance), and
+        structural fields (e.g., agent_inputs) to determine what has changed.
+
+        Parameters
+        ----------
+        old_mode : ModeConfig
+            The previous mode configuration.
+        new_mode : ModeConfig
+            The new mode configuration.
+        old_system : ModeSystemConfig
+            The previous system configuration.
+        new_system : ModeSystemConfig
+            The new system configuration.
+
+        Returns
+        -------
+        Set[str]
+            Set of field names that differ between the two configurations.
+        """
+        changed: Set[str] = set()
+
+        # Check mode-level hot-reloadable fields
+        for field_name in _MODE_HOT_RELOAD_FIELDS:
+            old_val = getattr(old_mode, field_name, None)
+            new_val = getattr(new_mode, field_name, None)
+            if old_val != new_val:
+                changed.add(field_name)
+
+        # Check system-level hot-reloadable fields
+        for field_name in _SYSTEM_HOT_RELOAD_FIELDS:
+            old_val = getattr(old_system, field_name, None)
+            new_val = getattr(new_system, field_name, None)
+            if old_val != new_val:
+                changed.add(field_name)
+
+        # Check structural fields via raw config comparison
+        structural_checks = {
+            "agent_inputs": ("_raw_inputs", "_raw_inputs"),
+            "cortex_llm": ("_raw_llm", "_raw_llm"),
+            "agent_actions": ("_raw_actions", "_raw_actions"),
+            "backgrounds": ("_raw_backgrounds", "_raw_backgrounds"),
+            "simulators": ("_raw_simulators", "_raw_simulators"),
+        }
+
+        for field_name, (old_attr, new_attr) in structural_checks.items():
+            old_val = getattr(old_mode, old_attr, None)
+            new_val = getattr(new_mode, new_attr, None)
+            if old_val != new_val:
+                changed.add(field_name)
+
+        return changed
+
+    def _apply_partial_reload(
+        self,
+        new_mode_config: ModeSystemConfig,
+        new_mode: ModeConfig,
+        changed_fields: Set[str],
+    ) -> None:
+        """
+        Apply in-place updates for hot-reloadable fields without restarting
+        orchestrators.
+
+        Updates the field values directly on the current ModeConfig,
+        ModeSystemConfig, and RuntimeConfig objects. Since these fields are
+        read dynamically at each tick (e.g., by the Fuser), the changes
+        take effect immediately.
+
+        Parameters
+        ----------
+        new_mode_config : ModeSystemConfig
+            The new complete system configuration.
+        new_mode : ModeConfig
+            The new mode configuration containing updated values.
+        changed_fields : Set[str]
+            Set of field names that were changed.
+        """
+        current_mode_name = self.mode_manager.current_mode_name
+        old_mode = self.mode_config.modes.get(current_mode_name)
+
+        for field_name in changed_fields:
+            # Determine the source of the new value
+            if field_name in _SYSTEM_HOT_RELOAD_FIELDS:
+                new_val = getattr(new_mode_config, field_name)
+                # Update system config
+                if hasattr(self.mode_config, field_name):
+                    setattr(self.mode_config, field_name, new_val)
+            else:
+                new_val = getattr(new_mode, field_name)
+                # Update current mode config
+                if old_mode and hasattr(old_mode, field_name):
+                    setattr(old_mode, field_name, new_val)
+
+            # Update current runtime config
+            if self.current_config and hasattr(self.current_config, field_name):
+                setattr(self.current_config, field_name, new_val)
+
+            logging.info(f"Hot-reloaded field '{field_name}'")
+
+        # Update the stored system config
+        self.mode_config = new_mode_config
+        self.mode_manager.config = new_mode_config
+
     async def _reload_config(self) -> None:
         """
         Reload the mode configuration when runtime config file changes.
 
-        The runtime config file serves as a trigger - when it changes, we reload
-        from the original configuration source and then regenerate the runtime config.
+        Performs selective (partial) reload when only hot-reloadable fields
+        have changed (e.g., system_prompt_base, hertz). For structural changes
+        that affect orchestrators (e.g., agent_inputs, cortex_llm), performs
+        a full reload by stopping and restarting all components.
         """
         try:
             logging.info(
@@ -663,13 +799,43 @@ class ModeCortexRuntime:
 
             current_mode = self.mode_manager.current_mode_name
 
-            await self._stop_current_orchestrators()
-
             logging.info("Loading configuration from the new runtime file")
             new_mode_config = load_mode_config(
                 self.mode_config_name,
                 mode_source_path=self.mode_manager._get_runtime_config_path(),
             )
+
+            # Attempt selective (partial) reload if possible
+            if (
+                current_mode in new_mode_config.modes
+                and current_mode in self.mode_config.modes
+                and self.current_config
+            ):
+                old_mode = self.mode_config.modes[current_mode]
+                new_mode = new_mode_config.modes[current_mode]
+                changed_fields = self._get_changed_fields(
+                    old_mode, new_mode, self.mode_config, new_mode_config
+                )
+
+                if not changed_fields:
+                    logging.info("No config changes detected, skipping reload")
+                    return
+
+                if changed_fields.issubset(_ALL_HOT_RELOAD_FIELDS):
+                    self._apply_partial_reload(
+                        new_mode_config, new_mode, changed_fields
+                    )
+                    logging.info(
+                        f"Partial hot-reload completed for fields: {changed_fields}"
+                    )
+                    return
+
+                logging.info(
+                    f"Structural changes detected in {changed_fields - _ALL_HOT_RELOAD_FIELDS}, performing full reload"
+                )
+
+            # Full reload: stop everything and reinitialize
+            await self._stop_current_orchestrators()
 
             self.mode_config = new_mode_config
             self.mode_manager.config = new_mode_config
@@ -692,7 +858,7 @@ class ModeCortexRuntime:
             await self._start_orchestrators()
 
             logging.info(
-                f"Mode configuration reloaded successfully, active mode: {current_mode}"
+                f"Full configuration reload completed, active mode: {current_mode}"
             )
 
         except Exception as e:

--- a/tests/runtime/test_cortex.py
+++ b/tests/runtime/test_cortex.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from runtime.config import ModeConfig, ModeSystemConfig
-from runtime.cortex import ModeCortexRuntime
+from runtime.config import ModeConfig, ModeSystemConfig, RuntimeConfig
+from runtime.cortex import (
+    ModeCortexRuntime,
+)
 
 
 @pytest.fixture
@@ -624,7 +626,11 @@ class TestModeCortexRuntimeHotReload:
 
     @pytest.mark.asyncio
     async def test_reload_config_failure(self, mock_system_config):
-        """Test config reload failure handling."""
+        """Test config reload failure handling.
+
+        When load_mode_config fails, the runtime should keep running with
+        the previous configuration and NOT stop orchestrators.
+        """
         with (
             patch("runtime.cortex.ModeManager") as mock_manager_class,
             patch("runtime.cortex.IOProvider"),
@@ -650,7 +656,8 @@ class TestModeCortexRuntimeHotReload:
 
             await runtime._reload_config()
 
-            runtime._stop_current_orchestrators.assert_called_once()
+            # Config load failed early, orchestrators should NOT be stopped
+            runtime._stop_current_orchestrators.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_with_hot_reload_enabled(self, mock_system_config):
@@ -805,3 +812,332 @@ class TestHotReloadMultiToSingle:
 
             assert len(new_single_config.modes) == 1
             assert "single_mode" in new_single_config.modes
+
+
+class TestSelectiveHotReload:
+    """Test cases for selective (partial) hot-reload functionality."""
+
+    @pytest.fixture
+    def old_mode_config(self):
+        """Create an old mode config for comparison."""
+        return ModeConfig(
+            version="v1.0.3",
+            name="test_mode",
+            display_name="Test Mode",
+            description="A test mode",
+            system_prompt_base="You are a test agent",
+            hertz=1.0,
+            _raw_inputs=[{"type": "TestInput"}],
+            _raw_llm={"type": "TestLLM"},
+            _raw_actions=[{"name": "test_action"}],
+            _raw_backgrounds=[],
+        )
+
+    @pytest.fixture
+    def old_system_config(self, old_mode_config):
+        """Create an old system config wrapping the mode config."""
+        config = Mock(spec=ModeSystemConfig)
+        config.modes = {"test_mode": old_mode_config}
+        config.default_mode = "test_mode"
+        config.system_governance = "Be safe"
+        config.system_prompt_examples = "Example 1"
+        return config
+
+    @pytest.fixture
+    def new_mode_config_partial(self):
+        """Create a new mode config with only hot-reloadable fields changed."""
+        return ModeConfig(
+            version="v1.0.3",
+            name="test_mode",
+            display_name="Test Mode",
+            description="A test mode",
+            system_prompt_base="You are an updated test agent",
+            hertz=2.0,
+            _raw_inputs=[{"type": "TestInput"}],
+            _raw_llm={"type": "TestLLM"},
+            _raw_actions=[{"name": "test_action"}],
+            _raw_backgrounds=[],
+        )
+
+    @pytest.fixture
+    def new_system_config_partial(self, new_mode_config_partial):
+        """Create a new system config with hot-reloadable fields changed."""
+        config = Mock(spec=ModeSystemConfig)
+        config.modes = {"test_mode": new_mode_config_partial}
+        config.default_mode = "test_mode"
+        config.system_governance = "Be safe and helpful"
+        config.system_prompt_examples = "Example 1"
+        return config
+
+    @pytest.fixture
+    def new_mode_config_structural(self):
+        """Create a new mode config with structural fields changed."""
+        return ModeConfig(
+            version="v1.0.3",
+            name="test_mode",
+            display_name="Test Mode",
+            description="A test mode",
+            system_prompt_base="You are a test agent",
+            hertz=1.0,
+            _raw_inputs=[{"type": "NewInput"}],
+            _raw_llm={"type": "TestLLM"},
+            _raw_actions=[{"name": "test_action"}],
+            _raw_backgrounds=[],
+        )
+
+    @pytest.fixture
+    def new_system_config_structural(self, new_mode_config_structural):
+        """Create a new system config with structural fields changed."""
+        config = Mock(spec=ModeSystemConfig)
+        config.modes = {"test_mode": new_mode_config_structural}
+        config.default_mode = "test_mode"
+        config.system_governance = "Be safe"
+        config.system_prompt_examples = "Example 1"
+        return config
+
+    def _create_runtime(self, mock_system_config):
+        """Helper to create a runtime instance for testing."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "test_mode"
+            mock_manager.state = Mock()
+            mock_manager.state.transition_history = []
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=True
+            )
+            runtime.mode_manager = mock_manager
+            return runtime
+
+    def test_get_changed_fields_no_changes(
+        self, mock_system_config, old_mode_config, old_system_config
+    ):
+        """Test that no changes are detected when configs are identical."""
+        runtime = self._create_runtime(mock_system_config)
+        changed = runtime._get_changed_fields(
+            old_mode_config,
+            old_mode_config,
+            old_system_config,
+            old_system_config,
+        )
+        assert changed == set()
+
+    def test_get_changed_fields_hot_reload_only(
+        self,
+        mock_system_config,
+        old_mode_config,
+        new_mode_config_partial,
+        old_system_config,
+        new_system_config_partial,
+    ):
+        """Test detection of hot-reloadable field changes."""
+        runtime = self._create_runtime(mock_system_config)
+        changed = runtime._get_changed_fields(
+            old_mode_config,
+            new_mode_config_partial,
+            old_system_config,
+            new_system_config_partial,
+        )
+        assert changed == {"system_prompt_base", "system_governance", "hertz"}
+
+    def test_get_changed_fields_structural(
+        self,
+        mock_system_config,
+        old_mode_config,
+        new_mode_config_structural,
+        old_system_config,
+        new_system_config_structural,
+    ):
+        """Test detection of structural field changes."""
+        runtime = self._create_runtime(mock_system_config)
+        changed = runtime._get_changed_fields(
+            old_mode_config,
+            new_mode_config_structural,
+            old_system_config,
+            new_system_config_structural,
+        )
+        assert "agent_inputs" in changed
+
+    def test_partial_reload_updates_runtime_config(
+        self,
+        mock_system_config,
+        old_mode_config,
+        new_mode_config_partial,
+        new_system_config_partial,
+    ):
+        """Test that partial reload updates config objects in-place."""
+        runtime = self._create_runtime(mock_system_config)
+
+        # Set up current state
+        runtime.mode_config = Mock(spec=ModeSystemConfig)
+        runtime.mode_config.modes = {"test_mode": old_mode_config}
+        runtime.mode_config.system_governance = "Be safe"
+        runtime.mode_config.system_prompt_examples = "Example 1"
+        runtime.current_config = Mock(spec=RuntimeConfig)
+        runtime.current_config.system_prompt_base = "You are a test agent"
+        runtime.current_config.system_governance = "Be safe"
+        runtime.current_config.hertz = 1.0
+
+        changed = {"system_prompt_base", "system_governance", "hertz"}
+        runtime._apply_partial_reload(
+            new_system_config_partial, new_mode_config_partial, changed
+        )
+
+        assert (
+            runtime.current_config.system_prompt_base == "You are an updated test agent"
+        )
+        assert runtime.current_config.system_governance == "Be safe and helpful"
+        assert runtime.current_config.hertz == 2.0
+
+    @pytest.mark.asyncio
+    async def test_reload_config_partial_reload(
+        self,
+        mock_system_config,
+        old_mode_config,
+        new_mode_config_partial,
+        old_system_config,
+        new_system_config_partial,
+    ):
+        """Test that partial reload skips orchestrator restart."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+            patch("runtime.cortex.load_mode_config") as mock_load_config,
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "test_mode"
+            mock_manager.state = Mock()
+            mock_manager.state.transition_history = []
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            mock_load_config.return_value = new_system_config_partial
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=True
+            )
+            runtime.mode_manager = mock_manager
+            runtime.mode_config = old_system_config
+            runtime.current_config = Mock(spec=RuntimeConfig)
+            runtime.current_config.system_prompt_base = "You are a test agent"
+            runtime.current_config.system_governance = "Be safe"
+            runtime.current_config.hertz = 1.0
+
+            runtime._stop_current_orchestrators = AsyncMock()
+            runtime._initialize_mode = AsyncMock()
+            runtime._start_orchestrators = AsyncMock()
+
+            await runtime._reload_config()
+
+            # Partial reload should NOT stop/restart orchestrators
+            runtime._stop_current_orchestrators.assert_not_called()
+            runtime._initialize_mode.assert_not_called()
+            runtime._start_orchestrators.assert_not_called()
+
+            # Config should be updated in-place
+            assert (
+                runtime.current_config.system_prompt_base
+                == "You are an updated test agent"
+            )
+
+    @pytest.mark.asyncio
+    async def test_reload_config_full_reload_on_structural_change(
+        self,
+        mock_system_config,
+        old_mode_config,
+        new_mode_config_structural,
+        old_system_config,
+        new_system_config_structural,
+    ):
+        """Test that structural changes trigger a full reload."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+            patch("runtime.cortex.load_mode_config") as mock_load_config,
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "test_mode"
+            mock_manager.state = Mock()
+            mock_manager.state.transition_history = []
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            mock_load_config.return_value = new_system_config_structural
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=True
+            )
+            runtime.mode_manager = mock_manager
+            runtime.mode_config = old_system_config
+            runtime.current_config = Mock(spec=RuntimeConfig)
+
+            runtime._stop_current_orchestrators = AsyncMock()
+            runtime._initialize_mode = AsyncMock()
+            runtime._start_orchestrators = AsyncMock()
+
+            await runtime._reload_config()
+
+            # Structural change should trigger full reload
+            runtime._stop_current_orchestrators.assert_called_once()
+            runtime._initialize_mode.assert_called_once_with("test_mode")
+            runtime._start_orchestrators.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reload_config_no_changes_skipped(
+        self,
+        mock_system_config,
+        old_mode_config,
+        old_system_config,
+    ):
+        """Test that reload is skipped when no changes are detected."""
+        with (
+            patch("runtime.cortex.ModeManager") as mock_manager_class,
+            patch("runtime.cortex.IOProvider"),
+            patch("runtime.cortex.SleepTickerProvider"),
+            patch("runtime.cortex.load_mode_config") as mock_load_config,
+        ):
+            mock_manager = Mock()
+            mock_manager.add_transition_callback = Mock()
+            mock_manager.current_mode_name = "test_mode"
+            mock_manager._get_runtime_config_path = Mock(
+                return_value="/fake/path/test_config.json5"
+            )
+            mock_manager_class.return_value = mock_manager
+
+            # Return a system config with same mode and same system fields
+            new_system_config = Mock(spec=ModeSystemConfig)
+            new_system_config.modes = {"test_mode": old_mode_config}
+            new_system_config.system_governance = "Be safe"
+            new_system_config.system_prompt_examples = "Example 1"
+            mock_load_config.return_value = new_system_config
+
+            runtime = ModeCortexRuntime(
+                mock_system_config, "test_config", hot_reload=True
+            )
+            runtime.mode_manager = mock_manager
+            runtime.mode_config = old_system_config
+            runtime.current_config = Mock(spec=RuntimeConfig)
+
+            runtime._stop_current_orchestrators = AsyncMock()
+
+            await runtime._reload_config()
+
+            # No changes should skip reload entirely
+            runtime._stop_current_orchestrators.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #984

Adds selective (partial) hot-reload support to `ModeCortexRuntime`, so that changes to non-structural config fields can be applied **without stopping and restarting orchestrators**.

### Problem

Currently, **any** config file change triggers a full reload: all orchestrators are stopped, the mode is re-initialized, and everything is restarted. This is disruptive and unnecessary when only simple fields like `system_prompt_base`, `hertz`, or `system_governance` have changed.

### Solution

- Introduced `_MODE_HOT_RELOAD_FIELDS` (mode-level: `system_prompt_base`, `hertz`, `name`) and `_SYSTEM_HOT_RELOAD_FIELDS` (system-level: `system_governance`, `system_prompt_examples`) constants to define which fields can be hot-reloaded safely.
- Added `_get_changed_fields()` method that compares old and new configurations at both mode and system levels, detecting exactly which fields changed.
- Added `_apply_partial_reload()` method that updates changed fields in-place on the current `ModeConfig`, `ModeSystemConfig`, and `RuntimeConfig` objects. Since `Fuser` reads these fields dynamically at each tick, changes take effect immediately.
- Modified `_reload_config()` to:
  1. Load the new config **before** stopping orchestrators (fail-safe: if config loading fails, the running system is unaffected).
  2. Compare old vs new configs to detect changes.
  3. Skip reload entirely if nothing changed.
  4. Apply partial reload if only hot-reloadable fields changed.
  5. Fall back to full reload only when structural fields (`agent_inputs`, `cortex_llm`, `agent_actions`, `backgrounds`, `simulators`) have changed.

### Changes

- `src/runtime/cortex.py`: Added selective reload logic with `_get_changed_fields()`, `_apply_partial_reload()`, and updated `_reload_config()`.
- `tests/runtime/test_cortex.py`: Added `TestSelectiveHotReload` class with 7 test cases covering: no changes detected, hot-reload-only changes, structural changes, partial reload in-place updates, config reload with partial/full/no-change scenarios. Updated existing `test_reload_config_failure` to reflect improved fail-safe behavior.

## Test plan

- [x] All 29 existing + new tests pass (`uv run pytest tests/runtime/test_cortex.py -v`)
- [x] Pre-commit checks pass (ruff, black, isort, typos)
- [x] No breaking changes to existing hot-reload behavior
- [x] Structural changes still trigger full reload
- [x] Config load failures preserve the running system (fail-safe)