### PR TITLE
Comment out ASR.stop() and add TODO

### DIFF
--- a/src/inputs/plugins/google_asr.py
+++ b/src/inputs/plugins/google_asr.py
@@ -340,9 +340,13 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             except Exception as e:
                 logging.warning(f"Failed to close Zenoh ASR session: {e}")
 
-        if self.asr:
-            try:
-                self.asr.stop()
-                logging.info("ASR provider stopped")
-            except Exception as e:
-                logging.warning(f"Failed to stop ASR provider: {e}")
+        # Todo:
+        # Consider sending the TTS status multiple times to ASR provider to ensure that
+        # the ASR provider properly receives the interrupt signal,
+        # especially in cases where the mode switch happens during TTS playback
+        # if self.asr:
+        #     try:
+        #         self.asr.stop()
+        #         logging.info("ASR provider stopped")
+        #     except Exception as e:
+        #         logging.warning(f"Failed to stop ASR provider: {e}")

--- a/src/inputs/plugins/google_asr.py
+++ b/src/inputs/plugins/google_asr.py
@@ -340,7 +340,7 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             except Exception as e:
                 logging.warning(f"Failed to close Zenoh ASR session: {e}")
 
-        # Todo:
+        # TODO:
         # Consider sending the TTS status multiple times to ASR provider to ensure that
         # the ASR provider properly receives the interrupt signal,
         # especially in cases where the mode switch happens during TTS playback


### PR DESCRIPTION
In src/inputs/plugins/google_asr.py, the shutdown logic that called self.asr.stop() has been commented out and replaced with a TODO note. The TODO suggests considering sending the TTS status multiple times to the ASR provider to ensure it receives the interrupt signal (particularly when mode switches occur during TTS playback). The original stop() call is left commented for reference so the behavior can be revisited when a more robust interrupt strategy is implemented.