### PR TITLE
fix: guard against uninitialized G1 Arm Action Client

### DIFF
--- a/src/actions/arm_g1/connector/unitree_sdk.py
+++ b/src/actions/arm_g1/connector/unitree_sdk.py
@@ -21,6 +21,7 @@ class ARMUnitreeSDKConnector(ActionConnector[ActionConfig, ArmInput]):
         """
         super().__init__(config)
 
+        self.client: G1ArmActionClient | None = None
         try:
             self.client = G1ArmActionClient()
             self.client.SetTimeout(10.0)
@@ -42,6 +43,10 @@ class ARMUnitreeSDKConnector(ActionConnector[ActionConfig, ArmInput]):
 
         if output_interface.action == "idle":
             logging.info("No action to perform, returning.")
+            return
+
+        if self.client is None:
+            logging.warning("G1 Arm Action Client not initialized, skipping action.")
             return
 
         action_id = None


### PR DESCRIPTION
If `G1ArmActionClient()` constructor fails (e.g. robot not connected, CycloneDDS unavailable), `self.client` is never assigned because the assignment is inside the `try` block. The `except` block logs the error and continues, but any subsequent `connect()` call crashes with `AttributeError`.

The original code intended graceful degradation (catch + log), but didn't handle the connect-after-failed-init case. This fix completes that intent by initializing `self.client = None` before the `try` block and adding a guard in `connect()`.