### PR TITLE
Use env vars for model IDs

### DIFF
--- a/config/greeting_local.json5
+++ b/config/greeting_local.json5
@@ -17,7 +17,7 @@
       agent_name: "${ROBOT_NAME:-Bits}",
       history_length: 0,
       base_url: "${QWEN_BASE_URL:-http://omr2.local:8860}/v1",
-      model: "nvidia/nemotron-3-nano",
+      model: "${QWEN_MODEL:-nvidia/nemotron-3-nano}",
     },
   },
 
@@ -70,7 +70,7 @@
           llm_label: "greeting_conversation",
           connector: "greeting_conversation_kokoro",
           config: {
-            model_id: "mlx-community/Kokoro-82M-bf16",
+            model_id: "${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}",
             base_url: "${KOKORO_BASE_URL:-http://omr2.local:8880}/v1",
           },
         },
@@ -83,7 +83,7 @@
           handler_config: {
             tts_provider: "kokoro",
             message: "Hello! I'm ${ROBOT_NAME:-Bits}, how can I help you today?",
-            model_id: "mlx-community/Kokoro-82M-bf16",
+            model_id: "${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}",
             base_url: "${KOKORO_BASE_URL:-http://omr2.local:8880}/v1",
           },
         },
@@ -93,7 +93,7 @@
           handler_config: {
             tts_provider: "kokoro",
             message: "Hello! I'm ${ROBOT_NAME:-Bits}, how can I help you today?",
-            model_id: "mlx-community/Kokoro-82M-bf16",
+            model_id: "${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}",
             base_url: "${KOKORO_BASE_URL:-http://omr2.local:8880}/v1",
           },
         },
@@ -104,7 +104,7 @@
             module_name: "greeting_hook",
             function: "geeting_end_hook",
             tts_provider: "kokoro",
-            model_id: "mlx-community/Kokoro-82M-bf16",
+            model_id: "${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}",
             base_url: "${KOKORO_BASE_URL:-http://omr2.local:8880}/v1",
           },
         },


### PR DESCRIPTION
Replace hardcoded model values in config/greeting_local.json5 with environment-variable placeholders so models can be overridden at runtime. QWEN model now uses ${QWEN_MODEL:-nvidia/nemotron-3-nano}, and Kokoro model_id entries use ${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}. Defaults are preserved when env vars are not set.