### PR TITLE
fix: rename adding_pending_message to add_pending_message in UbTtsProvider

### DIFF
--- a/src/actions/speak/connector/ub_tts.py
+++ b/src/actions/speak/connector/ub_tts.py
@@ -98,7 +98,7 @@ class UbTtsConnector(ActionConnector[UbTtsConfig, SpeakInput]):
         # Call the provider's speak method using data from SpeakInput.
         # The text comes from the 'action' field.
         # 'interrupt' and 'timestamp' use default values since they are not in SpeakInput.
-        self.tts.adding_pending_message(
+        self.tts.add_pending_message(
             message=output_interface.action,
             interrupt=True,
             timestamp=int(time.time()),  # Use current time as a sensible default

--- a/src/providers/ub_tts_provider.py
+++ b/src/providers/ub_tts_provider.py
@@ -38,7 +38,7 @@ class UbTtsProvider:
         """Placeholder start method for compatibility."""
         logging.info("Ubtech TTS Provider started.")
 
-    def adding_pending_message(
+    def add_pending_message(
         self, message: str, interrupt: bool = True, timestamp: int = 0
     ):
         """

--- a/tests/actions/speak/connector/test_speak_ub_tts.py
+++ b/tests/actions/speak/connector/test_speak_ub_tts.py
@@ -101,7 +101,7 @@ class TestUbTtsConnector:
             mock_time.time.return_value = 1000
             await connector.connect(speak_input)
 
-        mock_tts_provider["instance"].adding_pending_message.assert_called_once_with(
+        mock_tts_provider["instance"].add_pending_message.assert_called_once_with(
             message="Hello!",
             interrupt=True,
             timestamp=1000,
@@ -115,7 +115,7 @@ class TestUbTtsConnector:
 
         await connector.connect(speak_input)
 
-        mock_tts_provider["instance"].adding_pending_message.assert_not_called()
+        mock_tts_provider["instance"].add_pending_message.assert_not_called()
 
     def test_zenoh_tts_status_request_read(self, connector, mock_zenoh_session):
         """Test status request with code 2 (read status) responds with current state."""

--- a/tests/providers/test_ub_tts_provider.py
+++ b/tests/providers/test_ub_tts_provider.py
@@ -53,13 +53,13 @@ def test_stop_method():
 # Tests for async message processing
 
 
-def test_adding_pending_message_submits_to_executor():
-    """Test that adding_pending_message submits work to the executor."""
+def test_add_pending_message_submits_to_executor():
+    """Test that add_pending_message submits work to the executor."""
     provider = UbTtsProvider("http://localhost:8080/tts")
     executor_mock = MagicMock()
     provider.executor = executor_mock
 
-    provider.adding_pending_message("Hello world")
+    provider.add_pending_message("Hello world")
 
     executor_mock.submit.assert_called_once()
     args = executor_mock.submit.call_args[0]
@@ -71,13 +71,13 @@ def test_adding_pending_message_submits_to_executor():
     provider.stop()
 
 
-def test_adding_pending_message_with_custom_parameters():
-    """Test that adding_pending_message correctly passes custom parameters."""
+def test_add_pending_message_with_custom_parameters():
+    """Test that add_pending_message correctly passes custom parameters."""
     provider = UbTtsProvider("http://localhost:8080/tts")
     executor_mock = MagicMock()
     provider.executor = executor_mock
 
-    provider.adding_pending_message("Custom message", interrupt=False, timestamp=12345)
+    provider.add_pending_message("Custom message", interrupt=False, timestamp=12345)
 
     executor_mock.submit.assert_called_once()
     args = executor_mock.submit.call_args[0]
@@ -89,8 +89,8 @@ def test_adding_pending_message_with_custom_parameters():
     provider.stop()
 
 
-def test_adding_pending_message_integration():
-    """Test integration of adding_pending_message with actual worker."""
+def test_add_pending_message_integration():
+    """Test integration of add_pending_message with actual worker."""
     provider = UbTtsProvider("http://localhost:8080/tts")
 
     mock_response = MagicMock()
@@ -98,7 +98,7 @@ def test_adding_pending_message_integration():
     mock_response.raise_for_status = MagicMock()
 
     with patch("providers.ub_tts_provider.requests.put", return_value=mock_response):
-        provider.adding_pending_message("Hello world")
+        provider.add_pending_message("Hello world")
 
         time.sleep(0.1)
 


### PR DESCRIPTION
All other TTS providers (elevenlabs, kokoro, riva, ros2_publisher, zenoh_publisher) implement `add_pending_message`. `UbTtsProvider` uses `adding_pending_message` instead, breaking the generic TTS interface.

The hook system (`runtime/hook.py:266`), greeting conversation connector, and navigation providers all call `provider.add_pending_message(...)` — any of these will crash with `AttributeError` when `UbTtsProvider` is the configured TTS provider.

The only caller that worked was `speak/connector/ub_tts.py` because it directly used the wrong name. Updated both the provider and all callers/tests.