### PR TITLE
Refactor _emit method for message delivery and add tests

### DIFF
--- a/src/providers/face_presence_provider.py
+++ b/src/providers/face_presence_provider.py
@@ -165,7 +165,6 @@ class FacePresenceProvider:
         self._cb_lock = threading.Lock()
         self._session = requests.Session()
         self._unknown_faces: int = 0
-        self._last_emitted_text: Optional[str] = None
 
     def set_recent_sec(self, sec: float) -> None:
         """
@@ -255,18 +254,13 @@ class FacePresenceProvider:
 
     def _emit(self, text: str) -> None:
         """
-        Deliver one formatted presence line to all subscribers only if it has changed.
+        Deliver one formatted presence line to all subscribers.
 
         Parameters
         ----------
         text : str
             A concise, human-readable snapshot (e.g., "present=[alice], unknown=0, ts=...").
         """
-        if text == self._last_emitted_text:
-            return
-
-        self._last_emitted_text = text
-
         with self._cb_lock:
             callbacks = list(self._callbacks)
         for cb in callbacks:

--- a/tests/inputs/plugins/test_face_presence_input.py
+++ b/tests/inputs/plugins/test_face_presence_input.py
@@ -172,3 +172,43 @@ def test_formatted_latest_buffer_formats_and_clears_latest_message(face_presence
     assert "present=[eve], unknown=1, ts=123460" in result
     assert len(face_presence_instance.messages) == 0
     mock_io_provider.add_input.assert_called_once_with("FacePresence", "present=[eve], unknown=1, ts=123460", 1234.0)
+
+
+@pytest.mark.asyncio
+async def test_continuous_face_presence_updates_with_identical_messages(face_presence_instance, mock_io_provider):
+    """
+    Verify that the system can handle continuous updates of the same message, simulating a person staying in camera view, without skipping or dropping messages.
+    """
+    identical_message = "In Camera View: 1 known (alice)."
+
+    for i in range(5):
+        face_presence_instance._handle_face_message(identical_message)
+
+        raw_input = await face_presence_instance._poll()
+        assert raw_input == identical_message, f"Poll #{i+1} should return the message"
+        await face_presence_instance.raw_to_text(raw_input)
+
+        result = face_presence_instance.formatted_latest_buffer()
+        assert result is not None, f"formatted_latest_buffer() should work on iteration #{i+1}"
+        assert "Face Presence Sensor" in result
+        assert identical_message in result
+        assert len(face_presence_instance.messages) == 0
+    assert mock_io_provider.add_input.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_face_presence_buffer_cleared_and_refilled(face_presence_instance):
+    """
+    Verify that the message buffer can be cleared and refilled multiple times
+    with the same message, simulating a person staying in camera view.
+    """
+    message = "In Camera View: 1 known (bob)."
+
+    face_presence_instance._handle_face_message(message)
+    assert face_presence_instance.message_buffer.qsize() == 1
+
+    face_presence_instance._handle_face_message(message)
+    assert face_presence_instance.message_buffer.qsize() == 1, "Buffer should only have 1 message (old ones cleared)"
+
+    face_presence_instance._handle_face_message(message)
+    assert face_presence_instance.message_buffer.qsize() == 1

--- a/tests/providers/test_face_presence_provider.py
+++ b/tests/providers/test_face_presence_provider.py
@@ -180,3 +180,54 @@ def test_emit_invokes_callbacks(monkeypatch):
 
     assert got, "callback should be invoked"
     assert "In Camera View: 2 known (alice and bob) and 1 unknown face." in got[0]
+
+
+def test_emit_invokes_callbacks_even_with_identical_text(monkeypatch):
+    """
+    Regression test: ensure _emit() calls callbacks every time,
+    even when the text hasn't changed. This ensures continuous
+    refreshing of the input buffer.
+    """
+    provider = FacePresenceProvider(base_url="http://fake", recent_sec=3.0)
+    call_count = []
+
+    def cb(line: str):
+        call_count.append(line)
+
+    provider.register_message_callback(cb)
+
+    text = "In Camera View: 1 known (alice)."
+    provider._emit(text)
+    provider._emit(text)
+    provider._emit(text)
+
+    assert len(call_count) == 3, "callback should be invoked every time, even with identical text"
+    assert all(t == text for t in call_count)
+
+
+def test_emit_with_multiple_callbacks(monkeypatch):
+    """
+    Verify that all registered callbacks receive the same message,
+    even when called multiple times with identical text.
+    """
+    provider = FacePresenceProvider(base_url="http://fake", recent_sec=3.0)
+
+    calls_1 = []
+    calls_2 = []
+
+    def cb1(line: str):
+        calls_1.append(line)
+
+    def cb2(line: str):
+        calls_2.append(line)
+
+    provider.register_message_callback(cb1)
+    provider.register_message_callback(cb2)
+
+    text = "In Camera View: 1 known (bob)."
+    provider._emit(text)
+    provider._emit(text)
+
+    assert len(calls_1) == 2
+    assert len(calls_2) == 2
+    assert calls_1 == calls_2 == [text, text]


### PR DESCRIPTION
This pull request updates the face presence provider to always emit presence updates to subscribers, even if the message text is identical to the previous one. The change ensures that callbacks and input buffers are consistently refreshed, which is especially important for scenarios where continuous updates are required (e.g., a person remains in camera view). The test suite is expanded to verify this new behavior and to guard against regressions.

Core logic changes:

* Removed the logic in `FacePresenceProvider._emit` that suppressed emitting messages if the text was unchanged, so callbacks are now always invoked regardless of message content. [[1]](diffhunk://#diff-dd54955dad71fa39e2369e1ac8148c2914b6a0dda95816f13d923dadbbc3e3c6L168) [[2]](diffhunk://#diff-dd54955dad71fa39e2369e1ac8148c2914b6a0dda95816f13d923dadbbc3e3c6L258-L269)

Testing improvements:

* Added tests in `tests/providers/test_face_presence_provider.py` to confirm that callbacks are invoked every time `_emit` is called, even with identical text, and that all registered callbacks receive the message.
* Added async tests in `tests/inputs/plugins/test_face_presence_input.py` to verify that continuous updates with identical messages are handled correctly, and that the message buffer is managed as expected when the same message is repeatedly processed.