### PR TITLE
Increase default max_turn_count to 5

### DIFF
--- a/src/providers/greeting_conversation_state_provider.py
+++ b/src/providers/greeting_conversation_state_provider.py
@@ -231,7 +231,15 @@ class ConfidenceCalculator:
 class GreetingConversationStateMachineProvider:
     """Manages greeting conversation state transitions based on confidence scores."""
 
-    def __init__(self, max_turn_count: int = 3) -> None:
+    def __init__(self, max_turn_count: int = 5) -> None:
+        """
+        Initialize the state machine with default values.
+
+        Parameters
+        ----------
+        max_turn_count : int, optional
+            Maximum number of conversational turns before forcing a transition to finished (default is 5).
+        """
         self.current_state = ConversationState.IDLE
         self.previous_state = None
         self.state_entry_time = time.time()


### PR DESCRIPTION
Update GreetingConversationStateMachineProvider.__init__ to use a default max_turn_count of 5 instead of 3 and add a brief docstring documenting the initializer and the max_turn_count parameter. This increases the allowed number of conversational turns before forcing a transition to finished; no other logic changes were made.