### PR TITLE
fix: use .message field instead of Message repr in MockInput output

### DIFF
--- a/src/inputs/plugins/mock_input.py
+++ b/src/inputs/plugins/mock_input.py
@@ -256,7 +256,7 @@ class MockInput(FuserInput[MockSensorConfig, Optional[str]]):
         result = f"""
 INPUT: {self.descriptor_for_LLM}
 // START
-{self.messages[-1]}
+{self.messages[-1].message}
 // END
 """
         self.io_provider.add_input(


### PR DESCRIPTION
`formatted_latest_buffer` was embedding the full `Message` dataclass repr in the f-string (`{self.messages[-1]}`) instead of the `.message` text field (`{self.messages[-1].message}`). This caused the LLM to receive `Message(timestamp=1708700000.0, message='Hello...')` instead of just `Hello...`.

Line 263 already uses `.message` correctly for `add_input()` — the f-string on line 259 was the only place that missed it.