### PR TITLE
Simplify environment selection in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
       deployments: write
     needs: [ build-amd64, build-arm64 ]
     environment:
-      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
       url: https://gallery.ecr.aws/b8k9c8n5/openmind/om1
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
Change the GitHub Actions release workflow to set environment.name to 'production' only for refs/tags/v*; all other refs now use 'staging'. Removed the previous special-case that treated refs/heads/main as production to avoid unintended production deployments from the main branch.