### PR TITLE
feat: add universal thermal camera input plugin

### DIFF
--- a/config/thermal_camera.json5
+++ b/config/thermal_camera.json5
@@ -1,0 +1,50 @@
+{
+  version: "v1.0.3",
+  hertz: 0.5,
+  name: "thermal_patrol",
+  api_key: "${OM_API_KEY:-openmind_free}",
+  system_prompt_base: "You are an autonomous security patrol robot. Your name is GuardBot. You monitor the environment using a thermal camera to detect human presence and fire hazards. When a human is detected, issue a verbal warning. When abnormal heat is detected, alert immediately. Patrol continuously and report status every few minutes.",
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  system_prompt_examples: "Here are some examples of interactions you might encounter:\n\n1. If thermal camera detects a human:\n    Speak: {{'sentence': 'Human presence detected. Please identify yourself.'}}\n\n2. If thermal camera detects abnormal heat:\n    Speak: {{'sentence': 'Warning: abnormal heat source detected. Alerting operator.'}}\n\n3. If no heat signatures detected:\n    Move: 'forward'\n    Speak: {{'sentence': 'Sector clear. Continuing patrol.'}}",
+  agent_inputs: [
+    {
+      // Thermal camera for heat signature and fire detection
+      // connector options: "mock", "amg8833", "mlx90640", "usb", "serial"
+      type: "ThermalCameraInput",
+      config: {
+        connector: "mock",
+        cooldown: 3.0,
+        human_temp_min: 34.0,
+        human_temp_max: 39.0,
+        alert_temp_threshold: 60.0,
+        mock_scenario: "human",
+      },
+    },
+    {
+      type: "GoogleASRInput",
+      config: {
+        enable_tts_interrupt: false,
+      },
+    },
+  ],
+  simulators: [
+    {
+      type: "WebSim",
+    },
+  ],
+  cortex_llm: {
+    type: "OpenAILLM",
+    config: {
+      agent_name: "GuardBot",
+      history_length: 10,
+    },
+  },
+  agent_actions: [
+    {
+      name: "speak",
+      llm_label: "speak",
+      implementation: "passthrough",
+      connector: "elevenlabs_tts",
+    },
+  ],
+}

--- a/docs/developing/4_inputs.md
+++ b/docs/developing/4_inputs.md
@@ -25,5 +25,6 @@ Here are a few examples for you to reuse and build on:
 - [VLM_COCO_Local](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_coco_local.py)
 - [VLM_Vila](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/vlm_vila.py)
 - [Arduino GPS](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/gps.py)
+- [Thermal Camera](https://github.com/openmind/OM1/blob/main/src/inputs/plugins/thermal_camera_input.py)
 
 Learn how to build a new input plugin [here](../developer_cookbook/input.md)

--- a/src/inputs/plugins/thermal_camera_input.py
+++ b/src/inputs/plugins/thermal_camera_input.py
@@ -1,0 +1,842 @@
+import asyncio
+import logging
+import time
+from typing import Optional
+
+from pydantic import Field
+
+from inputs.base import Message, SensorConfig
+from inputs.base.loop import FuserInput
+from providers.io_provider import IOProvider
+
+try:
+    import adafruit_mlx90640 as _mlx90640_lib
+
+    _MLX90640_AVAILABLE = True
+except ImportError:
+    _mlx90640_lib = None
+    _MLX90640_AVAILABLE = False
+    logging.warning(
+        "adafruit-mlx90640 not found. MLX90640 connector unavailable. "
+        "Install with: pip install adafruit-circuitpython-mlx90640"
+    )
+
+try:
+    import adafruit_amg88xx as _amg88xx_lib
+
+    _AMG8833_AVAILABLE = True
+except ImportError:
+    _amg88xx_lib = None
+    _AMG8833_AVAILABLE = False
+    logging.warning(
+        "adafruit-amg88xx not found. AMG8833 connector unavailable. "
+        "Install with: pip install adafruit-circuitpython-amg88xx"
+    )
+
+try:
+    import cv2 as _cv2
+
+    _CV2_AVAILABLE = True
+except ImportError:
+    _cv2 = None
+    _CV2_AVAILABLE = False
+    logging.warning("opencv not found. USB thermal connector unavailable.")
+
+try:
+    import serial as _serial
+
+    _SERIAL_AVAILABLE = True
+except ImportError:
+    _serial = None
+    _SERIAL_AVAILABLE = False
+    logging.warning(
+        "pyserial not found. Serial thermal connector unavailable. "
+        "Install with: pip install pyserial"
+    )
+
+# Temperature thresholds
+HUMAN_TEMP_MIN = 34.0
+HUMAN_TEMP_MAX = 39.0
+ALERT_TEMP_THRESHOLD = 60.0
+
+
+class ThermalCameraConfig(SensorConfig):
+    """
+    Configuration for Thermal Camera input plugin.
+
+    Supports five hardware backends via the ``connector`` field:
+
+    - ``"mlx90640"`` : Melexis MLX90640 32x24 IR array via I2C.
+    - ``"amg8833"``  : Panasonic AMG8833 8x8 IR array via I2C.
+    - ``"usb"``      : USB thermal camera via OpenCV (V4L2).
+    - ``"serial"``   : Arduino with IR sensor via pyserial.
+    - ``"mock"``     : Simulated thermal data for development (default).
+
+    Parameters
+    ----------
+    connector : str
+        Hardware backend to use. Default is ``"mock"``.
+    camera_index : int
+        Camera index for USB connector. Default 0.
+    port : str
+        Serial port for serial connector. Default ``"/dev/ttyUSB0"``.
+    baudrate : int
+        Serial baudrate. Default 9600.
+    serial_timeout : float
+        Serial read timeout in seconds. Default 1.0.
+    i2c_address : int
+        I2C address for MLX90640. Default 0x33.
+    refresh_rate : int
+        MLX90640 refresh rate in Hz (1,2,4,8,16,32,64). Default 4.
+    cooldown : float
+        Minimum seconds between alerts forwarded to LLM. Default 3.0.
+    human_temp_min : float
+        Minimum temperature (°C) to classify as human. Default 34.0.
+    human_temp_max : float
+        Maximum temperature (°C) to classify as human. Default 39.0.
+    alert_temp_threshold : float
+        Temperature (°C) above which fire/equipment alert is triggered. Default 60.0.
+    mock_scenario : str
+        Mock scenario: ``"clear"``, ``"human"``, or ``"alert"``. Default ``"human"``.
+    """
+
+    connector: str = Field(
+        default="mock",
+        description=(
+            "Hardware backend: 'mlx90640' (I2C 32x24), "
+            "'amg8833' (I2C 8x8), "
+            "'usb' (OpenCV), "
+            "'serial' (Arduino), "
+            "'mock' (testing)"
+        ),
+    )
+    camera_index: int = Field(
+        default=0,
+        description="Camera index for USB thermal connector.",
+    )
+    port: str = Field(
+        default="/dev/ttyUSB0",
+        description="Serial port path. Used when connector='serial'.",
+    )
+    baudrate: int = Field(
+        default=9600,
+        description="Serial baudrate. Used when connector='serial'.",
+    )
+    serial_timeout: float = Field(
+        default=1.0,
+        description="Serial read timeout in seconds.",
+    )
+    i2c_address: int = Field(
+        default=0x33,
+        description="I2C address for MLX90640. Default 0x33.",
+    )
+    refresh_rate: int = Field(
+        default=4,
+        description="MLX90640 refresh rate in Hz.",
+    )
+    cooldown: float = Field(
+        default=3.0,
+        description="Minimum seconds between alerts forwarded to LLM.",
+    )
+    human_temp_min: float = Field(
+        default=HUMAN_TEMP_MIN,
+        description="Minimum temperature (°C) to classify as human presence.",
+    )
+    human_temp_max: float = Field(
+        default=HUMAN_TEMP_MAX,
+        description="Maximum temperature (°C) to classify as human presence.",
+    )
+    alert_temp_threshold: float = Field(
+        default=ALERT_TEMP_THRESHOLD,
+        description="Temperature (°C) above which fire/equipment alert triggers.",
+    )
+    mock_scenario: str = Field(
+        default="human",
+        description="Mock scenario: 'clear', 'human', or 'alert'.",
+    )
+
+
+class ThermalReading:
+    """
+    Container for a thermal sensor reading.
+
+    Parameters
+    ----------
+    frame : list[float]
+        Flat list of temperature values in Celsius.
+    width : int
+        Width of the thermal image in pixels.
+    height : int
+        Height of the thermal image in pixels.
+    """
+
+    def __init__(self, frame: list, width: int, height: int):
+        """
+        Initialize ThermalReading.
+
+        Parameters
+        ----------
+        frame : list[float]
+            Flat list of temperature values.
+        width : int
+            Image width in pixels.
+        height : int
+            Image height in pixels.
+        """
+        self.frame = frame
+        self.width = width
+        self.height = height
+
+    @property
+    def max_temp(self) -> float:
+        """Get maximum temperature in the frame."""
+        return max(self.frame) if self.frame else 0.0
+
+    @property
+    def min_temp(self) -> float:
+        """Get minimum temperature in the frame."""
+        return min(self.frame) if self.frame else 0.0
+
+    def get_zone_max(self, zone: str) -> float:
+        """
+        Get maximum temperature in a horizontal zone.
+
+        Parameters
+        ----------
+        zone : str
+            Zone name: 'left', 'center', or 'right'.
+
+        Returns
+        -------
+        float
+            Maximum temperature in the specified zone.
+        """
+        third = self.width // 3
+        pixels = []
+        for row in range(self.height):
+            for col in range(self.width):
+                idx = row * self.width + col
+                if idx >= len(self.frame):
+                    continue
+                if zone == "left" and col < third:
+                    pixels.append(self.frame[idx])
+                elif zone == "center" and third <= col < 2 * third:
+                    pixels.append(self.frame[idx])
+                elif zone == "right" and col >= 2 * third:
+                    pixels.append(self.frame[idx])
+        return max(pixels) if pixels else 0.0
+
+
+class _MLX90640Connector:
+    """
+    Read thermal data from Melexis MLX90640 32x24 IR array via I2C.
+
+    Wiring (MLX90640 to Raspberry Pi)
+    -----------------------------------
+    MLX90640 VIN  →  RPi Pin 1  (3.3V)
+    MLX90640 GND  →  RPi Pin 6  (GND)
+    MLX90640 SDA  →  RPi Pin 3  (GPIO2, I2C SDA)
+    MLX90640 SCL  →  RPi Pin 5  (GPIO3, I2C SCL)
+    """
+
+    WIDTH = 32
+    HEIGHT = 24
+
+    def __init__(self, i2c_address: int, refresh_rate: int):
+        """
+        Initialize MLX90640 connector.
+
+        Parameters
+        ----------
+        i2c_address : int
+            I2C address of the sensor.
+        refresh_rate : int
+            Refresh rate in Hz.
+        """
+        self._sensor = None
+        self._ready = False
+
+        if not _MLX90640_AVAILABLE or _mlx90640_lib is None:
+            logging.error("ThermalCamera MLX90640: library not available.")
+            return
+        try:
+            import board
+            import busio
+
+            i2c = busio.I2C(board.SCL, board.SDA, frequency=400000)
+            self._sensor = _mlx90640_lib.MLX90640(i2c, address=i2c_address)
+            self._sensor.refresh_rate = getattr(
+                _mlx90640_lib.RefreshRate,
+                f"REFRESH_{refresh_rate}_HZ",
+                _mlx90640_lib.RefreshRate.REFRESH_4_HZ,
+            )
+            self._ready = True
+            logging.info(
+                f"ThermalCamera MLX90640: initialized at address 0x{i2c_address:02x}"
+            )
+        except Exception as e:
+            logging.error(f"ThermalCamera MLX90640: setup failed: {e}")
+
+    async def read(self) -> Optional[ThermalReading]:
+        """
+        Read a thermal frame.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Thermal reading or None if unavailable.
+        """
+        if not self._ready or self._sensor is None:
+            return None
+        try:
+            frame = [0.0] * (self.WIDTH * self.HEIGHT)
+            self._sensor.getFrame(frame)
+            return ThermalReading(frame, self.WIDTH, self.HEIGHT)
+        except Exception as e:
+            logging.warning(f"ThermalCamera MLX90640: read error: {e}")
+            return None
+
+    def stop(self):
+        """Release MLX90640 resources."""
+        self._ready = False
+        logging.info("ThermalCamera MLX90640: stopped")
+
+
+class _AMG8833Connector:
+    """
+    Read thermal data from Panasonic AMG8833 8x8 IR array via I2C.
+
+    Wiring (AMG8833 to Raspberry Pi)
+    -----------------------------------
+    AMG8833 VIN  →  RPi Pin 1  (3.3V)
+    AMG8833 GND  →  RPi Pin 6  (GND)
+    AMG8833 SDA  →  RPi Pin 3  (GPIO2, I2C SDA)
+    AMG8833 SCL  →  RPi Pin 5  (GPIO3, I2C SCL)
+    """
+
+    WIDTH = 8
+    HEIGHT = 8
+
+    def __init__(self):
+        """Initialize AMG8833 connector."""
+        self._sensor = None
+        self._ready = False
+
+        if not _AMG8833_AVAILABLE or _amg88xx_lib is None:
+            logging.error("ThermalCamera AMG8833: library not available.")
+            return
+        try:
+            import board
+            import busio
+
+            i2c = busio.I2C(board.SCL, board.SDA)
+            self._sensor = _amg88xx_lib.AMG88XX(i2c)
+            self._ready = True
+            logging.info("ThermalCamera AMG8833: initialized")
+        except Exception as e:
+            logging.error(f"ThermalCamera AMG8833: setup failed: {e}")
+
+    async def read(self) -> Optional[ThermalReading]:
+        """
+        Read a thermal frame.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Thermal reading or None if unavailable.
+        """
+        if not self._ready or self._sensor is None:
+            return None
+        try:
+            pixels = self._sensor.pixels
+            frame = [temp for row in pixels for temp in row]
+            return ThermalReading(frame, self.WIDTH, self.HEIGHT)
+        except Exception as e:
+            logging.warning(f"ThermalCamera AMG8833: read error: {e}")
+            return None
+
+    def stop(self):
+        """Release AMG8833 resources."""
+        self._ready = False
+        logging.info("ThermalCamera AMG8833: stopped")
+
+
+class _USBThermalConnector:
+    """
+    Read thermal data from a USB thermal camera via OpenCV.
+
+    Compatible with FLIR Lepton USB, Seek Thermal Compact,
+    and any V4L2 thermal camera that outputs grayscale frames
+    where pixel values map linearly to temperature.
+
+    The temperature mapping assumes:
+    - pixel value 0   → min_temp_c
+    - pixel value 255 → max_temp_c
+
+    These defaults cover typical room-to-fire temperature ranges.
+    """
+
+    WIDTH = 32
+    HEIGHT = 24
+
+    def __init__(
+        self, camera_index: int, min_temp_c: float = 0.0, max_temp_c: float = 100.0
+    ):
+        """
+        Initialize USB thermal connector.
+
+        Parameters
+        ----------
+        camera_index : int
+            OpenCV camera index.
+        min_temp_c : float
+            Temperature corresponding to pixel value 0.
+        max_temp_c : float
+            Temperature corresponding to pixel value 255.
+        """
+        self._cap = None
+        self._ready = False
+        self._min_temp = min_temp_c
+        self._max_temp = max_temp_c
+        self._temp_range = max_temp_c - min_temp_c
+
+        if not _CV2_AVAILABLE or _cv2 is None:
+            logging.error("ThermalCamera USB: opencv not available.")
+            return
+        try:
+            self._cap = _cv2.VideoCapture(camera_index)
+            if not self._cap.isOpened():
+                logging.error(
+                    f"ThermalCamera USB: cannot open camera index {camera_index}"
+                )
+                self._cap = None
+                return
+            self._ready = True
+            logging.info(f"ThermalCamera USB: opened camera index {camera_index}")
+        except Exception as e:
+            logging.error(f"ThermalCamera USB: setup failed: {e}")
+
+    async def read(self) -> Optional[ThermalReading]:
+        """
+        Read and convert a USB thermal camera frame.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Thermal reading or None if unavailable.
+        """
+        if not self._ready or self._cap is None:
+            return None
+        try:
+            ret, frame = self._cap.read()
+            if not ret or frame is None:
+                return None
+            import cv2 as cv2_local
+
+            gray = (
+                cv2_local.cvtColor(frame, cv2_local.COLOR_BGR2GRAY)
+                if len(frame.shape) == 3
+                else frame
+            )
+            h, w = gray.shape
+            temps = (
+                (gray.astype(float) / 255.0 * self._temp_range + self._min_temp)
+                .flatten()
+                .tolist()
+            )
+            return ThermalReading(temps, w, h)
+        except Exception as e:
+            logging.warning(f"ThermalCamera USB: read error: {e}")
+            return None
+
+    def stop(self):
+        """Release USB camera resources."""
+        if self._cap is not None:
+            self._cap.release()
+            logging.info("ThermalCamera USB: camera released")
+        self._ready = False
+
+
+class _SerialThermalConnector:
+    """
+    Read thermal data from an Arduino with IR sensor via serial.
+
+    The paired Arduino sketch must send comma-separated temperature values
+    followed by width and height::
+
+        "THERMAL:24.1,25.3,36.8,...,8,8"
+
+    Where the last two values are width and height of the sensor grid.
+
+    Minimal Arduino sketch (AMG8833 via Adafruit library)
+    -------------------------------------------------------
+    .. code-block:: cpp
+
+        #include <Wire.h>
+        #include <Adafruit_AMG88xx.h>
+
+        Adafruit_AMG88xx amg;
+        float pixels[AMG88xx_PIXEL_ARRAY_SIZE];
+
+        void setup() {
+            Serial.begin(9600);
+            amg.begin();
+        }
+        void loop() {
+            amg.readPixels(pixels);
+            Serial.print("THERMAL:");
+            for (int i = 0; i < AMG88xx_PIXEL_ARRAY_SIZE; i++) {
+                Serial.print(pixels[i]);
+                if (i < AMG88xx_PIXEL_ARRAY_SIZE - 1) Serial.print(",");
+            }
+            Serial.println(",8,8");
+            delay(500);
+        }
+    """
+
+    def __init__(self, port: str, baudrate: int, timeout: float):
+        """
+        Initialize serial thermal connector.
+
+        Parameters
+        ----------
+        port : str
+            Serial port path.
+        baudrate : int
+            Serial baudrate.
+        timeout : float
+            Read timeout in seconds.
+        """
+        self._ser = None
+        if not _SERIAL_AVAILABLE or _serial is None:
+            logging.error("ThermalCamera Serial: pyserial not available.")
+            return
+        try:
+            self._ser = _serial.Serial(port, baudrate, timeout=timeout)
+            logging.info(f"ThermalCamera Serial: connected to {port} @ {baudrate} baud")
+        except _serial.SerialException as e:
+            logging.error(f"ThermalCamera Serial: failed to open {port}: {e}")
+
+    async def read(self) -> Optional[ThermalReading]:
+        """
+        Read a thermal frame from serial.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Thermal reading or None if unavailable.
+        """
+        if self._ser is None:
+            return None
+        try:
+            raw = self._ser.readline().decode("utf-8").strip()
+        except Exception as e:
+            logging.warning(f"ThermalCamera Serial: read error: {e}")
+            return None
+
+        if not raw.startswith("THERMAL:"):
+            if raw:
+                logging.debug(f"ThermalCamera Serial: unrecognised line: '{raw}'")
+            return None
+        try:
+            values = [float(v) for v in raw[8:].split(",") if v.strip()]
+            if len(values) < 3:
+                return None
+            width = int(values[-1])
+            height = int(values[-2])
+            frame = values[:-2]
+            if len(frame) != width * height:
+                logging.warning(
+                    f"ThermalCamera Serial: expected {width*height} pixels, got {len(frame)}"
+                )
+                return None
+            return ThermalReading(frame, width, height)
+        except (ValueError, IndexError) as e:
+            logging.warning(f"ThermalCamera Serial: parse error: {e}")
+            return None
+
+    def stop(self):
+        """Release serial resources."""
+        if self._ser and self._ser.is_open:
+            self._ser.close()
+            logging.info("ThermalCamera Serial: port closed")
+
+
+class _MockThermalConnector:
+    """
+    Simulated thermal connector for development and testing.
+
+    Cycles through three scenarios: clear, human detection, and alert.
+    """
+
+    WIDTH = 8
+    HEIGHT = 8
+
+    def __init__(self, scenario: str = "human"):
+        """
+        Initialize mock thermal connector.
+
+        Parameters
+        ----------
+        scenario : str
+            Scenario to simulate: 'clear', 'human', or 'alert'.
+        """
+        import random
+
+        self._random = random
+        self._scenario = scenario
+        self._call_count = 0
+        logging.info(
+            f"ThermalCamera mock: simulation active (scenario='{scenario}'). No real hardware used."
+        )
+
+    async def read(self) -> Optional[ThermalReading]:
+        """
+        Return simulated thermal frame.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Simulated thermal reading.
+        """
+        await asyncio.sleep(0)
+        self._call_count += 1
+
+        ambient = 22.0 + self._random.uniform(-1.0, 1.0)
+        frame = [
+            ambient + self._random.uniform(-0.5, 0.5)
+            for _ in range(self.WIDTH * self.HEIGHT)
+        ]
+
+        if self._scenario == "human":
+            center_start = (self.HEIGHT // 2 - 1) * self.WIDTH + self.WIDTH // 4
+            for i in range(4):
+                if center_start + i < len(frame):
+                    frame[center_start + i] = 36.5 + self._random.uniform(-0.5, 0.5)
+        elif self._scenario == "alert":
+            frame[0] = 75.0 + self._random.uniform(-2.0, 2.0)
+
+        return ThermalReading(frame, self.WIDTH, self.HEIGHT)
+
+    def stop(self):
+        """Stop mock connector."""
+        logging.info("ThermalCamera mock: stopped")
+
+
+class ThermalCameraInput(FuserInput[ThermalCameraConfig, Optional[ThermalReading]]):
+    """
+    Universal Thermal Camera input plugin for OM1.
+
+    Reads thermal data from IR sensors and converts temperature arrays
+    into natural language context for the LLM. Detects human presence,
+    abnormal heat sources, and fire hazards.
+
+    Supports five hardware backends: MLX90640, AMG8833, USB thermal
+    camera, Arduino serial, and mock simulation.
+
+    A ``cooldown`` parameter prevents the LLM context from being flooded
+    with repeated identical alerts.
+
+    Example config entry::
+
+        {
+          "type": "ThermalCameraInput",
+          "config": {
+            "connector": "amg8833",
+            "cooldown": 3.0,
+            "human_temp_min": 34.0,
+            "human_temp_max": 39.0,
+            "alert_temp_threshold": 60.0
+          }
+        }
+    """
+
+    def __init__(self, config: ThermalCameraConfig):
+        """
+        Initialize ThermalCameraInput.
+
+        Parameters
+        ----------
+        config : ThermalCameraConfig
+            Plugin configuration.
+        """
+        super().__init__(config)
+
+        self.descriptor_for_LLM = "Thermal Camera"
+        self.io_provider = IOProvider()
+        self.messages: list[Message] = []
+        self._last_alert_time: float = 0.0
+
+        connector = config.connector.lower()
+
+        if connector == "mlx90640":
+            self._connector = _MLX90640Connector(
+                i2c_address=config.i2c_address,
+                refresh_rate=config.refresh_rate,
+            )
+        elif connector == "amg8833":
+            self._connector = _AMG8833Connector()
+        elif connector == "usb":
+            self._connector = _USBThermalConnector(
+                camera_index=config.camera_index,
+            )
+        elif connector == "serial":
+            self._connector = _SerialThermalConnector(
+                port=config.port,
+                baudrate=config.baudrate,
+                timeout=config.serial_timeout,
+            )
+        elif connector == "mock":
+            self._connector = _MockThermalConnector(
+                scenario=config.mock_scenario,
+            )
+        else:
+            logging.error(
+                f"ThermalCameraInput: unknown connector '{connector}'. "
+                "Valid options: mlx90640, amg8833, usb, serial, mock. "
+                "Falling back to mock."
+            )
+            self._connector = _MockThermalConnector(
+                scenario=config.mock_scenario,
+            )
+
+        logging.info(
+            f"ThermalCameraInput initialized: connector='{connector}', "
+            f"cooldown={config.cooldown}s"
+        )
+
+    async def _poll(self) -> Optional[ThermalReading]:
+        """
+        Poll the active connector for a thermal frame.
+
+        Applies cooldown logic to suppress repeated alerts.
+
+        Returns
+        -------
+        Optional[ThermalReading]
+            Thermal reading if available, None otherwise.
+        """
+        await asyncio.sleep(0.5)
+        return await self._connector.read()
+
+    def _classify(self, reading: ThermalReading) -> tuple[str, float, str]:
+        """
+        Classify a thermal reading into a category.
+
+        Parameters
+        ----------
+        reading : ThermalReading
+            The thermal reading to classify.
+
+        Returns
+        -------
+        tuple[str, float, str]
+            Tuple of (category, peak_temp, zone) where category is
+            'alert', 'human', or 'clear'.
+        """
+        max_temp = reading.max_temp
+
+        zones = ["left", "center", "right"]
+        zone_temps = {z: reading.get_zone_max(z) for z in zones}
+        hottest_zone = max(zone_temps, key=lambda z: zone_temps[z])
+
+        if max_temp >= self.config.alert_temp_threshold:
+            return "alert", max_temp, hottest_zone
+
+        if self.config.human_temp_min <= max_temp <= self.config.human_temp_max:
+            return "human", max_temp, hottest_zone
+
+        return "clear", max_temp, hottest_zone
+
+    async def _raw_to_text(
+        self, raw_input: Optional[ThermalReading]
+    ) -> Optional[Message]:
+        """
+        Convert a thermal reading to a natural language message.
+
+        Parameters
+        ----------
+        raw_input : Optional[ThermalReading]
+            Thermal reading from the sensor.
+
+        Returns
+        -------
+        Optional[Message]
+            Timestamped message for LLM context, or None if suppressed.
+        """
+        if raw_input is None:
+            return None
+
+        category, peak_temp, zone = self._classify(raw_input)
+        now = time.time()
+
+        if category == "alert":
+            if (now - self._last_alert_time) < self.config.cooldown:
+                return None
+            self._last_alert_time = now
+            message = (
+                f"THERMAL ALERT: Abnormal heat detected at {zone} ({peak_temp:.1f}°C). "
+                f"Possible fire or overheating equipment. Immediate inspection recommended."
+            )
+        elif category == "human":
+            if (now - self._last_alert_time) < self.config.cooldown:
+                return None
+            self._last_alert_time = now
+            message = (
+                f"Thermal camera: Human-like heat signature detected at {zone} "
+                f"({peak_temp:.1f}°C). Possible person present."
+            )
+        else:
+            message = (
+                f"Thermal camera: No significant heat signatures detected. "
+                f"Max temperature: {peak_temp:.1f}°C."
+            )
+
+        return Message(timestamp=now, message=message)
+
+    async def raw_to_text(self, raw_input: Optional[ThermalReading]):
+        """
+        Convert raw thermal input to text and append to message buffer.
+
+        Parameters
+        ----------
+        raw_input : Optional[ThermalReading]
+            Raw thermal reading from the sensor connector.
+        """
+        pending = await self._raw_to_text(raw_input)
+        if pending is not None:
+            self.messages.append(pending)
+
+    def formatted_latest_buffer(self) -> Optional[str]:
+        """
+        Format the latest buffered message for LLM context injection.
+
+        Clears the buffer after formatting.
+
+        Returns
+        -------
+        Optional[str]
+            Formatted context string, or None if no events buffered.
+        """
+        if len(self.messages) == 0:
+            return None
+
+        latest = self.messages[-1]
+
+        result = (
+            f"\nINPUT: {self.descriptor_for_LLM}\n// START\n"
+            f"{latest.message}\n// END\n"
+        )
+
+        self.io_provider.add_input(
+            self.__class__.__name__, latest.message, latest.timestamp
+        )
+        self.messages = []
+        return result
+
+    def stop(self):
+        """Gracefully shut down the thermal camera connector."""
+        logging.info("ThermalCameraInput: stopping")
+        if self._connector and hasattr(self._connector, "stop"):
+            self._connector.stop()
+        self.messages = []

--- a/tests/inputs/plugins/test_thermal_camera_input.py
+++ b/tests/inputs/plugins/test_thermal_camera_input.py
@@ -1,0 +1,986 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import serial
+
+from inputs.base import Message
+from inputs.plugins.thermal_camera_input import (
+    ThermalCameraConfig,
+    ThermalCameraInput,
+    ThermalReading,
+    _MockThermalConnector,
+    _SerialThermalConnector,
+    _USBThermalConnector,
+)
+
+
+def test_thermal_reading_max_temp():
+    """Test max_temp property."""
+    reading = ThermalReading([20.0, 36.5, 25.0], 3, 1)
+    assert reading.max_temp == 36.5
+
+
+def test_thermal_reading_min_temp():
+    """Test min_temp property."""
+    reading = ThermalReading([20.0, 36.5, 25.0], 3, 1)
+    assert reading.min_temp == 20.0
+
+
+def test_thermal_reading_empty_frame():
+    """Test max/min temp with empty frame."""
+    reading = ThermalReading([], 0, 0)
+    assert reading.max_temp == 0.0
+    assert reading.min_temp == 0.0
+
+
+def test_thermal_reading_get_zone_max_left():
+    """Test get_zone_max returns correct max for left zone."""
+    reading = ThermalReading([10.0, 20.0, 30.0], 3, 1)
+    assert reading.get_zone_max("left") == 10.0
+
+
+def test_thermal_reading_get_zone_max_center():
+    """Test get_zone_max returns correct max for center zone."""
+    reading = ThermalReading([10.0, 20.0, 30.0], 3, 1)
+    assert reading.get_zone_max("center") == 20.0
+
+
+def test_thermal_reading_get_zone_max_right():
+    """Test get_zone_max returns correct max for right zone."""
+    reading = ThermalReading([10.0, 20.0, 30.0], 3, 1)
+    assert reading.get_zone_max("right") == 30.0
+
+
+def test_thermal_reading_get_zone_max_empty():
+    """Test get_zone_max returns 0.0 for empty frame."""
+    reading = ThermalReading([], 0, 0)
+    assert reading.get_zone_max("left") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_mock_connector_returns_reading():
+    """Test mock connector returns ThermalReading."""
+    connector = _MockThermalConnector(scenario="clear")
+    result = await connector.read()
+    assert result is not None
+    assert isinstance(result, ThermalReading)
+
+
+@pytest.mark.asyncio
+async def test_mock_connector_human_scenario():
+    """Test mock connector human scenario has human-range temperatures."""
+    connector = _MockThermalConnector(scenario="human")
+    result = await connector.read()
+    assert result is not None
+    assert result.max_temp >= 34.0
+
+
+@pytest.mark.asyncio
+async def test_mock_connector_alert_scenario():
+    """Test mock connector alert scenario has high temperature."""
+    connector = _MockThermalConnector(scenario="alert")
+    result = await connector.read()
+    assert result is not None
+    assert result.max_temp >= 60.0
+
+
+def test_mock_connector_stop():
+    """Test mock connector stop does not raise."""
+    connector = _MockThermalConnector()
+    connector.stop()
+
+
+def test_serial_connector_init_success():
+    """Test serial connector initializes successfully."""
+    mock_serial = MagicMock()
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        assert connector._ser == mock_serial
+
+
+def test_serial_connector_init_failure():
+    """Test serial connector handles connection failure gracefully."""
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        side_effect=serial.SerialException("Port not found"),
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        assert connector._ser is None
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_valid():
+    """Test serial connector parses valid THERMAL line."""
+    mock_serial = MagicMock()
+    mock_serial.readline.return_value = b"THERMAL:20.0,21.0,22.0,23.0,24.0,25.0,26.0,27.0,28.0,29.0,30.0,31.0,32.0,33.0,34.0,35.0,36.0,37.0,38.0,39.0,40.0,41.0,42.0,43.0,44.0,45.0,46.0,47.0,48.0,49.0,50.0,51.0,52.0,53.0,54.0,55.0,56.0,57.0,58.0,59.0,60.0,61.0,62.0,63.0,64.0,65.0,66.0,67.0,68.0,69.0,70.0,71.0,72.0,73.0,74.0,75.0,76.0,77.0,78.0,79.0,80.0,81.0,82.0,83.0,8,8\n"
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is not None
+        assert result.width == 8
+        assert result.height == 8
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_invalid_prefix():
+    """Test serial connector ignores lines without THERMAL prefix."""
+    mock_serial = MagicMock()
+    mock_serial.readline.return_value = b"INVALID:data\n"
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_no_connection():
+    """Test serial connector read returns None when not connected."""
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        side_effect=serial.SerialException("Port not found"),
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_exception():
+    """Test serial connector handles read exception gracefully."""
+    mock_serial = MagicMock()
+    mock_serial.readline.side_effect = Exception("Read error")
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None
+
+
+def test_serial_connector_stop():
+    """Test serial connector stop closes port."""
+    mock_serial = MagicMock()
+    mock_serial.is_open = True
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        connector.stop()
+        mock_serial.close.assert_called_once()
+
+
+def test_usb_connector_init_success():
+    """Test USB connector initializes successfully."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        assert connector._ready is True
+
+
+def test_usb_connector_init_failure():
+    """Test USB connector handles camera not found."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = False
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        assert connector._ready is False
+
+
+@pytest.mark.asyncio
+async def test_usb_connector_read_success():
+    """Test USB connector reads and converts frame."""
+    import numpy as np
+
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_frame = np.zeros((24, 32, 3), dtype=np.uint8)
+    mock_cap.read.return_value = (True, mock_frame)
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        result = await connector.read()
+        assert result is not None
+        assert result.width == 32
+        assert result.height == 24
+
+
+@pytest.mark.asyncio
+async def test_usb_connector_read_failure():
+    """Test USB connector handles read failure."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.read.return_value = (False, None)
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        result = await connector.read()
+        assert result is None
+
+
+def test_usb_connector_stop():
+    """Test USB connector releases camera on stop."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        connector.stop()
+        mock_cap.release.assert_called_once()
+
+
+def test_initialization_mock_connector():
+    """Test ThermalCameraInput initializes with mock connector."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _MockThermalConnector)
+        assert sensor.messages == []
+        assert sensor.descriptor_for_LLM == "Thermal Camera"
+
+
+def test_initialization_unknown_connector_falls_back_to_mock():
+    """Test unknown connector falls back to mock."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="unknown_hw")
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _MockThermalConnector)
+
+
+def test_initialization_serial_connector():
+    """Test ThermalCameraInput initializes with serial connector."""
+    mock_serial = MagicMock()
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch(
+            "inputs.plugins.thermal_camera_input._serial.Serial",
+            return_value=mock_serial,
+        ),
+    ):
+        config = ThermalCameraConfig(connector="serial", port="/dev/ttyUSB0")
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _SerialThermalConnector)
+
+
+def test_initialization_usb_connector():
+    """Test ThermalCameraInput initializes with USB connector."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch(
+            "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+            return_value=mock_cap,
+        ),
+    ):
+        config = ThermalCameraConfig(connector="usb", camera_index=0)
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _USBThermalConnector)
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_reading():
+    """Test _poll returns thermal reading from connector."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock", mock_scenario="human")
+        sensor = ThermalCameraInput(config=config)
+        with patch(
+            "inputs.plugins.thermal_camera_input.asyncio.sleep", new=AsyncMock()
+        ):
+            result = await sensor._poll()
+        assert result is not None
+        assert isinstance(result, ThermalReading)
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_none_when_connector_fails():
+    """Test _poll returns None when connector returns None."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        sensor._connector = MagicMock()
+        sensor._connector.read = AsyncMock(return_value=None)
+        with patch(
+            "inputs.plugins.thermal_camera_input.asyncio.sleep", new=AsyncMock()
+        ):
+            result = await sensor._poll()
+        assert result is None
+
+
+def test_classify_alert():
+    """Test _classify returns alert for high temperature."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock", alert_temp_threshold=60.0)
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([25.0, 25.0, 75.0], 3, 1)
+        category, peak, zone = sensor._classify(reading)
+        assert category == "alert"
+        assert peak == 75.0
+
+
+def test_classify_human():
+    """Test _classify returns human for body-temperature range."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(
+            connector="mock",
+            human_temp_min=34.0,
+            human_temp_max=39.0,
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 36.5, 23.0], 3, 1)
+        category, peak, zone = sensor._classify(reading)
+        assert category == "human"
+        assert peak == 36.5
+
+
+def test_classify_clear():
+    """Test _classify returns clear for ambient temperatures."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 23.0, 24.0], 3, 1)
+        category, peak, zone = sensor._classify(reading)
+        assert category == "clear"
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_alert():
+    """Test _raw_to_text returns alert message for high temperature."""
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch("inputs.plugins.thermal_camera_input.time.time", return_value=1000.0),
+    ):
+        config = ThermalCameraConfig(connector="mock", alert_temp_threshold=60.0)
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([25.0, 25.0, 75.0], 3, 1)
+        result = await sensor._raw_to_text(reading)
+        assert result is not None
+        assert "THERMAL ALERT" in result.message
+        assert "75.0" in result.message
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_human():
+    """Test _raw_to_text returns human presence message."""
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch("inputs.plugins.thermal_camera_input.time.time", return_value=1000.0),
+    ):
+        config = ThermalCameraConfig(
+            connector="mock",
+            human_temp_min=34.0,
+            human_temp_max=39.0,
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 36.5, 23.0], 3, 1)
+        result = await sensor._raw_to_text(reading)
+        assert result is not None
+        assert "Human-like heat signature" in result.message
+        assert "36.5" in result.message
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_clear():
+    """Test _raw_to_text returns clear message for ambient temperatures."""
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch("inputs.plugins.thermal_camera_input.time.time", return_value=1000.0),
+    ):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 23.0, 24.0], 3, 1)
+        result = await sensor._raw_to_text(reading)
+        assert result is not None
+        assert "No significant heat signatures" in result.message
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_input():
+    """Test _raw_to_text returns None for None input."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        result = await sensor._raw_to_text(None)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_cooldown_suppresses_repeated_alerts():
+    """Test cooldown suppresses repeated alert messages."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(
+            connector="mock", cooldown=5.0, alert_temp_threshold=60.0
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([25.0, 25.0, 75.0], 3, 1)
+        sensor._last_alert_time = 1000.0
+        sensor.config.cooldown = 5.0
+        with patch(
+            "inputs.plugins.thermal_camera_input.time.time", return_value=1001.0
+        ):
+            result = await sensor._raw_to_text(reading)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_cooldown_allows_after_expiry():
+    """Test alert is allowed again after cooldown expires."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(
+            connector="mock", cooldown=5.0, alert_temp_threshold=60.0
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([25.0, 25.0, 75.0], 3, 1)
+        sensor._last_alert_time = 1000.0
+        sensor.config.cooldown = 5.0
+        with patch(
+            "inputs.plugins.thermal_camera_input.time.time", return_value=1006.0
+        ):
+            result = await sensor._raw_to_text(reading)
+        assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_updates_messages():
+    """Test raw_to_text appends to messages buffer."""
+    with (
+        patch("inputs.plugins.thermal_camera_input.IOProvider"),
+        patch("inputs.plugins.thermal_camera_input.time.time", return_value=1000.0),
+    ):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 23.0, 24.0], 3, 1)
+        await sensor.raw_to_text(reading)
+        assert len(sensor.messages) == 1
+
+
+def test_formatted_latest_buffer_with_messages():
+    """Test formatted_latest_buffer returns formatted string and clears buffer."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        sensor.io_provider = MagicMock()
+        sensor.messages = [
+            Message(
+                timestamp=1000.0,
+                message="Thermal camera: No significant heat signatures detected. Max temperature: 24.0°C.",
+            )
+        ]
+        result = sensor.formatted_latest_buffer()
+        assert result is not None
+        assert "Thermal Camera" in result
+        assert "No significant heat signatures" in result
+        sensor.io_provider.add_input.assert_called_once()
+        assert len(sensor.messages) == 0
+
+
+def test_formatted_latest_buffer_empty():
+    """Test formatted_latest_buffer returns None when buffer is empty."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        result = sensor.formatted_latest_buffer()
+        assert result is None
+
+
+def test_stop_calls_connector_stop():
+    """Test stop calls connector stop method."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(connector="mock")
+        sensor = ThermalCameraInput(config=config)
+        sensor._connector = MagicMock()
+        sensor.stop()
+        sensor._connector.stop.assert_called_once()
+        assert sensor.messages == []
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_init_library_unavailable():
+    """Test MLX90640 connector handles missing library."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    mod._MLX90640_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+    connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+    assert connector._ready is False
+    mod._MLX90640_AVAILABLE = original
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_init_success():
+    """Test MLX90640 connector initializes with mocked hardware."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    original_lib = mod._mlx90640_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    mock_lib.MLX90640.return_value = mock_sensor
+    mock_lib.RefreshRate.REFRESH_4_HZ = 4
+    mod._MLX90640_AVAILABLE = True
+    mod._mlx90640_lib = mock_lib
+    mock_i2c = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {
+            "board": MagicMock(),
+            "busio": MagicMock(I2C=MagicMock(return_value=mock_i2c)),
+        },
+    ):
+        from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+        connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+        assert connector._ready is True
+    mod._MLX90640_AVAILABLE = original
+    mod._mlx90640_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_read_success():
+    """Test MLX90640 connector reads frame successfully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    original_lib = mod._mlx90640_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    mock_lib.MLX90640.return_value = mock_sensor
+    mock_lib.RefreshRate.REFRESH_4_HZ = 4
+    mod._MLX90640_AVAILABLE = True
+    mod._mlx90640_lib = mock_lib
+    mock_i2c = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {
+            "board": MagicMock(),
+            "busio": MagicMock(I2C=MagicMock(return_value=mock_i2c)),
+        },
+    ):
+        from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+        connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+        result = await connector.read()
+        assert result is not None
+    mod._MLX90640_AVAILABLE = original
+    mod._mlx90640_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_read_not_ready():
+    """Test MLX90640 connector returns None when not ready."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    mod._MLX90640_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+    connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+    result = await connector.read()
+    assert result is None
+    mod._MLX90640_AVAILABLE = original
+
+
+def test_mlx90640_connector_stop():
+    """Test MLX90640 connector stop."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    mod._MLX90640_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+    connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+    connector.stop()
+    assert connector._ready is False
+    mod._MLX90640_AVAILABLE = original
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_init_library_unavailable():
+    """Test AMG8833 connector handles missing library."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    mod._AMG8833_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+    connector = _AMG8833Connector()
+    assert connector._ready is False
+    mod._AMG8833_AVAILABLE = original
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_init_success():
+    """Test AMG8833 connector initializes with mocked hardware."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    original_lib = mod._amg88xx_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    mock_lib.AMG88XX.return_value = mock_sensor
+    mod._AMG8833_AVAILABLE = True
+    mod._amg88xx_lib = mock_lib
+    mock_i2c = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {
+            "board": MagicMock(),
+            "busio": MagicMock(I2C=MagicMock(return_value=mock_i2c)),
+        },
+    ):
+        from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+        connector = _AMG8833Connector()
+        assert connector._ready is True
+    mod._AMG8833_AVAILABLE = original
+    mod._amg88xx_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_read_success():
+    """Test AMG8833 connector reads pixels successfully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    original_lib = mod._amg88xx_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    mock_sensor.pixels = [[22.0] * 8 for _ in range(8)]
+    mock_lib.AMG88XX.return_value = mock_sensor
+    mod._AMG8833_AVAILABLE = True
+    mod._amg88xx_lib = mock_lib
+    mock_i2c = MagicMock()
+    with patch.dict(
+        "sys.modules",
+        {
+            "board": MagicMock(),
+            "busio": MagicMock(I2C=MagicMock(return_value=mock_i2c)),
+        },
+    ):
+        from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+        connector = _AMG8833Connector()
+        result = await connector.read()
+        assert result is not None
+        assert len(result.frame) == 64
+    mod._AMG8833_AVAILABLE = original
+    mod._amg88xx_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_read_not_ready():
+    """Test AMG8833 connector returns None when not ready."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    mod._AMG8833_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+    connector = _AMG8833Connector()
+    result = await connector.read()
+    assert result is None
+    mod._AMG8833_AVAILABLE = original
+
+
+def test_amg8833_connector_stop():
+    """Test AMG8833 connector stop."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    mod._AMG8833_AVAILABLE = False
+    from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+    connector = _AMG8833Connector()
+    connector.stop()
+    assert connector._ready is False
+    mod._AMG8833_AVAILABLE = original
+
+
+def test_initialization_amg8833_connector():
+    """Test ThermalCameraInput initializes with amg8833 connector."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    mod._AMG8833_AVAILABLE = False
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+        config = ThermalCameraConfig(connector="amg8833")
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _AMG8833Connector)
+    mod._AMG8833_AVAILABLE = original
+
+
+def test_initialization_mlx90640_connector():
+    """Test ThermalCameraInput initializes with mlx90640 connector."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    mod._MLX90640_AVAILABLE = False
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+        config = ThermalCameraConfig(connector="mlx90640")
+        sensor = ThermalCameraInput(config=config)
+        assert isinstance(sensor._connector, _MLX90640Connector)
+    mod._MLX90640_AVAILABLE = original
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_human_cooldown_suppresses():
+    """Test cooldown suppresses repeated human detection messages."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(
+            connector="mock",
+            cooldown=5.0,
+            human_temp_min=34.0,
+            human_temp_max=39.0,
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 36.5, 23.0], 3, 1)
+        sensor._last_alert_time = 1000.0
+        sensor.config.cooldown = 5.0
+        with patch(
+            "inputs.plugins.thermal_camera_input.time.time", return_value=1001.0
+        ):
+            result = await sensor._raw_to_text(reading)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_human_cooldown_allows_after_expiry():
+    """Test human detection allowed again after cooldown expires."""
+    with patch("inputs.plugins.thermal_camera_input.IOProvider"):
+        config = ThermalCameraConfig(
+            connector="mock",
+            cooldown=5.0,
+            human_temp_min=34.0,
+            human_temp_max=39.0,
+        )
+        sensor = ThermalCameraInput(config=config)
+        reading = ThermalReading([22.0, 36.5, 23.0], 3, 1)
+        sensor._last_alert_time = 1000.0
+        sensor.config.cooldown = 5.0
+        with patch(
+            "inputs.plugins.thermal_camera_input.time.time", return_value=1006.0
+        ):
+            result = await sensor._raw_to_text(reading)
+        assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_too_few_values():
+    """Test serial connector returns None for lines with too few values."""
+    mock_serial = MagicMock()
+    mock_serial.readline.return_value = b"THERMAL:20.0,8\n"
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_pixel_count_mismatch():
+    """Test serial connector returns None when pixel count mismatches dimensions."""
+    mock_serial = MagicMock()
+    mock_serial.readline.return_value = b"THERMAL:20.0,21.0,22.0,4,4\n"
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_usb_connector_read_exception():
+    """Test USB connector handles read exception gracefully."""
+    mock_cap = MagicMock()
+    mock_cap.isOpened.return_value = True
+    mock_cap.read.side_effect = Exception("Read error")
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        return_value=mock_cap,
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        result = await connector.read()
+        assert result is None
+
+
+def test_thermal_reading_get_zone_idx_out_of_bounds():
+    """Test get_zone_max handles idx beyond frame length gracefully."""
+    reading = ThermalReading([10.0, 20.0], 3, 2)
+    result = reading.get_zone_max("left")
+    assert result == 10.0
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_init_exception():
+    """Test MLX90640 connector handles init exception gracefully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    original_lib = mod._mlx90640_lib
+    mock_lib = MagicMock()
+    mock_lib.MLX90640.side_effect = Exception("I2C error")
+    mod._MLX90640_AVAILABLE = True
+    mod._mlx90640_lib = mock_lib
+    with patch.dict(
+        "sys.modules", {"board": MagicMock(), "busio": MagicMock(I2C=MagicMock())}
+    ):
+        from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+        connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+        assert connector._ready is False
+    mod._MLX90640_AVAILABLE = original
+    mod._mlx90640_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_mlx90640_connector_read_exception():
+    """Test MLX90640 connector handles read exception gracefully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._MLX90640_AVAILABLE
+    original_lib = mod._mlx90640_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    mock_sensor.getFrame.side_effect = Exception("Read error")
+    mock_lib.MLX90640.return_value = mock_sensor
+    mock_lib.RefreshRate.REFRESH_4_HZ = 4
+    mod._MLX90640_AVAILABLE = True
+    mod._mlx90640_lib = mock_lib
+    with patch.dict(
+        "sys.modules", {"board": MagicMock(), "busio": MagicMock(I2C=MagicMock())}
+    ):
+        from inputs.plugins.thermal_camera_input import _MLX90640Connector
+
+        connector = _MLX90640Connector(i2c_address=0x33, refresh_rate=4)
+        result = await connector.read()
+        assert result is None
+    mod._MLX90640_AVAILABLE = original
+    mod._mlx90640_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_init_exception():
+    """Test AMG8833 connector handles init exception gracefully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    original_lib = mod._amg88xx_lib
+    mock_lib = MagicMock()
+    mock_lib.AMG88XX.side_effect = Exception("I2C error")
+    mod._AMG8833_AVAILABLE = True
+    mod._amg88xx_lib = mock_lib
+    with patch.dict(
+        "sys.modules", {"board": MagicMock(), "busio": MagicMock(I2C=MagicMock())}
+    ):
+        from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+        connector = _AMG8833Connector()
+        assert connector._ready is False
+    mod._AMG8833_AVAILABLE = original
+    mod._amg88xx_lib = original_lib
+
+
+@pytest.mark.asyncio
+async def test_amg8833_connector_read_exception():
+    """Test AMG8833 connector handles read exception gracefully."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._AMG8833_AVAILABLE
+    original_lib = mod._amg88xx_lib
+    mock_lib = MagicMock()
+    mock_sensor = MagicMock()
+    type(mock_sensor).pixels = property(
+        lambda self: (_ for _ in ()).throw(Exception("Read error"))
+    )
+    mock_lib.AMG88XX.return_value = mock_sensor
+    mod._AMG8833_AVAILABLE = True
+    mod._amg88xx_lib = mock_lib
+    with patch.dict(
+        "sys.modules", {"board": MagicMock(), "busio": MagicMock(I2C=MagicMock())}
+    ):
+        from inputs.plugins.thermal_camera_input import _AMG8833Connector
+
+        connector = _AMG8833Connector()
+        result = await connector.read()
+        assert result is None
+    mod._AMG8833_AVAILABLE = original
+    mod._amg88xx_lib = original_lib
+
+
+def test_usb_connector_init_cv2_unavailable():
+    """Test USB connector handles missing cv2 library."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._CV2_AVAILABLE
+    mod._CV2_AVAILABLE = False
+    connector = _USBThermalConnector(camera_index=0)
+    assert connector._ready is False
+    mod._CV2_AVAILABLE = original
+
+
+def test_usb_connector_init_videocapture_exception():
+    """Test USB connector handles VideoCapture exception."""
+    with patch(
+        "inputs.plugins.thermal_camera_input._cv2.VideoCapture",
+        side_effect=Exception("Camera error"),
+    ):
+        connector = _USBThermalConnector(camera_index=0)
+        assert connector._ready is False
+
+
+def test_serial_connector_init_serial_unavailable():
+    """Test serial connector handles missing pyserial library."""
+    import inputs.plugins.thermal_camera_input as mod
+
+    original = mod._SERIAL_AVAILABLE
+    mod._SERIAL_AVAILABLE = False
+    connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+    assert connector._ser is None
+    mod._SERIAL_AVAILABLE = original
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_read_parse_error():
+    """Test serial connector handles parse error gracefully."""
+    mock_serial = MagicMock()
+    mock_serial.readline.return_value = b"THERMAL:not,a,number,x,y\n"
+    with patch(
+        "inputs.plugins.thermal_camera_input._serial.Serial",
+        return_value=mock_serial,
+    ):
+        connector = _SerialThermalConnector("/dev/ttyUSB0", 9600, 1.0)
+        result = await connector.read()
+        assert result is None


### PR DESCRIPTION
## Summary

Adds a universal thermal camera input plugin for OM1 that reads IR sensor 
data and converts temperature arrays into natural language context for the LLM. #365 

## Supported Hardware

- **MLX90640** — Melexis 32x24 IR array via I2C
- **AMG8833** — Panasonic 8x8 IR array via I2C  
- **USB** — Generic USB thermal camera via OpenCV (FLIR Lepton, Seek Thermal, V4L2)
- **Serial** — Arduino with IR sensor via pyserial
- **Mock** — Simulated data for development and testing

## Features

- Detects human presence (34–39°C) and fire/heat alerts (>60°C)
- Cooldown logic to suppress repeated identical LLM alerts
- Optional imports pattern — no hard dependency on hardware libraries
- Zone-based detection (left, center, right) for spatial awareness
- Configurable temperature thresholds via config

## Files Changed

- `src/inputs/plugins/thermal_camera_input.py` — plugin implementation
- `tests/inputs/plugins/test_thermal_camera_input.py` — 68 tests, 97% coverage
- `config/thermal_camera.json5` — example config for security patrol use case
- `docs/developing/4_inputs.md` — added Thermal Camera to examples list