### PR TITLE
fix: initialize all 10 possible paths in TurtleBot4 RPLidar provider

### DIFF
--- a/src/providers/turtlebot4_rplidar_provider.py
+++ b/src/providers/turtlebot4_rplidar_provider.py
@@ -343,7 +343,7 @@ class TurtleBot4RPLidarProvider:
         """
         Determine set of possible paths
         """
-        possible_paths = np.array([4])
+        possible_paths = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         if array.ndim > 1:
             # we have valid LIDAR returns


### PR DESCRIPTION
## Summary
- During the d0aaf442 refactor (Split odom and rplidar #2136), the `possible_paths` initialization logic was lost
- Originally (a8d562fa) there were two stages:
  ```python
  possible_paths = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])  # all paths
  if self.simple_paths:
      possible_paths = np.array([4])  # fallback for simple mode
  ```
- After the refactor only the fallback line remained, so the robot always started with a single path (straight forward)
- `turn_left`, `turn_right`, `retreat` were always empty/False — LIDAR obstacle checking never evaluated the other 9 paths