### PR TITLE
fix: correct typo 'geeting' -> 'greeting' in hook name, class, and co…

### DIFF
--- a/config/greeting.json5
+++ b/config/greeting.json5
@@ -117,7 +117,7 @@
           handler_type: "function",
           handler_config: {
             module_name: "greeting_hook",
-            function: "geeting_end_hook",
+            function: "greeting_end_hook",
             tts_provider: "elevenlabs",
             voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
           },

--- a/config/greeting_conversation.json5
+++ b/config/greeting_conversation.json5
@@ -133,7 +133,7 @@ Visa reference: Sarthak - Senior Director, Visa; previously Visa and Gojek; 8+ y
           handler_type: "function",
           handler_config: {
             module_name: "greeting_hook",
-            function: "geeting_end_hook",
+            function: "greeting_end_hook",
             tts_provider: "elevenlabs",
             voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
           },

--- a/config/greeting_local.json5
+++ b/config/greeting_local.json5
@@ -102,7 +102,7 @@
           handler_type: "function",
           handler_config: {
             module_name: "greeting_hook",
-            function: "geeting_end_hook",
+            function: "greeting_end_hook",
             tts_provider: "kokoro",
             model_id: "${KOKORO_MODEL_ID:-mlx-community/Kokoro-82M-bf16}",
             base_url: "${KOKORO_BASE_URL:-http://omr2.local:8880}/v1",

--- a/config/greeting_parallel.json5
+++ b/config/greeting_parallel.json5
@@ -125,7 +125,7 @@
           handler_type: "function",
           handler_config: {
             module_name: "greeting_hook",
-            function: "geeting_end_hook",
+            function: "greeting_end_hook",
             tts_provider: "elevenlabs",
             voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
           },

--- a/src/hooks/greeting_hook.py
+++ b/src/hooks/greeting_hook.py
@@ -12,9 +12,9 @@ from providers.kokoro_tts_provider import KokoroTTSProvider
 from providers.riva_tts_provider import RivaTTSProvider
 
 
-class GeetingHookContext(BaseModel):
+class GreetingHookContext(BaseModel):
     """
-    Configuration for geeting hooks.
+    Configuration for greeting hooks.
 
     Parameters
     ----------
@@ -106,7 +106,7 @@ async def greeting_start_hook(context: Dict[str, Any]):
     context : Dict[str, Any]
         Context dictionary containing relevant information for the hook.
     """
-    ctx = GeetingHookContext(**context)
+    ctx = GreetingHookContext(**context)
 
     tts_provider = ctx.tts_provider.lower()
     provider = None
@@ -167,7 +167,7 @@ async def greeting_start_hook(context: Dict[str, Any]):
         return False
 
 
-async def geeting_end_hook(context: Dict[str, Any]):
+async def greeting_end_hook(context: Dict[str, Any]):
     """
     Hook to handle the end of a greeting conversation.
 
@@ -176,7 +176,7 @@ async def geeting_end_hook(context: Dict[str, Any]):
     context : Dict[str, Any]
         Context dictionary containing relevant information for the hook.
     """
-    ctx = GeetingHookContext(**context)
+    ctx = GreetingHookContext(**context)
 
     tts_provider = ctx.tts_provider.lower()
     provider = None
@@ -231,5 +231,5 @@ async def geeting_end_hook(context: Dict[str, Any]):
         return True
 
     except Exception:
-        logging.exception("Error in geeting_end_hook")
+        logging.exception("Error in greeting_end_hook")
         return False

--- a/tests/hooks/test_greeting_hook.py
+++ b/tests/hooks/test_greeting_hook.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from hooks.greeting_hook import GeetingHookContext, geeting_end_hook, greeting_start_hook
+from hooks.greeting_hook import GreetingHookContext, greeting_end_hook, greeting_start_hook
 
 
 class TestGeetingHookContext:
@@ -10,7 +10,7 @@ class TestGeetingHookContext:
 
     def test_context_default_values(self):
         """Test context model with default values."""
-        context = GeetingHookContext()
+        context = GreetingHookContext()
         assert context.message == ""
         assert context.tts_provider == "elevenlabs"
         assert context.base_url is None
@@ -26,7 +26,7 @@ class TestGeetingHookContext:
 
     def test_context_custom_values(self):
         """Test context model with custom values."""
-        context = GeetingHookContext(
+        context = GreetingHookContext(
             message="Hello, world!",
             tts_provider="kokoro",
             base_url="http://localhost:8880",
@@ -55,7 +55,7 @@ class TestGeetingHookContext:
 
     def test_context_extra_fields_allowed(self):
         """Test that extra fields are allowed in the context."""
-        context = GeetingHookContext(message="Test", extra_field="extra_value")  # type: ignore
+        context = GreetingHookContext(message="Test", extra_field="extra_value")  # type: ignore
         # Should not raise an error due to Config.extra = "allow"
         assert context.message == "Test"
 
@@ -579,7 +579,7 @@ class TestGreetingStartHook:
 
 
 class TestGeetingEndHook:
-    """Tests for geeting_end_hook function."""
+    """Tests for greeting_end_hook function."""
 
     @pytest.mark.asyncio
     async def test_hook_with_elevenlabs_default_params(self, mock_elevenlabs_provider, mock_greeting_state_provider):
@@ -595,7 +595,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             mock_provider_class.assert_called_once()
@@ -636,7 +636,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             call_kwargs = mock_provider_class.call_args[1]
@@ -663,7 +663,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_kokoro_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             call_kwargs = mock_provider_class.call_args[1]
@@ -699,7 +699,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_kokoro_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             call_kwargs = mock_provider_class.call_args[1]
@@ -725,7 +725,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_riva_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             call_kwargs = mock_provider_class.call_args[1]
@@ -751,7 +751,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_riva_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             call_kwargs = mock_provider_class.call_args[1]
@@ -772,7 +772,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             mock_elevenlabs_provider.start.assert_called_once()
@@ -795,7 +795,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_kokoro_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             message = mock_kokoro_provider.add_pending_message.call_args[0][0]
@@ -815,7 +815,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_riva_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             mock_riva_provider.start.assert_called_once()
@@ -831,7 +831,7 @@ class TestGeetingEndHook:
         with patch("hooks.greeting_hook.GreetingConversationStateMachineProvider") as mock_state_class:
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -848,7 +848,7 @@ class TestGeetingEndHook:
             mock_provider_class.side_effect = Exception("Provider initialization failed")
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -866,7 +866,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -883,7 +883,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             mock_provider_class.assert_called_once()
@@ -902,10 +902,10 @@ class TestGeetingEndHook:
             mock_provider_class.side_effect = ValueError("Test error")
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
-            assert "Error in geeting_end_hook" in caplog.text
+            assert "Error in greeting_end_hook" in caplog.text
             assert "Test error" in caplog.text
 
     @pytest.mark.asyncio
@@ -920,7 +920,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.side_effect = Exception("State provider failed")
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -937,7 +937,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
 
@@ -954,7 +954,7 @@ class TestGeetingEndHook:
             mock_provider_class.side_effect = Exception("Test error")
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -972,7 +972,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is False
 
@@ -993,7 +993,7 @@ class TestGeetingEndHook:
             mock_provider_class.return_value = mock_elevenlabs_provider
             mock_state_class.return_value = mock_greeting_state_provider
 
-            result = await geeting_end_hook(context)
+            result = await greeting_end_hook(context)
 
             assert result is True
             assert "Greeting conversation ended due to maximum turn count" in caplog.text


### PR DESCRIPTION
## Changes
- Renamed `GeetingHookContext` -> `GreetingHookContext`
- Renamed `geeting_end_hook` -> `greeting_end_hook`
- Fixed docstring: "Configuration for geeting hooks" -> "Configuration for greeting hooks"
- Updated function reference in 4 config files (greeting.json5, greeting_local.json5, greeting_parallel.json5, greeting_conversation.json5)
