### PR TITLE
Add environment config to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      deployments: write
     needs: [ build-amd64, build-arm64 ]
     environment:
       name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || github.ref == 'refs/heads/main' && 'production' || 'staging' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
       id-token: write
       contents: read
     needs: [ build-amd64, build-arm64 ]
+    environment:
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+      url: https://gallery.ecr.aws/b8k9c8n5/openmind/om1
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
Add an environment stanza to the release job that sets the environment name dynamically (production for v* tags and main, staging otherwise) and sets the environment URL to the ECR gallery. This enables GitHub environment features/deployment protections for releases.