### PR TITLE
Add Unitree G1 configuration and update Gemini model to 3.1

### DIFF
--- a/config/unitree_g1_conversation.json5
+++ b/config/unitree_g1_conversation.json5
@@ -1,0 +1,98 @@
+{
+  // Configuration version
+  version: "v1.0.3",
+
+  // Mode system configuration for Unitree Go2
+  default_mode: "greeting",
+  allow_manual_switching: true,
+  mode_memory_enabled: true,
+
+  // Global settings
+  api_key: "${OM_API_KEY:-openmind_free}",
+  unitree_ethernet: "${UNITREE_ETHERNET:-enP2p1s0}",
+  system_governance: "",
+  cortex_llm: {
+    type: "GeminiLLM",
+    config: {
+      agent_name: "${ROBOT_NAME:-Pam}",
+      history_length: 10,
+    },
+  },
+
+  knowledge_base: {
+    knowledge_base_name: "om",
+    base_url: "${KB_BASE_URL:-http://localhost:8100}",
+    min_score: 0.6,
+  },
+
+  modes: {
+    greeting: {
+      display_name: "Greeting Conversation Mode",
+      description: "Robot engages in greeting conversations with users upon approach.",
+      system_prompt_base: "You are ${ROBOT_NAME:-Pam}, a friendly and engaging robotic companion built on a ${ROBOT_PLATFORM:-Unitree G1} platform at the Visa Innvotion Center. You run OpenMind's OM1 robotics software stack. OpenMind is a software company that makes robots useful, and you demonstrate what robots can do when powered by OM1. Answer questions in 1-2 short spoken sentences. If users ask you about the items that you want to purchase, please do the payment action. If relevant info is provided, use it and rephrase in your own words. DO NOT REPEAT THE VOICE INPUT. Always response in the language that the user voice input is in.",
+      hertz: 0.001,
+      agent_inputs: [
+        {
+          type: "GoogleASRInput",
+          config: {
+            api_version: "v2",
+            enable_tts_interrupt: false,
+            rate: 16000,
+            chunk: 1600,
+          },
+        },
+        {
+          type: "ConversationHistoryInput",
+          config: {
+            max_rounds: 3,
+          },
+        },
+      ],
+      cortex_llm: {
+        type: "ParallelLLM",
+        config: {
+          llms: [
+            {
+              llm_type: "GeminiLLM",
+              action_filter: ["speak", "arm_g1", "face"],
+            }
+          ],
+          execute_immediately: true,
+        },
+      },
+      action_execution_mode: "concurrent",
+      agent_actions: [
+        {
+          name: "speak",
+          llm_label: "speak",
+          connector: "elevenlabs_tts",
+          config: {
+            voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
+          },
+        },
+        {
+          name: "face",
+          llm_label: "show_emotion",
+          connector: "avatar",
+        },
+        {
+          name: "arm_g1",
+          llm_label: "robot_action",
+          connector: "zenoh",
+        },
+      ],
+      backgrounds: [],
+      lifecycle_hooks: [
+        {
+          hook_type: "on_startup",
+          handler_type: "message",
+          handler_config: {
+            tts_provider: "elevenlabs",
+            message: "Hello! I'm ${ROBOT_NAME:-Pam}, how are you?",
+            voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
+          },
+        },
+      ],
+    },
+  },
+}

--- a/config/unitree_g1_conversation.json5
+++ b/config/unitree_g1_conversation.json5
@@ -2,7 +2,7 @@
   // Configuration version
   version: "v1.0.3",
 
-  // Mode system configuration for Unitree Go2
+  // Mode system configuration for Unitree G1
   default_mode: "greeting",
   allow_manual_switching: true,
   mode_memory_enabled: true,
@@ -55,7 +55,7 @@
             {
               llm_type: "GeminiLLM",
               action_filter: ["speak", "arm_g1", "face"],
-            }
+            },
           ],
           execute_immediately: true,
         },

--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -67,7 +67,7 @@ class GeminiLLM(LLM[R]):
         if not config.api_key:
             raise ValueError("config file missing api_key")
         if not config.model:
-            self._config.model = "gemini-2.5-flash"
+            self._config.model = GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW
 
         self._client = openai.AsyncOpenAI(
             base_url=config.base_url or "https://api.openmind.com/api/core/gemini",
@@ -111,7 +111,7 @@ class GeminiLLM(LLM[R]):
             formatted_messages.append({"role": "user", "content": prompt})
 
             response = await self._client.chat.completions.create(
-                model=self._config.model or "gemini-2.0-flash-exp",
+                model=self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
                 messages=T.cast(T.Any, formatted_messages),
                 tools=T.cast(T.Any, self.function_schemas),
                 tool_choice="auto",

--- a/tests/llm/plugins/test_gemini_llm.py
+++ b/tests/llm/plugins/test_gemini_llm.py
@@ -167,7 +167,7 @@ async def test_init_without_model():
     """When the test model is None, use the default value"""
     config = GeminiConfig(api_key="test_key", model=None)
     llm = GeminiLLM(config)
-    assert llm._config.model == "gemini-2.5-flash"
+    assert llm._config.model == "gemini-3.1-flash-lite-preview"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request introduces a new configuration file for Unitree G1 conversation settings and updates the default Gemini LLM model used in the `gemini_llm.py` plugin. The main changes focus on improving robot conversational capabilities and ensuring the latest Gemini model is used by default.

**Unitree G1 Conversation Configuration:**

* Added a new configuration file `unitree_g1_conversation.json5` for the Unitree G1 robot, specifying default modes, API keys, LLM settings, knowledge base integration, and detailed mode setup for greeting conversations, including agent inputs, actions, and lifecycle hooks.

**Gemini LLM Plugin Updates:**

* Changed the default Gemini model in the `GeminiLLM` plugin to use `GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW` if not specified in the config, ensuring use of the latest model version.
* Updated the fallback model in the `ask` method to use `GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW` instead of the previous model string.