### PR TITLE
Add auto done_payment handling to ARM zenoh connector

### DIFF
--- a/src/actions/arm_g1/connector/zenoh.py
+++ b/src/actions/arm_g1/connector/zenoh.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from typing import Optional
@@ -22,12 +23,13 @@ CUSTOM_ACTION_MAP = {
     "face_wave": "face_wave",
     "hands_up": "hands_up",
     "stand_still": "stand_still",
-    "show_hand": "show_hand",
     "wave": "wave",
-    "move": "move",
+    "show_hand": "show_hand",
     "show_hand1": "show_hand1",
     "show_hand2": "show_hand2",
     "my_gesture": "my_gesture",
+    "do_payment": "do_payment",
+    "done_payment": "done_payment",
 }
 
 
@@ -67,30 +69,61 @@ class ARMZenohConnector(ActionConnector[ActionConfig, ArmInput]):
         output_interface : ArmInput
             The output interface containing the arm action command.
         """
-        action = output_interface.action
+        try:
+            action = output_interface.action
 
-        if action == "idle":
-            return
+            if action == "idle":
+                return
 
-        if self.session is None:
-            logging.error("ARMZenohConnector: No Zenoh session available")
-            return
+            if self.session is None:
+                logging.error("ARMZenohConnector: No Zenoh session available")
+                return
 
-        action_name = CUSTOM_ACTION_MAP.get(action)
-        if action_name is None:
-            logging.warning(f"ARMZenohConnector: Unknown action '{action}'")
-            return
+            action_name = CUSTOM_ACTION_MAP.get(action)
+            if action_name is None:
+                logging.warning(f"ARMZenohConnector: Unknown action '{action}'")
+                return
 
-        identity = UnitreeRequestIdentity(id=0, api_id=CUSTOM_API_ID)
-        header = UnitreeRequestHeader(identity=identity)
-        request = UnitreeRequest(
-            header=header,
-            parameter=json.dumps({"action": action_name}),
-        )
+            identity = UnitreeRequestIdentity(id=0, api_id=CUSTOM_API_ID)
+            header = UnitreeRequestHeader(identity=identity)
+            request = UnitreeRequest(
+                header=header,
+                parameter=json.dumps({"action": action_name}),
+            )
 
-        payload = ZBytes(request.serialize())
-        self.session.put(SPORT_REQUEST_TOPIC, payload)
-        logging.info(f"ARMZenohConnector: Published '{action}' -> action={action_name}")
+            payload = ZBytes(request.serialize())
+            self.session.put(SPORT_REQUEST_TOPIC, payload)
+            logging.info(f"ARMZenohConnector: Published '{action}' -> action={action_name}")
+
+            if action == "do_payment":
+                asyncio.create_task(self._auto_done_payment())
+        except Exception:
+            logging.exception("ARMZenohConnector: Exception in connect method")
+
+    async def _auto_done_payment(self) -> None:
+        """
+        Automatically issue done_payment action after 10 seconds. This is triggered after do_payment is executed.
+        """
+        try:
+            await asyncio.sleep(10)
+
+            if self.session is None:
+                logging.error("ARMZenohConnector: No Zenoh session available for auto done_payment")
+                return
+
+            action_name = CUSTOM_ACTION_MAP.get("done_payment")
+            identity = UnitreeRequestIdentity(id=0, api_id=CUSTOM_API_ID)
+            header = UnitreeRequestHeader(identity=identity)
+            request = UnitreeRequest(
+                header=header,
+                parameter=json.dumps({"action": action_name}),
+            )
+
+            payload = ZBytes(request.serialize())
+            self.session.put(SPORT_REQUEST_TOPIC, payload)
+            logging.info("ARMZenohConnector: Auto-published 'done_payment' after 10 seconds")
+        except Exception:
+            logging.exception("ARMZenohConnector: Exception in auto done_payment task")
 
     def stop(self) -> None:
         """Close the Zenoh session."""

--- a/src/actions/arm_g1/interface.py
+++ b/src/actions/arm_g1/interface.py
@@ -24,7 +24,9 @@ class ArmAction(str, Enum):
     HANDS_UP = "hands_up"
     STAND_STILL = "stand_still"
     SHOW_HAND = "show_hand"
-    # WAVE = "wave"
+    DO_PAYMENT = "do_payment"
+    DONE_PAYMENT = "done_payment"
+    WAVE = "wave"
     # MOVE = "move"
 
 

--- a/tests/actions/arm_g1/connector/test_arm_g1_zenoh.py
+++ b/tests/actions/arm_g1/connector/test_arm_g1_zenoh.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -163,3 +163,124 @@ class TestARMZenohConnectorStop:
             config = ActionConfig()
             conn = ARMZenohConnector(config)
             conn.stop()  # Should not raise
+
+
+class TestARMZenohConnectorAutoPayment:
+    """Test automatic done_payment functionality."""
+
+    @pytest.mark.asyncio
+    async def test_do_payment_triggers_auto_done_payment(self, connector, mock_dependencies):
+        """Test that do_payment action triggers automatic done_payment after 10 seconds."""
+        arm_input = ArmInput(action=ArmAction.DO_PAYMENT)
+
+        with patch.object(connector, "_auto_done_payment", new_callable=AsyncMock) as mock_auto_done:
+            await connector.connect(arm_input)
+
+            # Verify do_payment was published
+            assert mock_dependencies["session"].put.call_count == 1
+
+            # Verify _auto_done_payment was scheduled as a task
+            mock_auto_done.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_done_payment_publishes_after_10_seconds(self, connector, mock_dependencies):
+        """Test that _auto_done_payment publishes done_payment after 10 seconds."""
+        # Mock asyncio.sleep to avoid actual delay in tests
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await connector._auto_done_payment()
+
+            # Verify sleep was called with 10 seconds
+            mock_sleep.assert_called_once_with(10)
+
+            # Verify done_payment was published
+            mock_dependencies["session"].put.assert_called_once()
+            topic = mock_dependencies["session"].put.call_args[0][0]
+            assert topic == SPORT_REQUEST_TOPIC
+
+    @pytest.mark.asyncio
+    async def test_auto_done_payment_no_session(self):
+        """Test _auto_done_payment handles no session gracefully."""
+        with (
+            patch("actions.arm_g1.connector.zenoh.open_zenoh_session") as mock_open_session,
+            patch("actions.arm_g1.connector.zenoh.logging") as mock_logging,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_open_session.side_effect = Exception("No connection")
+            config = ActionConfig()
+            conn = ARMZenohConnector(config)
+
+            await conn._auto_done_payment()
+
+            # Should log error about no session
+            mock_logging.error.assert_any_call("ARMZenohConnector: No Zenoh session available for auto done_payment")
+
+    @pytest.mark.asyncio
+    async def test_auto_done_payment_exception_handling(self, connector):
+        """Test that exceptions in _auto_done_payment are caught and logged."""
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("actions.arm_g1.connector.zenoh.logging") as mock_logging,
+        ):
+            # Make sleep raise an exception
+            mock_sleep.side_effect = Exception("Unexpected error")
+
+            # Should not raise, exception is caught
+            await connector._auto_done_payment()
+
+            # Should log the exception
+            mock_logging.exception.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_do_payment_full_workflow(self, connector, mock_dependencies):
+        """Test complete workflow: do_payment publishes, then done_payment auto-publishes."""
+        arm_input = ArmInput(action=ArmAction.DO_PAYMENT)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            # Call connect which publishes do_payment and schedules auto done_payment
+            await connector.connect(arm_input)
+
+            # Verify do_payment was published
+            assert mock_dependencies["session"].put.call_count == 1
+
+            # Manually call _auto_done_payment to simulate the scheduled task completing
+            await connector._auto_done_payment()
+
+            # Now done_payment should also be published (total 2 calls)
+            assert mock_dependencies["session"].put.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_other_actions_dont_trigger_auto_payment(self, connector, mock_dependencies):
+        """Test that non-payment actions don't trigger automatic done_payment."""
+        test_actions = [
+            ArmAction.SHAKE_HAND,
+            ArmAction.FACE_WAVE,
+            ArmAction.HANDS_UP,
+            ArmAction.STAND_STILL,
+        ]
+
+        for action in test_actions:
+            mock_dependencies["session"].put.reset_mock()
+            arm_input = ArmInput(action=action)
+
+            with patch.object(connector, "_auto_done_payment", new_callable=AsyncMock) as mock_auto_done:
+                await connector.connect(arm_input)
+
+                # Verify action was published
+                mock_dependencies["session"].put.assert_called_once()
+
+                # Verify _auto_done_payment was NOT called
+                mock_auto_done.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_done_payment_action_format(self, connector, mock_dependencies):
+        """Test that done_payment action is formatted correctly."""
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await connector._auto_done_payment()
+
+            # Get the payload that was published
+            call_args = mock_dependencies["session"].put.call_args
+            topic = call_args[0][0]
+
+            assert topic == SPORT_REQUEST_TOPIC
+            # Payload should contain the done_payment action
+            assert mock_dependencies["session"].put.called

--- a/tests/actions/move_k1_autonomy/connector/test_k1_sdk.py
+++ b/tests/actions/move_k1_autonomy/connector/test_k1_sdk.py
@@ -1,5 +1,5 @@
 from queue import Queue
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -73,11 +73,35 @@ def connector(mock_dependencies):
     Returns
     -------
     MoveBoosterZenohConnector
-        Configured connector instance.
+        Configured connector instance with _move_robot mocked to prevent warnings.
     """
     config = MoveBoosterZenohConfig()
-    connector = MoveBoosterZenohConnector(config)
-    return connector
+    connector_instance = MoveBoosterZenohConnector(config)
+
+    connector_instance._original_move_robot = connector_instance._move_robot  # type: ignore
+    connector_instance._move_robot = AsyncMock()
+
+    return connector_instance
+
+
+@pytest.fixture
+def connector_with_real_move_robot(mock_dependencies):
+    """
+    Create a MoveBoosterZenohConnector instance without mocking _move_robot.
+    Use this for tests that need to test the actual _move_robot implementation.
+
+    Parameters
+    ----------
+    mock_dependencies : dict
+        Dictionary containing mock instances.
+
+    Returns
+    -------
+    MoveBoosterZenohConnector
+        Configured connector instance with real _move_robot.
+    """
+    config = MoveBoosterZenohConfig()
+    return MoveBoosterZenohConnector(config)
 
 
 class TestMoveBoosterZenohConfig:
@@ -216,7 +240,7 @@ class TestMoveRobot:
     """Test _move_robot async method."""
 
     @pytest.mark.asyncio
-    async def test_move_robot_success(self, connector, mock_dependencies):
+    async def test_move_robot_success(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot sends movement command successfully."""
         mock_reply = Mock()
         mock_reply.ok = Mock()
@@ -230,7 +254,7 @@ class TestMoveRobot:
             mock_response.msg.body = ""
             mock_deserialize.return_value = mock_response
 
-            await connector._move_robot(0.1, 0.0, 0.0)
+            await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
             mock_dependencies["zenoh"].get.assert_called_once()
             args, kwargs = mock_dependencies["zenoh"].get.call_args
@@ -238,27 +262,27 @@ class TestMoveRobot:
             assert kwargs["timeout"] == 5.0
 
     @pytest.mark.asyncio
-    async def test_move_robot_no_session(self, connector, mock_dependencies):
+    async def test_move_robot_no_session(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot returns early when session is None."""
-        connector.session = None
+        connector_with_real_move_robot.session = None
 
-        await connector._move_robot(0.1, 0.0, 0.0)
+        await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
         mock_dependencies["zenoh"].get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_move_robot_not_standing(self, connector, mock_dependencies):
+    async def test_move_robot_not_standing(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot returns early when robot is not standing."""
         mock_dependencies["odom"].position["body_attitude"] = RobotState.SITTING
 
-        await connector._move_robot(0.1, 0.0, 0.0)
+        await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
         mock_dependencies["zenoh"].get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_move_robot_allow_without_odom(self, connector, mock_dependencies):
+    async def test_move_robot_allow_without_odom(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot bypasses odom check when allow_move_without_odom is True."""
-        connector.config.allow_move_without_odom = True
+        connector_with_real_move_robot.config.allow_move_without_odom = True
         mock_dependencies["odom"].position["body_attitude"] = RobotState.SITTING
 
         mock_reply = Mock()
@@ -267,12 +291,12 @@ class TestMoveRobot:
         mock_dependencies["zenoh"].get.return_value = [mock_reply]
 
         with patch("actions.move_k1_autonomy.connector.k1_sdk.RpcServiceResponse.deserialize"):
-            await connector._move_robot(0.1, 0.0, 0.0)
+            await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
             mock_dependencies["zenoh"].get.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_move_robot_service_error(self, connector, mock_dependencies):
+    async def test_move_robot_service_error(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot handles service errors."""
         mock_reply = Mock()
         mock_reply.ok = None
@@ -280,17 +304,17 @@ class TestMoveRobot:
         mock_dependencies["zenoh"].get.return_value = [mock_reply]
 
         with patch("actions.move_k1_autonomy.connector.k1_sdk.logging") as mock_logging:
-            await connector._move_robot(0.1, 0.0, 0.0)
+            await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
             mock_logging.error.assert_called()
 
     @pytest.mark.asyncio
-    async def test_move_robot_exception(self, connector, mock_dependencies):
+    async def test_move_robot_exception(self, connector_with_real_move_robot, mock_dependencies):
         """Test _move_robot handles exceptions during service call."""
         mock_dependencies["zenoh"].get.side_effect = Exception("Connection timeout")
 
         with patch("actions.move_k1_autonomy.connector.k1_sdk.logging") as mock_logging:
-            await connector._move_robot(0.1, 0.0, 0.0)
+            await connector_with_real_move_robot._move_robot(0.1, 0.0, 0.0)
 
             mock_logging.error.assert_called()
 


### PR DESCRIPTION
Introduce DO_PAYMENT and DONE_PAYMENT actions in the ArmAction enum and CUSTOM_ACTION_MAP. The connector now imports asyncio, wraps connect in exception handling, and schedules an async _auto_done_payment task (via asyncio.create_task) when a do_payment action is sent. _auto_done_payment sleeps 10 seconds then publishes a done_payment request (with logging and error handling). Tests were updated/added to use AsyncMock and cover scheduling, publishing, no-session handling, and exception paths for the auto-payment workflow.