### PR TITLE
fix: correct Queue truthiness check in TwitterInput plugin

### DIFF
--- a/src/inputs/plugins/twitter.py
+++ b/src/inputs/plugins/twitter.py
@@ -118,7 +118,7 @@ class TwitterInput(FuserInput[TwitterSensorConfig, Optional[str]]):
         if raw_input:
             self.message_buffer.put_nowait(raw_input)
 
-        if self.message_buffer:
+        if not self.message_buffer.empty():
             try:
                 message = self.message_buffer.get_nowait()
                 if message:


### PR DESCRIPTION
## Overview

`self.message_buffer` is a `Queue` object. In Python, a Queue instance 
is always truthy regardless of whether it is empty, meaning the guard 
`if self.message_buffer:` never prevents the `get_nowait()` call on an 
empty queue. The code currently relies on catching the `Empty` exception 
as control flow rather than properly checking first.

## Type of change
Fix

## Changes
Fixed a bug in src/inputs/plugins/twitter.py where self.message_buffer (a queue.Queue object) was being used as a boolean condition with if self.message_buffer:. In Python, a Queue instance is always truthy regardless of whether it is empty or not, meaning this check never evaluates to False and provides no actual guard.
Replaced if self.message_buffer: with if not self.message_buffer.empty(): so the condition correctly reflects whether the buffer has messages before attempting to call get_nowait().

## Checklist

- [ ] Code complies with style guidelines (check)
- [ ] Self-review completed (check)
- [ ] Documentation updated (if applicable)
- [ ] Local testing completed(check)
- [ ] Tests added/updated (if applicable)

## Impact
Low risk, isolated change. The fix corrects a silent logic error where the empty queue check was never working as intended. The behavior of the code is unchanged in practice since the Empty exception was already being caught below, but the fix makes the guard explicit and correct rather than relying on exception handling as control flow.

## Additional Information
Closes #2411