### PR TITLE
fix: correct Queue truthiness check in TwitterInput plugin

### DIFF
--- a/src/inputs/plugins/twitter.py
+++ b/src/inputs/plugins/twitter.py
@@ -118,7 +118,7 @@ class TwitterInput(FuserInput[TwitterSensorConfig, Optional[str]]):
         if raw_input:
             self.message_buffer.put_nowait(raw_input)
 
-        if self.message_buffer:
+        if not self.message_buffer.empty():
             try:
                 message = self.message_buffer.get_nowait()
                 if message:


### PR DESCRIPTION
Fixes #2411. The TwitterInput plugin used  which always evaluates True for a Queue object, causing get_nowait() to be called even when the queue is empty. This relied on catching Empty exceptions rather than proper flow control.\n\nChanged to  to correctly check for messages before attempting to retrieve them.\n\nThis is a tiny but important bug fix that eliminates unnecessary exception handling and improves efficiency.