### PR TITLE
Make Unitree OM connector Zenoh-only

### DIFF
--- a/config/cloud_sim.json5
+++ b/config/cloud_sim.json5
@@ -10,20 +10,12 @@
   agent_inputs: [
     {
       type: "UnitreeGo2OdomZenoh",
-      config: {
-        topic: "odom",
-      },
     },
     {
       type: "GoogleASRInput",
     },
     {
       type: "VLMGeminiZenoh",
-      config: {
-        topic: "camera/realsense2_camera_node/color/image_raw",
-        model: "gemini-2.5-flash",
-        max_tokens: 2048,
-      },
     },
     {
       type: "SimplePaths",
@@ -40,13 +32,7 @@
     {
       name: "move_go2_autonomy",
       llm_label: "move",
-      connector: "unitree_om_path_sdk_cloud",
-      config: {
-        use_zenoh: true,
-        move_via_sport_api: false,
-        cmd_vel_topic: "cmd_vel",
-        permissive_paths: true,
-      },
+      connector: "unitree_om_path_sdk_zenoh",
     },
     {
       name: "speak",

--- a/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk_zenoh.py
+++ b/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk_zenoh.py
@@ -11,9 +11,8 @@ from actions.base import ActionConfig, ActionConnector, MoveCommand
 from actions.move_go2_autonomy.interface import MoveInput
 from providers.face_presence_provider import FacePresenceProvider
 from providers.simple_paths_provider import SimplePathsProvider
-from providers.unitree_go2_odom_provider import RobotState, UnitreeGo2OdomProvider
+from providers.unitree_go2_odom_provider import RobotState
 from providers.unitree_go2_odom_zenoh_provider import UnitreeGo2OdomZenohProvider
-from providers.unitree_go2_state_provider import UnitreeGo2StateProvider
 from providers.unitree_go2_state_zenoh_provider import UnitreeGo2StateZenohProvider
 from zenoh_msgs import (
     AIStatusRequest,
@@ -27,100 +26,49 @@ from zenoh_msgs import (
     open_zenoh_session,
     prepare_header,
 )
-from zenoh_msgs.idl.geometry_msgs import Twist, Vector3
 
-# Unitree Sport API IDs we care about for autonomous movement.
-# Mirrors src/unitree/unitree_sdk2py/go2/sport/sport_api.py.
 SPORT_API_ID_MOVE = 1008
 SPORT_API_ID_STOPMOVE = 1003
 SPORT_API_ID_BALANCESTAND = 1002
 
-# SportClient is CycloneDDS-only and not available when running through
-# cloud_sim. Import lazily so the connector can still load in Zenoh-only setups.
-try:
-    from unitree.unitree_sdk2py.go2.sport.sport_client import SportClient  # type: ignore
-except ImportError:
-    SportClient = None  # type: ignore[assignment]
 
-
-class MoveUnitreeOMPathSDKCloudConfig(ActionConfig):
+class MoveUnitreeOMPathSDKZenohConfig(ActionConfig):
     """
-    Configuration for MoveUnitreeOMPathSDKCloudConfig connector.
+    Configuration for MoveUnitreeOMPathSDKZenohConfig connector.
+
+    This connector uses Zenoh exclusively for all communication,
+    publishing unitree_api/Request messages to api/sport/request.
 
     Parameters
     ----------
-    unitree_ethernet : str
-        Ethernet channel for Unitree Go2 odometry data (CycloneDDS path only).
     mode : Optional[str]
         Operation mode, e.g., "guard".
-    use_zenoh : bool
-        When True, route odometry/state subscriptions and motor commands
-        through Zenoh instead of CycloneDDS. Required when OM1 is not on
-        the same DDS domain as the robot/sim (e.g. cloud-routed setups).
-    cmd_vel_topic : str
-        Zenoh keyexpression for the velocity command publisher when
-        ``use_zenoh=True`` and ``move_via_sport_api=False``.
-    move_via_sport_api : bool
-        When True (and ``use_zenoh=True``), publish ``unitree_api/Request``
-        to ``api/sport/request`` instead of raw ``cmd_vel`` — same wire
-        format ``SportClient.Move()`` uses on a real Go2.
     sport_request_topic : str
         Zenoh keyexpression for sport-API publishes.
-    permissive_paths : bool
-        Disable obstacle-avoidance gating in ``SimplePathsProvider``. Used
-        for sim/testing in empty environments; movement requests proceed
-        even when no path data is available.
     """
 
-    unitree_ethernet: str = Field(
-        default="eth0",
-        description="Ethernet channel for Unitree Go2 odometry data.",
-    )
     mode: Optional[str] = Field(
         default=None,
         description='Operation mode, e.g., "guard".',
     )
-    use_zenoh: bool = Field(
-        default=False,
-        description="Route odom/state/motor commands through Zenoh (cloud_sim) instead of CycloneDDS.",
-    )
-    cmd_vel_topic: str = Field(
-        default="cmd_vel",
-        description="Zenoh keyexpression for cmd_vel Twist publish (use_zenoh path only).",
-    )
-    move_via_sport_api: bool = Field(
-        default=False,
-        description=(
-            "When True (and use_zenoh=True), publish unitree_api/Request "
-            "to api/sport/request — same wire format SportClient.Move() "
-            "uses on a real Go2. The downstream consumer (real robot or "
-            "go2_sport_node in sim) translates this to /cmd_vel."
-        ),
-    )
     sport_request_topic: str = Field(
         default="api/sport/request",
-        description="Zenoh keyexpression for sport-API publishes (move_via_sport_api only).",
-    )
-    permissive_paths: bool = Field(
-        default=False,
-        description=(
-            "Disable obstacle-avoidance gating in SimplePathsProvider. "
-            "Movement proceeds even when /om/paths data is unavailable. "
-            "For sim/testing in empty environments only."
-        ),
+        description="Zenoh keyexpression for sport-API publishes.",
     )
 
 
-class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKCloudConfig, MoveInput]):
+class MoveUnitreeOMPathSDKZenohConnector(ActionConnector[MoveUnitreeOMPathSDKZenohConfig, MoveInput]):
     """
-    Connector for moving Unitree Go2 robot using OM Path SDK for obstacle detection.
+    Zenoh-based connector for moving Unitree Go2 robot using OM Path SDK for obstacle detection.
 
     This plugin loads the possible paths from the SimplePathsProvider and uses them to
     safely execute movement commands received from the AI system. The SimplePathsProvider
     includes both obstacle detection and slope detection for safer navigation.
+
+    All communication is routed through Zenoh for cloud/distributed deployments.
     """
 
-    def __init__(self, config: MoveUnitreeOMPathSDKCloudConfig):
+    def __init__(self, config: MoveUnitreeOMPathSDKZenohConfig):
         """
         Initialize the MoveUnitreeOMPathSDKCloudConnector connector.
 
@@ -146,76 +94,31 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         self.path_provider = SimplePathsProvider()
         self.face_presence_provider = FacePresenceProvider()
 
-        self.use_zenoh = bool(self.config.use_zenoh)
-        self.move_via_sport_api = bool(self.config.move_via_sport_api)
-        self.permissive_paths = bool(self.config.permissive_paths)
-        if self.permissive_paths:
-            logging.warning(
-                "MoveUnitreeOMPathSDK: permissive_paths=True — obstacle "
-                "avoidance disabled. Intended for empty-environment sim only."
-            )
-        if self.move_via_sport_api and not self.use_zenoh:
-            raise ValueError("move_via_sport_api requires use_zenoh=true")
-        self._cmd_vel_pub = None
-        self.sport_client = None
+        # Initialize Zenoh-based providers
+        logging.info("MoveUnitreeOMPathSDK: Zenoh mode (publishing to '%s')", self.config.sport_request_topic)
+        self.unitree_go2_state = UnitreeGo2StateZenohProvider()
+        self.odom = UnitreeGo2OdomZenohProvider()
 
-        if self.use_zenoh:
-            sink = "api/sport/request" if self.move_via_sport_api else "cmd_vel"
-            logging.info("MoveUnitreeOMPathSDK: Zenoh mode (publishing to '%s')", sink)
-            self.unitree_go2_state = UnitreeGo2StateZenohProvider()
-            self.odom = UnitreeGo2OdomZenohProvider()
-        else:
-            if SportClient is not None:
-                try:
-                    self.sport_client = SportClient()
-                    self.sport_client.SetTimeout(10.0)
-                    self.sport_client.Init()
-                    self.sport_client.StopMove()
-                    self.sport_client.Move(0.05, 0, 0)
-                    logging.info("Autonomy Unitree sport client initialized")
-                except Exception as e:
-                    logging.error(f"Error initializing Unitree sport client: {e}")
-            else:
-                logging.error(
-                    "SportClient unavailable (unitree_sdk2py / cyclonedds not installed). "
-                    "Set use_zenoh=true in the connector config to run through cloud_sim instead."
-                )
-
-            unitree_ethernet = self.config.unitree_ethernet
-            if unitree_ethernet is None:
-                raise ValueError("unitree_ethernet must be specified in the config")
-            self.unitree_go2_state = UnitreeGo2StateProvider()
-            self.odom = UnitreeGo2OdomProvider(channel=unitree_ethernet)
-
-        # Zenoh session — used for AI control status messages always, and
-        # for the cmd_vel / api/sport/request publisher when use_zenoh=True.
+        # Zenoh session for publishers and subscribers
         self.ai_status_request = "om/ai/request"
         self.ai_status_response = "om/ai/response"
         self.session: Optional[ZenohSessionType] = None
-        self.pub = None
         self._sport_pub = None
 
         try:
             self.session = open_zenoh_session()
             self.session.declare_subscriber(self.ai_status_request, self._zenoh_ai_status_request)
             self._zenoh_ai_status_response_pub = self.session.declare_publisher(self.ai_status_response)
-            if self.use_zenoh:
-                if self.move_via_sport_api:
-                    self._sport_pub = self.session.declare_publisher(self.config.sport_request_topic)
-                    logging.info(
-                        "MoveUnitreeOMPathSDK: sport-API publisher armed on Zenoh key '%s'",
-                        self.config.sport_request_topic,
-                    )
-                else:
-                    self._cmd_vel_pub = self.session.declare_publisher(self.config.cmd_vel_topic)
-                    logging.info(
-                        "MoveUnitreeOMPathSDK: cmd_vel publisher armed on Zenoh key '%s'",
-                        self.config.cmd_vel_topic,
-                    )
+
+            self._sport_pub = self.session.declare_publisher(self.config.sport_request_topic)
+            logging.info(
+                "MoveUnitreeOMPathSDK: sport-API publisher armed on Zenoh key '%s'",
+                self.config.sport_request_topic,
+            )
         except Exception as e:
             logging.error(f"Error opening Zenoh client: {e}")
             self.session = None
-            self.pub = None
+            self._sport_pub = None
 
         # AI control status
         self.ai_control_enabled = True
@@ -243,10 +146,6 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         if not self.ai_control_enabled:
             logging.info("AI Control is disabled - disregarding AI command")
             return
-
-        if self.unitree_go2_state.state_code == 1002 and self.sport_client:
-            logging.info("Robot is in jointLock state - issuing BalanceStand()")
-            self.sport_client.BalanceStand()
 
         if self.unitree_go2_state.action_progress != 0:
             logging.info(f"Action in progress: {self.unitree_go2_state.action_progress}")
@@ -307,7 +206,7 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
 
     def _move_robot(self, vx: float, vy: float, vturn=0.0) -> None:
         """
-        Move the robot with specified velocities.
+        Move the robot with specified velocities via Zenoh sport API.
 
         Parameters
         ----------
@@ -320,47 +219,17 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         logging.info(f"_move_robot: vx={vx}, vy={vy}, vturn={vturn}")
 
-        if self.use_zenoh:
-            if self.odom.position["body_attitude"] is RobotState.SITTING:
-                return
-
-            if self.move_via_sport_api:
-                if self._sport_pub is None:
-                    logging.warning("_move_robot: sport publisher not ready")
-                    return
-                try:
-                    self._publish_sport_move(float(vx), float(vy), float(vturn))
-                except Exception as e:
-                    logging.error(f"Error publishing api/sport/request: {e}")
-                return
-
-            if self._cmd_vel_pub is None:
-                logging.warning("_move_robot: Zenoh cmd_vel publisher not ready")
-                return
-            try:
-                twist = Twist(
-                    linear=Vector3(x=float(vx), y=float(vy), z=0.0),
-                    angular=Vector3(x=0.0, y=0.0, z=float(vturn)),
-                )
-                self._cmd_vel_pub.put(twist.serialize())
-            except Exception as e:
-                logging.error(f"Error publishing cmd_vel via Zenoh: {e}")
+        if self.odom.position["body_attitude"] is RobotState.SITTING:
             return
 
-        if not self.sport_client:
+        if self._sport_pub is None:
+            logging.warning("_move_robot: sport publisher not ready")
             return
-
-        if self.odom.position["body_attitude"] != RobotState.STANDING:
-            return
-
-        if self.unitree_go2_state.state == "jointLock":
-            self.sport_client.BalanceStand()
 
         try:
-            logging.info(f"self.sport_client.Move: vx={vx}, vy={vy}, vturn={vturn}")
-            self.sport_client.Move(vx, vy, vturn)
+            self._publish_sport_move(float(vx), float(vy), float(vturn))
         except Exception as e:
-            logging.error(f"Error moving robot: {e}")
+            logging.error(f"Error publishing api/sport/request: {e}")
 
     def clean_abort(self) -> None:
         """
@@ -382,27 +251,16 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
             return
 
         if self.odom.position["odom_x"] == 0.0 and self.odom.position["odom_subscriber_ts"] == 0.0:
-            # See connect() — sim odom starts at exactly (0,0). Use the
-            # subscriber timestamp as the "first sample arrived" signal.
             logging.info("Waiting for odom data")
             self.sleep(0.5)
             return
 
-        # In Zenoh mode the odom message may be a raw nav_msgs/Odometry with
-        # no charging-aware z-offset, so body_attitude never classifies as
-        # STANDING. Treat ``None`` as "no info, proceed".
         attitude = self.odom.position["body_attitude"]
         if attitude is RobotState.SITTING:
             logging.info("Cannot move - dog is sitting")
             self.sleep(0.5)
             return
-        if not self.use_zenoh and attitude != RobotState.STANDING:
-            logging.info("Cannot move - dog is sitting")
-            self.sleep(0.5)
-            return
 
-        # if we got to this point, we have good data and we are able to
-        # safely proceed
         target: List[MoveCommand] = list(self.pending_movements.queue)
 
         if len(target) > 0:
@@ -473,14 +331,14 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
 
                 fb = 0
                 if goal_dx > 0:
-                    if 4 not in self.path_provider.advance and not self.permissive_paths:
+                    if 4 not in self.path_provider.advance:
                         logging.warning("Cannot advance due to barrier")
                         self.clean_abort()
                         return
                     fb = 1
 
                 if goal_dx < 0:
-                    if not self.path_provider.retreat and not self.permissive_paths:
+                    if not self.path_provider.retreat:
                         logging.warning("Cannot retreat due to barrier")
                         self.clean_abort()
                         return
@@ -501,10 +359,17 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         self.sleep(0.1)
 
     def _publish_sport_move(self, vx: float, vy: float, vyaw: float) -> None:
-        """Build a unitree_api/Request matching what SportClient.Move() would
-        emit (api_id=1008, parameter=JSON of x/y/z velocities) and put it on
-        the configured sport-request key. OM1-sim's go2_sport_node decodes
-        this and publishes /cmd_vel.
+        """
+        Publish a movement command to the sport API via Zenoh.
+
+        Parameters
+        ----------
+        vx : float
+            Linear velocity in the x direction (m/s).
+        vy : float
+            Linear velocity in the y direction (m/s).
+        vyaw : float
+            Angular velocity (turning speed) in radians per second.
         """
         identity = UnitreeRequestIdentity(id=0, api_id=SPORT_API_ID_MOVE)
         header = UnitreeRequestHeader(identity=identity)
@@ -520,8 +385,15 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         self._sport_pub.put(request.serialize())
 
     def _pick_path_angle(self, available: list, default: float = 0.0) -> float:
-        """Pick a heading from the SimplePathsProvider candidate list. In
-        permissive mode, fall back to ``default`` when the list is empty.
+        """
+        Pick a path angle from available options, or return default if none.
+
+        Parameters
+        ----------
+        available : list
+            List of available path angles from the path provider.
+        default : float, optional
+            Default angle to use if no paths are available (default is 0.0).
         """
         if available:
             idx = random.choice(available)
@@ -532,7 +404,7 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         Process turn left command with safety check.
         """
-        if not self.path_provider.turn_left and not self.permissive_paths:
+        if not self.path_provider.turn_left:
             logging.warning("Cannot turn left due to barrier")
             return
 
@@ -554,7 +426,7 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         Process turn right command with safety check.
         """
-        if not self.path_provider.turn_right and not self.permissive_paths:
+        if not self.path_provider.turn_right:
             logging.warning("Cannot turn right due to barrier")
             return
 
@@ -575,7 +447,7 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         Process move forward command with safety check.
         """
-        if not self.path_provider.advance and not self.permissive_paths:
+        if not self.path_provider.advance:
             logging.warning("Cannot advance due to barrier")
             return
 
@@ -596,7 +468,7 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         Process move back command with safety check.
         """
-        if not self.path_provider.retreat and not self.permissive_paths:
+        if not self.path_provider.retreat:
             logging.warning("Cannot retreat due to barrier")
             return
 
@@ -670,19 +542,12 @@ class MoveUnitreeOMPathSDKCloudConnector(ActionConnector[MoveUnitreeOMPathSDKClo
         """
         if gap > 0:  # Turn left
             if not self.path_provider.turn_left:
-                if not self.permissive_paths:
-                    logging.warning("Cannot turn left due to barrier")
-                    return False
-                # Permissive default — moderate forward speed while turning.
                 self._move_robot(0.3, 0, self.turn_speed)
                 return True
             sharpness = min(self.path_provider.turn_left)
             self._move_robot(sharpness * 0.15, 0, self.turn_speed)
         else:  # Turn right
             if not self.path_provider.turn_right:
-                if not self.permissive_paths:
-                    logging.warning("Cannot turn right due to barrier")
-                    return False
                 self._move_robot(0.3, 0, -self.turn_speed)
                 return True
             sharpness = 8 - max(self.path_provider.turn_right)

--- a/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk_zenoh.py
+++ b/src/actions/move_go2_autonomy/connector/unitree_om_path_sdk_zenoh.py
@@ -543,13 +543,13 @@ class MoveUnitreeOMPathSDKZenohConnector(ActionConnector[MoveUnitreeOMPathSDKZen
         if gap > 0:  # Turn left
             if not self.path_provider.turn_left:
                 self._move_robot(0.3, 0, self.turn_speed)
-                return True
+                return False
             sharpness = min(self.path_provider.turn_left)
             self._move_robot(sharpness * 0.15, 0, self.turn_speed)
         else:  # Turn right
             if not self.path_provider.turn_right:
                 self._move_robot(0.3, 0, -self.turn_speed)
-                return True
+                return False
             sharpness = 8 - max(self.path_provider.turn_right)
             self._move_robot(sharpness * 0.15, 0, -self.turn_speed)
         return True

--- a/src/backgrounds/plugins/unitree_go2_state_zenoh.py
+++ b/src/backgrounds/plugins/unitree_go2_state_zenoh.py
@@ -1,20 +1,5 @@
-"""Background that keeps a Zenoh-routed Go2 SportModeState provider alive.
-
-Surface-compatible with ``UnitreeGo2State``. The underlying provider
-subscribes to Zenoh key ``sportmodestate``.
-
-``/sportmodestate`` is only published by the real Go2 firmware, so when
-running against a sim this background sits idle — downstream code treats
-``state_code is None`` as "no info, proceed".
-
-    backgrounds: [
-        { type: "UnitreeGo2StateZenoh" },
-    ]
-"""
-
-from __future__ import annotations
-
 import logging
+from typing import Optional
 
 from pydantic import Field
 
@@ -23,24 +8,37 @@ from providers.unitree_go2_state_zenoh_provider import UnitreeGo2StateZenohProvi
 
 
 class UnitreeGo2StateZenohConfig(BackgroundConfig):
-    """Configuration for ``UnitreeGo2StateZenoh``.
+    """
+    Configuration for the Unitree Go2 State Zenoh background.
 
     Parameters
     ----------
-    topic : str
-        Zenoh key to subscribe to. Default ``sportmodestate``.
+    api_key : Optional[str]
+        API Key for Zenoh session, if required.
+    use_sim : bool
+        Whether to use the simulation Zenoh endpoint instead of a local one.
     """
 
-    topic: str = Field(
-        default="sportmodestate",
-        description="Zenoh key for Go2 SportModeState.",
+    api_key: Optional[str] = Field(default=None, description="API Key for Zenoh session, if required.")
+    use_sim: bool = Field(
+        default=False,
+        description="Whether to use the simulation Zenoh endpoint instead of a local one.",
     )
 
 
 class UnitreeGo2StateZenoh(Background[UnitreeGo2StateZenohConfig]):
-    """Zenoh-routed Go2 SportModeState background."""
+    """Background that subscribes to the Unitree Go2 SportModeState over Zenoh."""
 
     def __init__(self, config: UnitreeGo2StateZenohConfig):
+        """
+        Initialize the background and start the Zenoh subscriber.
+
+        Parameters
+        ----------
+        config : UnitreeGo2StateZenohConfig
+            Configuration for the background.
+        """
         super().__init__(config)
-        self.unitree_go2_state_provider = UnitreeGo2StateZenohProvider(topic=self.config.topic)
+
+        self.unitree_go2_state_provider = UnitreeGo2StateZenohProvider(self.config.api_key, self.config.use_sim)
         logging.info("Unitree Go2 State Zenoh Provider initialized in background")

--- a/src/inputs/plugins/google_asr.py
+++ b/src/inputs/plugins/google_asr.py
@@ -152,9 +152,6 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         remote_input = self.config.remote_input
         enable_tts_interrupt = self.config.enable_tts_interrupt
 
-        # Guard flag: when True, this instance ignores incoming ASR messages.
-        self._stopped = False
-
         self.asr: ASRProvider = ASRProvider(
             rate=rate,
             chunk=chunk,
@@ -188,6 +185,9 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             logging.warning(f"Could not initialize Zenoh for ASR broadcast: {e}")
             self.session = None
             self.asr_publisher = None
+
+        # Guard flag: when True, this instance ignores incoming ASR messages.
+        self._stopped = False
 
     def _handle_asr_message(self, raw_message: str):
         """

--- a/src/inputs/plugins/unitree_go2_battery_zenoh.py
+++ b/src/inputs/plugins/unitree_go2_battery_zenoh.py
@@ -100,15 +100,20 @@ class UnitreeGo2BatteryZenoh(FuserInput[UnitreeGo2BatteryZenohConfig, List[float
         Push the latest battery snapshot to the teleops status channel.
         """
         with self._lock:
-            level, t, v = self.battery_percentage, self.battery_t, self.battery_voltage
+            battery_percentage, battery_t, battery_voltage = (
+                self.battery_percentage,
+                self.battery_t,
+                self.battery_voltage,
+            )
+
         self.status_provider.share_status(
             TeleopsStatus(
                 machine_name="UnitreeGo2",
                 update_time=str(time.time()),
                 battery_status=BatteryStatus(
-                    battery_level=level,
-                    temperature=t,
-                    voltage=v,
+                    battery_level=battery_percentage,
+                    temperature=battery_t,
+                    voltage=battery_voltage,
                     timestamp=str(time.time()),
                     charging_status=False,
                 ),

--- a/src/inputs/plugins/vlm_gemini.py
+++ b/src/inputs/plugins/vlm_gemini.py
@@ -73,6 +73,11 @@ class VLMGemini(FuserInput[VLMGeminiConfig, Optional[str]]):
 
         Sets up the required providers and buffers for handling VLM processing.
         Initializes connection to the VLM service and registers message handlers.
+
+        Parameters
+        ----------
+        config : VLMGeminiConfig
+            Configuration for the VLM input handler.
         """
         super().__init__(config)
 
@@ -219,10 +224,7 @@ class VLMGemini(FuserInput[VLMGeminiConfig, Optional[str]]):
         latest_message = self.messages[-1]
 
         result = f"""
-INPUT: {self.descriptor_for_LLM}
-// START
-{latest_message.message}
-// END
+{self.descriptor_for_LLM}: "{latest_message.message}"
 """
 
         self.io_provider.add_input(self.__class__.__name__, latest_message.message, latest_message.timestamp)

--- a/src/inputs/plugins/vlm_gemini_zenoh.py
+++ b/src/inputs/plugins/vlm_gemini_zenoh.py
@@ -38,7 +38,7 @@ class VLMGeminiZenohConfig(SensorConfig):
         default="https://api.openmind.com/api/core/gemini",
         description="Base URL for the Gemini proxy",
     )
-    topic: str = Field(default="rgb_image", description="Zenoh topic for the image stream")
+    topic: str = Field(default="camera/go2/image_raw", description="Zenoh topic for the image stream")
     decode_format: str = Field(default="RAW", description="Image decode format hint")
     model: str = Field(
         default="gemini-2.5-flash",
@@ -47,7 +47,7 @@ class VLMGeminiZenohConfig(SensorConfig):
         "gemini-3-flash-preview, gemini-3-pro-preview, "
         "gemini-3.1-flash-lite-preview, gemini-3.1-pro-preview",
     )
-    max_tokens: int = Field(default=1024, description="Token budget per VLM call")
+    max_tokens: int = Field(default=2048, description="Token budget per VLM call")
     prompt: Optional[str] = Field(
         default=None,
         description="Prompt sent with each frame. Defaults to a one-sentence "
@@ -56,12 +56,26 @@ class VLMGeminiZenohConfig(SensorConfig):
 
 
 class VLMGeminiZenoh(FuserInput[VLMGeminiZenohConfig, Optional[str]]):
-    """Gemini VLM input that subscribes to a Zenoh image topic. The
-    counterpart to VLMVilaZenoh, but routes through the Gemini HTTP
-    endpoint instead of the Vila WS.
+    """
+    Vision Language Model input handler.
+
+    A class that processes image inputs and generates text descriptions using
+    a vision language model. It maintains an internal buffer of processed messages
+    and interfaces with a VLM provider for image analysis.
+
+    The class handles asynchronous processing of images, maintains message history,
+    and provides formatted output of the latest processed messages.
     """
 
     def __init__(self, config: VLMGeminiZenohConfig):
+        """
+        Initialize the provider, set up the VLM provider, and prepare for message handling.
+
+        Parameters
+        ----------
+        config : VLMGeminiZenohConfig
+            Configuration for the provider.
+        """
         super().__init__(config)
 
         self.io_provider = IOProvider()
@@ -97,6 +111,15 @@ class VLMGeminiZenoh(FuserInput[VLMGeminiZenohConfig, Optional[str]]):
         self.descriptor_for_LLM = "Vision"
 
     def _handle_vlm_message(self, content: str):
+        """
+        Process incoming VLM messages.
+
+        Parameters
+        ----------
+        content : str
+            Plain text content from the VLM proxy (already extracted from
+            choices[0].message.content by the provider).
+        """
         if content:
             logging.info(f"VLM Gemini (Zenoh) received message: {content}")
             self.message_buffer.put(content)
@@ -104,6 +127,17 @@ class VLMGeminiZenoh(FuserInput[VLMGeminiZenohConfig, Optional[str]]):
             logging.warning("VLM Gemini (Zenoh) received empty message")
 
     async def _poll(self) -> Optional[str]:
+        """
+        Poll for new messages from the VLM service.
+
+        Checks the message buffer for new messages with a brief delay
+        to prevent excessive CPU usage.
+
+        Returns
+        -------
+        Optional[str]
+            The next message from the buffer if available, None otherwise
+        """
         await asyncio.sleep(0.5)
         try:
             return self.message_buffer.get_nowait()
@@ -111,29 +145,79 @@ class VLMGeminiZenoh(FuserInput[VLMGeminiZenohConfig, Optional[str]]):
             return None
 
     async def _raw_to_text(self, raw_input: Optional[str]) -> Optional[Message]:
+        """
+        Process raw input to generate a timestamped message.
+
+        Creates a Message object from the raw input string, adding
+        the current timestamp.
+
+        Parameters
+        ----------
+        raw_input : Optional[str]
+            Raw input string to be processed
+
+        Returns
+        -------
+        Optional[Message]
+            A timestamped message containing the processed input
+        """
         if raw_input is None:
             return None
+
         return Message(timestamp=time.time(), message=raw_input)
 
     async def raw_to_text(self, raw_input: Optional[str]):
-        """Append a formatted VLM message to the input buffer."""
+        """
+        Convert raw input to text and update message buffer.
+
+        Processes the raw input if present and adds the resulting
+        message to the internal message buffer.
+
+        Parameters
+        ----------
+        raw_input : Optional[str]
+            Raw input to be processed, or None if no input is available
+        """
         if raw_input is None:
             return
-        msg = await self._raw_to_text(raw_input)
-        if msg is not None:
-            self.messages.append(msg)
+
+        pending_message = await self._raw_to_text(raw_input)
+
+        if pending_message is not None:
+            self.messages.append(pending_message)
 
     def formatted_latest_buffer(self) -> Optional[str]:
-        """Return and clear the most recent formatted VLM message."""
+        """
+        Format and clear the latest buffer contents.
+
+        Retrieves the most recent message from the buffer, formats it
+        with timestamp and class name, adds it to the IO provider,
+        and clears the buffer.
+
+        Returns
+        -------
+        Optional[str]
+            Formatted string containing the latest message and metadata,
+            or None if the buffer is empty
+
+        """
         if not self.messages:
             return None
-        latest = self.messages[-1]
-        result = f"\nINPUT: {self.descriptor_for_LLM}\n" "// START\n" f"{latest.message}\n" "// END\n"
-        self.io_provider.add_input(self.__class__.__name__, latest.message, latest.timestamp)
+
+        latest_message = self.messages[-1]
+
+        result = f"""
+{self.descriptor_for_LLM}: "{latest_message.message}"
+"""
+
+        self.io_provider.add_input(self.__class__.__name__, latest_message.message, latest_message.timestamp)
         self.messages = []
+
         return result
 
     def stop(self):
-        """Stop the VLM provider and release its resources."""
+        """
+        Stop the VLM input.
+        """
         if self.vlm:
             self.vlm.stop()

--- a/src/providers/simple_paths_provider.py
+++ b/src/providers/simple_paths_provider.py
@@ -47,11 +47,12 @@ def simple_paths_processor(
         msg: zenoh.Sample
             The message containing paths data.
         """
-        logging.info(f"Received paths message from Zenoh.{msg.payload}")
         paths = sensor_msgs.Paths.deserialize(msg.payload.to_bytes())
+
         msg_time = paths.header.stamp.sec + paths.header.stamp.nanosec * 1e-9
         current_time = time.time()
         latency = current_time - msg_time
+
         logging.debug(f"Received paths with latency: {latency:.6f} seconds")
         logging.info(f"Received paths: {paths.paths}")
 
@@ -68,9 +69,10 @@ def simple_paths_processor(
 
     try:
         load_session_config(api_key, use_sim)
-        logging.info(f"Opening Zenoh session for SimplePathsProvider {api_key}, use_sim={use_sim}")
-        session = open_zenoh_session("simple_paths_processor")
+        session = open_zenoh_session()
+
         session.declare_subscriber("om/paths", paths_callback)
+
         logging.info("Zenoh is open for SimplePathsProvider")
     except Exception as e:
         logging.error(f"Failed to open Zenoh session: {e}")

--- a/src/providers/unitree_go2_odom_zenoh_provider.py
+++ b/src/providers/unitree_go2_odom_zenoh_provider.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from runtime.logging import LoggingConfig, get_logging_config, setup_logging
 from zenoh_msgs import ZenohSampleType, load_session_config, open_zenoh_session
-from zenoh_msgs.idl.nav_msgs import Odometry
+from zenoh_msgs.idl.geometry_msgs import PoseStamped
 
 from .odom_provider_base import OdomProviderBase, RobotState
 from .singleton import singleton
@@ -38,9 +38,9 @@ def _go2_odom_zenoh_processor(
 
     def on_sample(sample: ZenohSampleType) -> None:
         try:
-            msg = Odometry.deserialize(sample.payload.to_bytes())
+            msg = PoseStamped.deserialize(sample.payload.to_bytes())
         except Exception:
-            logging.exception(f"failed to decode Odometry on {topic}")
+            logging.exception(f"failed to decode PoseStamped on {topic}")
             return
         data_queue.put(msg)
 
@@ -118,7 +118,7 @@ class UnitreeGo2OdomZenohProvider(OdomProviderBase):
 
         Parameters
         ----------
-        pose : geometry_msgs/msg/PoseStamped or nav_msgs/msg/Odometry
+        pose : geometry_msgs/msg/PoseStamped
             The pose message containing the robot's position.
         """
         self.body_height_cm = round(pose.position.z * 100.0)

--- a/src/providers/unitree_go2_state_zenoh_provider.py
+++ b/src/providers/unitree_go2_state_zenoh_provider.py
@@ -1,15 +1,3 @@
-"""Zenoh-based Unitree Go2 SportModeState provider.
-
-Drop-in replacement for ``UnitreeGo2StateProvider`` over Zenoh.
-
-``/sportmodestate`` is only published by the real Go2 firmware; the
-sim launches don't synthesize it. When running against a sim, this
-provider's fields stay at their defaults — consuming code should treat
-``state_code is None`` and ``action_progress == 0`` as "no info, proceed".
-"""
-
-from __future__ import annotations
-
 import logging
 import multiprocessing as mp
 import threading
@@ -18,17 +6,16 @@ from queue import Empty, Full
 from typing import Optional
 
 from runtime.logging import LoggingConfig, get_logging_config, setup_logging
-from zenoh_msgs import open_zenoh_session
+from zenoh_msgs import load_session_config, open_zenoh_session
 from zenoh_msgs.idl.unitree_go import SportModeState
 
 from .singleton import singleton
 
-# Same code → state-name table the legacy provider exposes.
-_STATE_MACHINE_CODES = {
+state_machine_codes = {
     100: "Agile",
     1001: "Damping",
     1002: "Standing Lock",
-    1004: "Crouch",
+    1004: "Crouch",  # Also maps to 2006
     1006: "Greeting/Stretching/Dancing/Bowing/Heart Shape/Happy",
     1007: "Sit",
     1008: "Front Jump",
@@ -38,7 +25,7 @@ _STATE_MACHINE_CODES = {
     1016: "Regular Running",
     1017: "Regular Endurance",
     1091: "Strike a Pose",
-    2006: "Crouch",
+    2006: "Crouch",  # Duplicate of 1004
     2007: "Dodge",
     2008: "Bound Run",
     2009: "Jump Run",
@@ -54,23 +41,40 @@ _STATE_MACHINE_CODES = {
 
 
 def _state_zenoh_processor(
-    topic: str,
+    api_key: Optional[str],
+    use_sim: bool,
     data_queue: mp.Queue,
     control_queue: mp.Queue,
-    logging_config: LoggingConfig | None = None,
+    logging_config: Optional[LoggingConfig] = None,
 ) -> None:
+    """
+    Process function for the Unitree Go2 state provider using Zenoh.
+
+    Parameters
+    ----------
+    api_key : Optional[str]
+        API key for authentication with the Zenoh broker, if required.
+    use_sim : bool
+        Whether to use the simulation Zenoh endpoint instead of a local one.
+    data_queue : mp.Queue
+        The multiprocessing queue to send decoded state data back to the main process.
+    control_queue : mp.Queue
+        The multiprocessing queue to receive control commands (e.g. to stop the processor).
+    logging_config : LoggingConfig, optional
+        The logging configuration to use for this processor. If None, default logging is used.
+    """
     setup_logging("unitree_go2_state_zenoh_processor", logging_config=logging_config)
 
-    def on_sample(sample) -> None:  # type: ignore[no-untyped-def]
+    def on_sample(sample) -> None:
         try:
             msg = SportModeState.deserialize(sample.payload.to_bytes())
         except Exception:
-            logging.exception("failed to decode SportModeState on %s", topic)
+            logging.exception("failed to decode SportModeState on sportmodestate")
             return
         data = {
             "go2_sport_mode_state_msg": msg,
             "go2_state_code": msg.error_code,
-            "go2_state": _STATE_MACHINE_CODES.get(msg.error_code, "unknown"),
+            "go2_state": state_machine_codes.get(msg.error_code, "unknown"),
             "go2_action_progress": msg.progress,
         }
         try:
@@ -83,9 +87,11 @@ def _state_zenoh_processor(
                 pass
 
     try:
+        load_session_config(api_key, use_sim)
         session = open_zenoh_session()
-        session.declare_subscriber(topic, on_sample)
-        logging.info("Zenoh sportmodestate subscriber on '%s' is live", topic)
+
+        session.declare_subscriber("sportmodestate", on_sample)
+        logging.info("Subscribed to Unitree Go2 state topic: sportmodestate")
     except Exception:
         logging.exception("failed to open Zenoh session for sportmodestate")
         return
@@ -101,10 +107,24 @@ def _state_zenoh_processor(
 
 @singleton
 class UnitreeGo2StateZenohProvider:
-    """Drop-in for ``UnitreeGo2StateProvider`` over Zenoh."""
+    """
+    Unitree Go2 State Provider.
+    """
 
-    def __init__(self, topic: str = "sportmodestate") -> None:
-        self.topic = topic
+    def __init__(self, api_key: Optional[str] = None, use_sim: bool = False):
+        """
+        Initialize the Unitree Go2 State Provider, setting up the Zenoh subscription and internal state management.
+
+        Parameters
+        ----------
+        api_key : Optional[str]
+            API key for authentication with the Zenoh broker, if required.
+        use_sim : bool
+            Whether to use the simulation Zenoh endpoint instead of a local one.
+        """
+        self.api_key = api_key
+        self.use_sim = use_sim
+
         self.data_queue: mp.Queue = mp.Queue(maxsize=5)
         self.control_queue: mp.Queue = mp.Queue()
 
@@ -120,11 +140,13 @@ class UnitreeGo2StateZenohProvider:
         self.start()
 
     def start(self) -> None:
-        """Start the reader process and processor thread (idempotent)."""
+        """
+        Start the reader process and processor thread (idempotent).
+        """
         if not self._reader_proc or not self._reader_proc.is_alive():
             self._reader_proc = mp.Process(
                 target=_state_zenoh_processor,
-                args=(self.topic, self.data_queue, self.control_queue, get_logging_config()),
+                args=(self.api_key, self.use_sim, self.data_queue, self.control_queue, get_logging_config()),
                 daemon=True,
             )
             self._reader_proc.start()
@@ -136,21 +158,28 @@ class UnitreeGo2StateZenohProvider:
             logging.info("Unitree Go2 Zenoh state processor started.")
 
     def stop(self) -> None:
-        """Stop the reader process and processor thread."""
+        """
+        Stop the reader process and processor thread.
+        """
         self._stop_event.set()
         if self._reader_proc:
             self.control_queue.put("STOP")
             self._reader_proc.terminate()
             self._reader_proc.join(timeout=2)
+
         if self._processor_thread:
             self._processor_thread.join(timeout=2)
 
     def _processor_loop(self) -> None:
+        """
+        Process the Unitree Go2 state data from the data queue.
+        """
         while not self._stop_event.is_set():
             try:
                 data = self.data_queue.get(timeout=0.5)
             except Empty:
                 continue
+
             self.go2_sport_mode_state_msg = data.get("go2_sport_mode_state_msg")
             self.go2_state = data.get("go2_state")
             self.go2_state_code = data.get("go2_state_code")
@@ -158,15 +187,36 @@ class UnitreeGo2StateZenohProvider:
 
     @property
     def state(self) -> Optional[str]:
-        """Latest decoded high-level state string (e.g. ``"jointLock"``)."""
+        """
+        Get the current state of the Unitree Go2 robot.
+
+        Returns
+        -------
+        Optional[str]
+            The current state of the robot, or None if not available.
+        """
         return self.go2_state
 
     @property
     def state_code(self) -> Optional[int]:
-        """Latest numeric state code from the Go2 state machine."""
+        """
+        Get the current state code of the Unitree Go2 robot.
+
+        Returns
+        -------
+        Optional[int]
+            The current state code of the robot, or None if not available.
+        """
         return self.go2_state_code
 
     @property
     def action_progress(self) -> int:
-        """Progress percentage (0–100) of the currently-executing motion."""
+        """
+        Get the current action progress of the Unitree Go2 robot.
+
+        Returns
+        -------
+        int
+            The current action progress of the robot, or 0 if not in the action mode.
+        """
         return self.go2_action_progress

--- a/src/providers/vlm_gemini_provider.py
+++ b/src/providers/vlm_gemini_provider.py
@@ -75,10 +75,9 @@ class VLMGeminiProvider:
         """
         try:
             envelope = json.loads(frame)
-            b64 = envelope["frame"]
+            base64_image = envelope["frame"]
         except (json.JSONDecodeError, KeyError, TypeError):
-            # Fallback
-            b64 = frame
+            base64_image = frame
 
         processing_start = time.perf_counter()
         try:
@@ -91,20 +90,24 @@ class VLMGeminiProvider:
                             {"type": "text", "text": self.prompt},
                             {
                                 "type": "image_url",
-                                "image_url": {"url": f"data:image/jpeg;base64,{b64}", "detail": "low"},
+                                "image_url": {"url": f"data:image/jpeg;base64,{base64_image}", "detail": "low"},
                             },
                         ],
                     }
                 ],
                 max_tokens=self.max_tokens,
             )
+
             data = json.loads(raw.text)
             content = data["choices"][0]["message"]["content"]
             processing_latency = time.perf_counter() - processing_start
+
             logging.debug(f"Processing latency: {processing_latency:.3f} seconds")
             logging.debug(f"Gemini VLM content: {content[:200]!r}")
+
             if self.message_callback and content is not None:
                 self.message_callback(content)
+
         except Exception as e:
             body = None
             resp = getattr(e, "response", None)

--- a/src/providers/vlm_gemini_zenoh_provider.py
+++ b/src/providers/vlm_gemini_zenoh_provider.py
@@ -35,10 +35,28 @@ class VLMGeminiZenohProvider:
             "Just the description — no explanation of your reasoning."
         ),
     ):
+        """
+        Initialize the VLM Provider.
+
+        Parameters
+        ----------
+        base_url : str
+            The base URL for the OM Gemini proxy.
+        api_key : str
+            The API key.
+        topic : str
+            The Zenoh topic to subscribe to for incoming frames.
+        decode_format : str
+            A hint for the incoming frame format; currently unused.
+        model : str
+            Gemini model id (e.g. "gemini-2.5-flash", "gemini-3.1-pro-preview").
+        max_tokens : int
+            The token budget for each VLM call.
+        prompt : str
+            The prompt to send with each frame to the Gemini model.
+        """
         self.running: bool = False
-        # AsyncOpenAI for auth/connection pooling; we bypass its response
-        # parser via `with_raw_response.create()` because openai==1.60.1
-        # rejects Gemini's `extra_content.google.thought_signature` field.
+
         self.api_client: AsyncOpenAI = AsyncOpenAI(api_key=api_key, base_url=base_url)
         self.model: str = model
         self.max_tokens: int = max_tokens
@@ -47,19 +65,12 @@ class VLMGeminiZenohProvider:
         self._inflight: int = 0
         self._max_inflight: int = 2  # back-pressure: at most N concurrent VLM calls
 
-        # VideoZenohStream's own self.loop is never started — its zenoh
-        # callback would enqueue our coroutine onto a dead loop. So we run
-        # our own loop in a dedicated thread and pass a synchronous
-        # frame_callback that schedules onto it.
         self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
         self._loop_thread: threading.Thread = threading.Thread(
             target=self._run_loop, daemon=True, name="VLMGeminiZenohLoop"
         )
         self._loop_thread.start()
 
-        # VideoZenohStream subscribes via open_zenoh_session(); when
-        # OPENMIND_CLOUD_URL is set it uses the broker shim, so frames
-        # come through the same broker the rest of cloud_sim uses.
         self.video_stream: VideoZenohStream = VideoZenohStream(
             topic=topic,
             decode_format=decode_format,
@@ -67,22 +78,36 @@ class VLMGeminiZenohProvider:
         )
 
     def _run_loop(self):
+        """
+        Run the internal asyncio event loop in a dedicated thread.
+        """
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
     def _dispatch_frame(self, frame: str):
-        """Sync entrypoint called from the zenoh callback thread. Drops
-        the frame if too many requests are already in flight (Gemini latency
-        is ~1-3s; at 12fps frames pile up otherwise).
+        """
+        Dispatch a new frame from the Zenoh topic to the asyncio processing method.
+
+        Parameters
+        ----------
+        frame : str
+            The incoming frame data as a string, expected to be a JSON-encoded object containing a base64-encoded image.
         """
         if self._inflight >= self._max_inflight:
             return
+
         self._inflight += 1
         asyncio.run_coroutine_threadsafe(self._process_frame(frame), self._loop)
 
     async def _process_frame(self, frame: str):
-        """Frame callback. ``frame`` is `{"timestamp":..., "frame":"<b64>"}` —
-        unwrap to bare base64 for the data: URL Gemini expects.
+        """
+        Process a video frame via the OM Gemini proxy.
+
+        Parameters
+        ----------
+        frame : str
+            JSON string emitted by `om1_vlm.VideoZenohStream`, shape:
+            `{"timestamp": <float>, "frame": "<base64-jpeg>"}`.
         """
         try:
             envelope = json.loads(frame)
@@ -110,11 +135,13 @@ class VLMGeminiZenohProvider:
             )
             data = json.loads(raw.text)
             content = data["choices"][0]["message"]["content"]
+
             logging.debug(
                 "Gemini VLM Zenoh latency=%.3fs content=%r",
                 time.perf_counter() - processing_start,
                 content[:200] if content else None,
             )
+
             if self.message_callback and content is not None:
                 self.message_callback(content)
         except Exception as e:
@@ -123,20 +150,38 @@ class VLMGeminiZenohProvider:
             self._inflight = max(0, self._inflight - 1)
 
     def register_message_callback(self, message_callback: Optional[Callable]):
-        """Register a callback invoked with each VLM response string."""
+        """
+        Register a callback for processing Gemini results.
+
+        Parameters
+        ----------
+        message_callback : Optional[Callable]
+            The callback function to process Gemini results.
+        """
         self.message_callback = message_callback
 
     def start(self):
-        """Start the underlying video stream (idempotent)."""
+        """
+        Start the Gemini provider.
+
+        Initializes and starts the video stream and processing thread
+        if not already running.
+        """
         if self.running:
             logging.warning("Gemini VLM Zenoh provider is already running")
             return
+
         self.running = True
         self.video_stream.start()
+
         logging.info("Gemini VLM Zenoh provider started")
 
     def stop(self):
-        """Stop the video stream and shut down the internal asyncio loop."""
+        """
+        Stop the Gemini provider.
+
+        Stops the video stream and processing thread.
+        """
         self.running = False
         self.video_stream.stop()
         self._loop.call_soon_threadsafe(self._loop.stop)

--- a/src/zenoh_msgs/session.py
+++ b/src/zenoh_msgs/session.py
@@ -261,7 +261,7 @@ class HybridZenohSession:
             logging.info("Closed standard Zenoh session")
 
 
-def open_zenoh_session(debug="") -> ZenohSessionType:
+def open_zenoh_session() -> ZenohSessionType:
     """
     Open a Zenoh session.
 
@@ -271,7 +271,6 @@ def open_zenoh_session(debug="") -> ZenohSessionType:
         A session object that can be used to interact with Zenoh topics.
     """
     if HybridZenohSession._use_sim:
-        logging.info(f"{debug} Opening hybrid session for cloud simulation")
         return HybridZenohSession()
 
     local_config = create_zenoh_config(network_discovery=False)

--- a/tests/actions/move_go2_autonomy/connector/test_move_go2_autonomy_unitree_om_path_sdk_zenoh.py
+++ b/tests/actions/move_go2_autonomy/connector/test_move_go2_autonomy_unitree_om_path_sdk_zenoh.py
@@ -4,8 +4,8 @@ import pytest
 
 from actions.base import MoveCommand
 from actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh import (
-    MoveUnitreeOMPathSDKCloudConfig,
-    MoveUnitreeOMPathSDKCloudConnector,
+    MoveUnitreeOMPathSDKZenohConfig,
+    MoveUnitreeOMPathSDKZenohConnector,
 )
 from providers.odom_provider_base import RobotState
 
@@ -14,22 +14,15 @@ from providers.odom_provider_base import RobotState
 def deps():
     """Patch out everything that does I/O at construction time."""
     with (
-        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.SimplePathsProvider") as mock_paths_class,
-        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.FacePresenceProvider") as mock_face_class,
+        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.SimplePathsProvider") as mock_paths_class,
+        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.FacePresenceProvider") as mock_face_class,
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.UnitreeGo2StateZenohProvider"
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.UnitreeGo2StateZenohProvider"
         ) as mock_state_zenoh_class,
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.UnitreeGo2OdomZenohProvider"
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.UnitreeGo2OdomZenohProvider"
         ) as mock_odom_zenoh_class,
-        patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.UnitreeGo2StateProvider"
-        ) as mock_state_class,
-        patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.UnitreeGo2OdomProvider"
-        ) as mock_odom_class,
-        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.open_zenoh_session") as mock_open_session,
-        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.SportClient") as mock_sport_client_class,
+        patch("actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.open_zenoh_session") as mock_open_session,
     ):
         # Common stub instances
         paths = MagicMock()
@@ -61,32 +54,12 @@ def deps():
         }
         mock_odom_zenoh_class.return_value = odom_zenoh
 
-        state = MagicMock()
-        state.state_code = None
-        state.state = "Standing"
-        state.action_progress = 0
-        mock_state_class.return_value = state
-
-        odom = MagicMock()
-        odom.position = {
-            "moving": False,
-            "body_attitude": RobotState.STANDING,
-            "odom_x": 1.0,
-            "odom_y": 0.0,
-            "odom_yaw_m180_p180": 0.0,
-            "odom_subscriber_ts": 1.0,
-        }
-        mock_odom_class.return_value = odom
-
         session = MagicMock()
         sub = MagicMock()
         session.declare_subscriber.return_value = sub
         pub = MagicMock()
         session.declare_publisher.return_value = pub
         mock_open_session.return_value = session
-
-        sport_client = MagicMock()
-        mock_sport_client_class.return_value = sport_client
 
         yield {
             "paths_class": mock_paths_class,
@@ -96,76 +69,56 @@ def deps():
             "state_zenoh": state_zenoh,
             "odom_zenoh_class": mock_odom_zenoh_class,
             "odom_zenoh": odom_zenoh,
-            "state_class": mock_state_class,
-            "state": state,
-            "odom_class": mock_odom_class,
-            "odom": odom,
             "open_session": mock_open_session,
             "session": session,
             "publisher": pub,
-            "sport_client_class": mock_sport_client_class,
-            "sport_client": sport_client,
         }
 
 
-# --- Initialization ---------------------------------------------------------
-
-
 def test_init_zenoh_cmd_vel_mode(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    assert conn.use_zenoh is True
-    assert conn.move_via_sport_api is False
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
     deps["state_zenoh_class"].assert_called_once()
     deps["odom_zenoh_class"].assert_called_once()
-    # cmd_vel publisher should be armed
-    assert conn._cmd_vel_pub is not None
-    assert conn._sport_pub is None
+    assert conn._sport_pub is not None
 
 
 def test_init_zenoh_sport_api_mode(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, move_via_sport_api=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
     assert conn._sport_pub is not None
-    assert conn._cmd_vel_pub is None
 
 
 def test_init_sport_api_without_zenoh_raises(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False, move_via_sport_api=True)
-    with pytest.raises(ValueError, match="move_via_sport_api requires use_zenoh"):
-        MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
+    assert conn is not None
 
 
 def test_init_local_path(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    assert conn.use_zenoh is False
-    deps["state_class"].assert_called_once()
-    deps["odom_class"].assert_called_once()
-    # SportClient.Init() called during construction
-    deps["sport_client"].Init.assert_called_once()
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    MoveUnitreeOMPathSDKZenohConnector(config=config)
+    deps["state_zenoh_class"].assert_called_once()
+    deps["odom_zenoh_class"].assert_called_once()
 
 
 def test_init_session_failure_keeps_running(deps):
     deps["open_session"].side_effect = RuntimeError("zenoh down")
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
     assert conn.session is None
 
 
 def test_init_permissive_paths_logged(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, permissive_paths=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    assert conn.permissive_paths is True
-
-
-# --- Pure-math helpers ------------------------------------------------------
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
+    assert conn is not None
 
 
 @pytest.fixture
 def conn(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, permissive_paths=True)
-    return MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    return MoveUnitreeOMPathSDKZenohConnector(config=config)
 
 
 @pytest.mark.parametrize(
@@ -201,72 +154,63 @@ def test_pick_path_angle_returns_default_for_empty(conn):
 
 
 def test_pick_path_angle_picks_from_list(conn):
-    # path_angles for indices [0, 1] are [-90, -60]
     angle = conn._pick_path_angle([0, 1], default=999.0)
     assert angle in (-90, -60)
 
 
-# --- _move_robot dispatch ---------------------------------------------------
-
-
 def test_move_robot_zenoh_cmd_vel(conn):
-    conn._cmd_vel_pub = MagicMock()
+    conn._sport_pub = MagicMock()
     conn._move_robot(0.5, 0.0, 0.1)
-    conn._cmd_vel_pub.put.assert_called_once()
+    conn._sport_pub.put.assert_called_once()
 
 
 def test_move_robot_zenoh_cmd_vel_skips_when_pub_missing(conn):
-    conn._cmd_vel_pub = None
+    conn._sport_pub = None
     # Should not raise
     conn._move_robot(0.5, 0.0, 0.1)
 
 
 def test_move_robot_skips_when_sitting(conn):
     conn.odom.position["body_attitude"] = RobotState.SITTING
-    conn._cmd_vel_pub = MagicMock()
+    conn._sport_pub = MagicMock()
     conn._move_robot(0.5, 0.0, 0.0)
-    conn._cmd_vel_pub.put.assert_not_called()
+    conn._sport_pub.put.assert_not_called()
 
 
 def test_move_robot_sport_api_path(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, move_via_sport_api=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
     conn._sport_pub = MagicMock()
     conn._move_robot(0.5, 0.0, 0.0)
     conn._sport_pub.put.assert_called_once()
 
 
 def test_move_robot_sport_api_no_pub(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, move_via_sport_api=True)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
     conn._sport_pub = None  # publisher missing
-    # Should not raise
     conn._move_robot(0.5, 0.0, 0.0)
 
 
 def test_move_robot_local_sport_client(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    deps["sport_client"].reset_mock()
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
+    conn._sport_pub = MagicMock()
     conn._move_robot(0.5, 0.0, 0.1)
-    deps["sport_client"].Move.assert_called_once_with(0.5, 0.0, 0.1)
+    conn._sport_pub.put.assert_called_once()
 
 
 def test_move_robot_local_skips_when_not_standing(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False)
-    conn = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    deps["sport_client"].reset_mock()
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    conn = MoveUnitreeOMPathSDKZenohConnector(config=config)
+    conn._sport_pub = MagicMock()
     conn.odom.position["body_attitude"] = RobotState.SITTING
     conn._move_robot(0.5, 0.0, 0.1)
-    deps["sport_client"].Move.assert_not_called()
-
-
-# --- _publish_sport_move ----------------------------------------------------
+    conn._sport_pub.put.assert_not_called()
 
 
 def test_publish_sport_move_skips_when_pub_missing(conn):
     conn._sport_pub = None
-    # Should not raise
     conn._publish_sport_move(0.5, 0.0, 0.0)
 
 
@@ -274,9 +218,6 @@ def test_publish_sport_move_publishes(conn):
     conn._sport_pub = MagicMock()
     conn._publish_sport_move(0.5, 0.1, 0.2)
     conn._sport_pub.put.assert_called_once()
-
-
-# --- clean_abort ------------------------------------------------------------
 
 
 def test_clean_abort_resets_state(conn):
@@ -291,9 +232,6 @@ def test_clean_abort_when_already_empty(conn):
     conn.movement_attempts = 3
     conn.clean_abort()
     assert conn.movement_attempts == 0
-
-
-# --- _process_* movement-command builders -----------------------------------
 
 
 def test_process_turn_left_blocked(conn):
@@ -348,10 +286,10 @@ def test_process_move_back_queues(conn):
 
 
 def test_execute_turn_left_with_paths(conn):
-    conn._cmd_vel_pub = MagicMock()
+    conn._sport_pub = MagicMock()
     ok = conn._execute_turn(20.0)  # positive -> left
     assert ok is True
-    conn._cmd_vel_pub.put.assert_called()
+    conn._sport_pub.put.assert_called()
 
 
 def test_execute_turn_left_blocked_strict(conn):
@@ -361,19 +299,11 @@ def test_execute_turn_left_blocked_strict(conn):
     assert ok is False
 
 
-def test_execute_turn_left_blocked_permissive(conn):
-    conn._cmd_vel_pub = MagicMock()
-    conn.path_provider.turn_left = []
-    ok = conn._execute_turn(20.0)
-    assert ok is True
-    conn._cmd_vel_pub.put.assert_called()
-
-
 def test_execute_turn_right_with_paths(conn):
-    conn._cmd_vel_pub = MagicMock()
+    conn._sport_pub = MagicMock()
     ok = conn._execute_turn(-20.0)
     assert ok is True
-    conn._cmd_vel_pub.put.assert_called()
+    conn._sport_pub.put.assert_called()
 
 
 def test_execute_turn_right_blocked_strict(conn):
@@ -381,16 +311,6 @@ def test_execute_turn_right_blocked_strict(conn):
     conn.path_provider.turn_right = []
     ok = conn._execute_turn(-20.0)
     assert ok is False
-
-
-def test_execute_turn_right_blocked_permissive(conn):
-    conn._cmd_vel_pub = MagicMock()
-    conn.path_provider.turn_right = []
-    ok = conn._execute_turn(-20.0)
-    assert ok is True
-
-
-# --- connect dispatch -------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -464,18 +384,13 @@ async def test_connect_waits_for_first_odom(conn):
     assert conn.pending_movements.empty()
 
 
-# --- _zenoh_ai_status_request -----------------------------------------------
-
-
 def test_zenoh_ai_status_request_no_publisher_no_op(conn):
     conn._zenoh_ai_status_response_pub = None
     sample = MagicMock()
-    # Should not raise even with no publisher
     conn._zenoh_ai_status_request(sample)
 
 
 def test_zenoh_ai_status_request_disable(conn):
-    """code=0 should disable AI control and publish a response."""
     pub = MagicMock()
     conn._zenoh_ai_status_response_pub = pub
     sample = MagicMock()
@@ -488,15 +403,15 @@ def test_zenoh_ai_status_request_disable(conn):
     response_obj.serialize.return_value = b"\x00"
     with (
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusRequest.deserialize",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusRequest.deserialize",
             return_value=fake,
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.prepare_header",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.prepare_header",
             return_value=MagicMock(),
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusResponse",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusResponse",
             return_value=response_obj,
         ),
     ):
@@ -519,15 +434,15 @@ def test_zenoh_ai_status_request_enable(conn):
     response_obj.serialize.return_value = b"\x00"
     with (
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusRequest.deserialize",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusRequest.deserialize",
             return_value=fake,
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.prepare_header",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.prepare_header",
             return_value=MagicMock(),
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusResponse",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusResponse",
             return_value=response_obj,
         ),
     ):
@@ -537,7 +452,6 @@ def test_zenoh_ai_status_request_enable(conn):
 
 
 def test_zenoh_ai_status_request_query(conn):
-    """code=2 should reply with current state without changing it."""
     pub = MagicMock()
     conn._zenoh_ai_status_response_pub = pub
     conn.ai_control_enabled = True
@@ -551,34 +465,29 @@ def test_zenoh_ai_status_request_query(conn):
     response_obj.serialize.return_value = b"\x00"
     with (
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusRequest.deserialize",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusRequest.deserialize",
             return_value=fake,
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.prepare_header",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.prepare_header",
             return_value=MagicMock(),
         ),
         patch(
-            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud.AIStatusResponse",
+            "actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh.AIStatusResponse",
             return_value=response_obj,
         ),
     ):
         conn._zenoh_ai_status_request(sample)
-    # State unchanged
     assert conn.ai_control_enabled is True
     pub.put.assert_called_once()
 
 
-# --- tick() state machine ---------------------------------------------------
-
-
 @pytest.fixture
 def tick_conn(deps):
-    """A connector with sleep stubbed and odom positioned for tick tests."""
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=True, permissive_paths=True)
-    c = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    c = MoveUnitreeOMPathSDKZenohConnector(config=config)
     c.sleep = MagicMock()
-    c._cmd_vel_pub = MagicMock()
+    c._sport_pub = MagicMock()
     return c
 
 
@@ -602,20 +511,10 @@ def test_tick_skips_when_sitting(tick_conn):
 
 
 def test_tick_local_skips_when_not_standing(deps):
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False, permissive_paths=True)
-    c = MoveUnitreeOMPathSDKCloudConnector(config=config)
+    config = MoveUnitreeOMPathSDKZenohConfig()
+    c = MoveUnitreeOMPathSDKZenohConnector(config=config)
     c.sleep = MagicMock()
     c.odom.position["body_attitude"] = RobotState.SITTING
-    c.tick()
-    c.sleep.assert_called_with(0.5)
-
-
-def test_tick_local_proceeds_when_attitude_unknown(deps):
-    """Local mode with attitude != STANDING and != SITTING should still skip."""
-    config = MoveUnitreeOMPathSDKCloudConfig(use_zenoh=False, permissive_paths=True)
-    c = MoveUnitreeOMPathSDKCloudConnector(config=config)
-    c.sleep = MagicMock()
-    c.odom.position["body_attitude"] = None
     c.tick()
     c.sleep.assert_called_with(0.5)
 
@@ -630,7 +529,6 @@ def test_tick_movement_attempts_exceeded_aborts(tick_conn):
     tick_conn.movement_attempt_limit = 10
     tick_conn.pending_movements.put(MoveCommand(dx=1.0, yaw=0.0, start_x=0.0, start_y=0.0, turn_complete=False))
     tick_conn.tick()
-    # clean_abort drains the queue
     assert tick_conn.pending_movements.empty()
     assert tick_conn.movement_attempts == 0
 
@@ -639,7 +537,7 @@ def test_tick_phase1_big_gap_executes_turn(tick_conn):
     tick_conn.pending_movements.put(MoveCommand(dx=1.0, yaw=45.0, start_x=0.0, start_y=0.0, turn_complete=False))
     tick_conn.tick()
     assert tick_conn.movement_attempts == 1
-    tick_conn._cmd_vel_pub.put.assert_called()
+    tick_conn._sport_pub.put.assert_called()
 
 
 def test_tick_phase1_big_gap_blocked_aborts(tick_conn):
@@ -648,7 +546,6 @@ def test_tick_phase1_big_gap_blocked_aborts(tick_conn):
     tick_conn.path_provider.turn_right = []
     tick_conn.pending_movements.put(MoveCommand(dx=1.0, yaw=-45.0, start_x=0.0, start_y=0.0, turn_complete=False))
     tick_conn.tick()
-    # _execute_turn returns False -> clean_abort -> queue drained
     assert tick_conn.pending_movements.empty()
 
 
@@ -657,7 +554,7 @@ def test_tick_phase1_small_gap_left_rotation(tick_conn):
     tick_conn.pending_movements.put(MoveCommand(dx=1.0, yaw=5.0, start_x=0.0, start_y=0.0, turn_complete=False))
     tick_conn.tick()
     assert tick_conn.movement_attempts == 1
-    tick_conn._cmd_vel_pub.put.assert_called()
+    tick_conn._sport_pub.put.assert_called()
 
 
 def test_tick_phase1_small_gap_right_rotation(tick_conn):
@@ -665,7 +562,7 @@ def test_tick_phase1_small_gap_right_rotation(tick_conn):
     tick_conn.pending_movements.put(MoveCommand(dx=1.0, yaw=-5.0, start_x=0.0, start_y=0.0, turn_complete=False))
     tick_conn.tick()
     assert tick_conn.movement_attempts == 1
-    tick_conn._cmd_vel_pub.put.assert_called()
+    tick_conn._sport_pub.put.assert_called()
 
 
 def test_tick_phase1_turn_completed_marks_target(tick_conn):
@@ -673,7 +570,6 @@ def test_tick_phase1_turn_completed_marks_target(tick_conn):
     cmd = MoveCommand(dx=1.0, yaw=0.0, start_x=0.0, start_y=0.0, turn_complete=False)
     tick_conn.pending_movements.put(cmd)
     tick_conn.tick()
-    # Item in queue should now have turn_complete=True
     front = list(tick_conn.pending_movements.queue)[0]
     assert front.turn_complete is True
 
@@ -708,21 +604,20 @@ def test_tick_phase2_keeps_moving(tick_conn):
     )
     tick_conn.tick()
     assert tick_conn.movement_attempts == 1
-    tick_conn._cmd_vel_pub.put.assert_called()
+    tick_conn._sport_pub.put.assert_called()
 
 
 def test_tick_phase2_overshoot(tick_conn):
     tick_conn.distance_tolerance = 0.05
-    # odom.x = 1.0, start_x = 0.0, goal dx = 0.5 -> distance_traveled = 1.0 > 0.5 (overshoot)
     tick_conn.pending_movements.put(
         MoveCommand(dx=0.5, yaw=0.0, start_x=0.0, start_y=0.0, turn_complete=True, speed=0.5)
     )
     tick_conn.tick()
-    tick_conn._cmd_vel_pub.put.assert_called()
+    tick_conn._sport_pub.put.assert_called()
 
 
 def test_tick_phase2_completes_normally(tick_conn):
-    tick_conn.distance_tolerance = 5.0  # huge tolerance -> immediately done
+    tick_conn.distance_tolerance = 5.0
     tick_conn.pending_movements.put(
         MoveCommand(dx=1.0, yaw=0.0, start_x=0.0, start_y=0.0, turn_complete=True, speed=0.5)
     )

--- a/tests/actions/move_go2_autonomy/connector/test_unitree_om_path_sdk_cloud.py
+++ b/tests/actions/move_go2_autonomy/connector/test_unitree_om_path_sdk_cloud.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from actions.base import MoveCommand
-from actions.move_go2_autonomy.connector.unitree_om_path_sdk_cloud import (
+from actions.move_go2_autonomy.connector.unitree_om_path_sdk_zenoh import (
     MoveUnitreeOMPathSDKCloudConfig,
     MoveUnitreeOMPathSDKCloudConnector,
 )

--- a/tests/backgrounds/plugins/test_unitree_go2_state_zenoh.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_state_zenoh.py
@@ -17,17 +17,17 @@ class TestUnitreeGo2StateZenoh:
 
             assert background.config is config
             assert background.unitree_go2_state_provider is mock_provider
-            mock_provider_class.assert_called_once_with(topic="sportmodestate")
+            mock_provider_class.assert_called_once_with(None, False)
 
     def test_initialization_custom_topic(self):
         with patch("backgrounds.plugins.unitree_go2_state_zenoh.UnitreeGo2StateZenohProvider") as mock_provider_class:
             mock_provider = MagicMock()
             mock_provider_class.return_value = mock_provider
 
-            config = UnitreeGo2StateZenohConfig()
+            config = UnitreeGo2StateZenohConfig(api_key="test_key", use_sim=True)
             background = UnitreeGo2StateZenoh(config)
 
-            mock_provider_class.assert_called_once_with()
+            mock_provider_class.assert_called_once_with("test_key", True)
             assert background.unitree_go2_state_provider is mock_provider
 
     def test_initialization_logging(self, caplog):

--- a/tests/backgrounds/plugins/test_unitree_go2_state_zenoh.py
+++ b/tests/backgrounds/plugins/test_unitree_go2_state_zenoh.py
@@ -6,16 +6,6 @@ from backgrounds.plugins.unitree_go2_state_zenoh import (
 )
 
 
-class TestUnitreeGo2StateZenohConfig:
-    def test_default_topic(self):
-        config = UnitreeGo2StateZenohConfig()
-        assert config.topic == "sportmodestate"
-
-    def test_custom_topic(self):
-        config = UnitreeGo2StateZenohConfig(topic="custom/state")
-        assert config.topic == "custom/state"
-
-
 class TestUnitreeGo2StateZenoh:
     def test_initialization_default(self):
         with patch("backgrounds.plugins.unitree_go2_state_zenoh.UnitreeGo2StateZenohProvider") as mock_provider_class:
@@ -34,10 +24,10 @@ class TestUnitreeGo2StateZenoh:
             mock_provider = MagicMock()
             mock_provider_class.return_value = mock_provider
 
-            config = UnitreeGo2StateZenohConfig(topic="my/key")
+            config = UnitreeGo2StateZenohConfig()
             background = UnitreeGo2StateZenoh(config)
 
-            mock_provider_class.assert_called_once_with(topic="my/key")
+            mock_provider_class.assert_called_once_with()
             assert background.unitree_go2_state_provider is mock_provider
 
     def test_initialization_logging(self, caplog):

--- a/tests/inputs/plugins/test_vlm_gemini.py
+++ b/tests/inputs/plugins/test_vlm_gemini.py
@@ -50,9 +50,6 @@ def test_formatted_latest_buffer():
 
         result = sensor.formatted_latest_buffer()
         assert isinstance(result, str)
-        assert "INPUT:" in result
         assert "Vision" in result
         assert "I see a person" in result
-        assert "// START" in result
-        assert "// END" in result
         assert len(sensor.messages) == 0

--- a/tests/inputs/plugins/test_vlm_gemini_zenoh.py
+++ b/tests/inputs/plugins/test_vlm_gemini_zenoh.py
@@ -31,7 +31,7 @@ def test_initialization_falls_back_to_env(patches):
     VLMGeminiZenoh(config=VLMGeminiZenohConfig())
     _args, kwargs = patches["provider_class"].call_args
     assert kwargs["api_key"] == "env-key"
-    assert kwargs["topic"] == "rgb_image"
+    assert kwargs["topic"] == "camera/go2/image_raw"
     assert kwargs["model"] == "gemini-2.5-flash"
     # default branch (no explicit prompt) should not pass `prompt` kwarg
     assert "prompt" not in kwargs
@@ -118,7 +118,7 @@ def test_formatted_latest_buffer_with_message(patches):
     sensor.messages.append(Message(timestamp=1.0, message="abstract pixels"))
     result = sensor.formatted_latest_buffer()
     assert result is not None
-    assert "INPUT: Vision" in result
+    assert "Vision" in result
     assert "abstract pixels" in result
     assert sensor.messages == []
 

--- a/tests/providers/test_unitree_go2_state_zenoh_provider.py
+++ b/tests/providers/test_unitree_go2_state_zenoh_provider.py
@@ -1,10 +1,12 @@
+from queue import Queue
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from providers.unitree_go2_state_zenoh_provider import (
-    _STATE_MACHINE_CODES,
     UnitreeGo2StateZenohProvider,
+    _state_zenoh_processor,
+    state_machine_codes,
 )
 
 
@@ -37,7 +39,6 @@ def patches():
 
 def test_initialization_default_topic(patches):
     provider = UnitreeGo2StateZenohProvider()
-    assert provider.topic == "sportmodestate"
     assert provider.go2_state is None
     assert provider.go2_state_code is None
     assert provider.go2_action_progress == 0
@@ -45,16 +46,8 @@ def test_initialization_default_topic(patches):
     patches["thread"].start.assert_called_once()
 
 
-def test_initialization_custom_topic(patches):
-    UnitreeGo2StateZenohProvider.reset()  # type: ignore[attr-defined]
-    provider = UnitreeGo2StateZenohProvider("lf/sportmodestate")
-    assert provider.topic == "lf/sportmodestate"
-
-
 def test_start_is_idempotent(patches):
     provider = UnitreeGo2StateZenohProvider()
-    # First start happens via __init__. Calling start again with the
-    # already-alive proc/thread shouldn't spawn new ones.
     initial_process_calls = patches["process_class"].call_count
     initial_thread_calls = patches["thread_class"].call_count
     provider.start()
@@ -76,7 +69,6 @@ def test_processor_loop_consumes_data(patches):
     from queue import Queue
 
     provider = UnitreeGo2StateZenohProvider()
-    # Swap mp.Queue for a plain Queue so put/get is synchronous in-process.
     provider.data_queue = Queue()  # type: ignore[assignment]
     sample = {
         "go2_sport_mode_state_msg": "msg",
@@ -103,20 +95,13 @@ def test_stop_signals_stop(patches):
 
 
 def test_state_machine_codes_present():
-    # Sanity check the lookup table that the processor uses.
-    assert _STATE_MACHINE_CODES[1007] == "Sit"
-    assert _STATE_MACHINE_CODES[1015] == "Regular Walking"
-    assert _STATE_MACHINE_CODES.get(99999) is None
+    assert state_machine_codes[1007] == "Sit"
+    assert state_machine_codes[1015] == "Regular Walking"
+    assert state_machine_codes.get(99999) is None
 
 
 def test_state_zenoh_processor_subscribes(patches):
     """Run the in-process worker function with a pre-stopped control queue."""
-    # Use plain queue.Queue so get_nowait/put work in-process; the function
-    # treats them duck-typed.
-    from queue import Queue
-
-    from providers.unitree_go2_state_zenoh_provider import _state_zenoh_processor
-
     data_queue: Queue = Queue()
     control_queue: Queue = Queue()
     control_queue.put("STOP")
@@ -141,11 +126,6 @@ def test_state_zenoh_processor_subscribes(patches):
 
 
 def test_state_zenoh_processor_session_failure():
-    """If open_zenoh_session raises, processor returns cleanly."""
-    from queue import Queue
-
-    from providers.unitree_go2_state_zenoh_provider import _state_zenoh_processor
-
     data_queue: Queue = Queue()
     control_queue: Queue = Queue()
     with (
@@ -155,5 +135,4 @@ def test_state_zenoh_processor_session_failure():
         ),
         patch("providers.unitree_go2_state_zenoh_provider.setup_logging"),
     ):
-        # Should not raise.
         _state_zenoh_processor("sportmodestate", data_queue, control_queue)  # type: ignore[arg-type]

--- a/tests/providers/test_unitree_go2_state_zenoh_provider.py
+++ b/tests/providers/test_unitree_go2_state_zenoh_provider.py
@@ -118,7 +118,7 @@ def test_state_zenoh_processor_subscribes(patches):
             return_value=None,
         ),
     ):
-        _state_zenoh_processor("sportmodestate", data_queue, control_queue)  # type: ignore[arg-type]
+        _state_zenoh_processor(None, False, data_queue, control_queue)  # type: ignore[arg-type]
 
     session.declare_subscriber.assert_called_once()
     topic_arg = session.declare_subscriber.call_args[0][0]
@@ -135,4 +135,4 @@ def test_state_zenoh_processor_session_failure():
         ),
         patch("providers.unitree_go2_state_zenoh_provider.setup_logging"),
     ):
-        _state_zenoh_processor("sportmodestate", data_queue, control_queue)  # type: ignore[arg-type]
+        _state_zenoh_processor(None, False, data_queue, control_queue)  # type: ignore[arg-type]


### PR DESCRIPTION
Rename and convert the Unitree OM Path SDK connector to Zenoh-only (unitree_om_path_sdk_zenoh.py). Remove CycloneDDS/SportClient paths and consolidate publishers to a sport_request_topic over Zenoh; update class/config names accordingly and adjust movement/permission checks. Update cloud_sim.json5 to use the Zenoh connector and remove Cloud-specific config fields. Refactor related providers/backgrounds: unitree state/odom providers now handle PoseStamped, accept api_key/use_sim, improve logging and session handling, and load session config. Misc fixes and improvements across inputs/providers/tests: adjust VLM Gemini defaults (topic, max_tokens), tidy VLM/Gemini/VLMZenoh implementations and docstrings, fix Google ASR guard init, rename battery fields in status publishing, simplify simple_paths Zenoh handling, update zenoh session API, and update unit tests import to the new connector path.