### PR TITLE
feat: add Bittle BLE protocol actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ logs/
 config/memory
 config/.runtime.json5
 config/cron_job/
+.envrc

--- a/PETOI_PROTOCOL.md
+++ b/PETOI_PROTOCOL.md
@@ -1,0 +1,240 @@
+# Petoi Bittle BLE Protocol Reference
+
+Derived from source analysis of PetoiControllerQt.
+
+---
+
+## 1. Transport Stack
+
+```
+┌─────────────────────────────────────┐
+│     Application (ASCII commands)    │  UiSerialHandler / UiMotionControl
+├─────────────────────────────────────┤
+│       QSerialPort abstraction       │  QSerialMessageQueue
+├─────────────────────────────────────┤
+│   Virtual serial device (/dev/...)  │  rfcomm or BLE UART shim
+├─────────────────────────────────────┤
+│   Nordic UART Service (NUS) / BLE   │  GATT over BLE
+└─────────────────────────────────────┘
+```
+
+The device (`D0:EF:76:CD:BA:D6`, advertised as `BittleA6_SSP`) connects over
+**Bluetooth LE** using the **Nordic UART Service**. BlueZ exposes this as a
+virtual serial port that `QSerialPort` opens normally.
+
+### NUS GATT characteristics
+
+| Characteristic | UUID | Direction | D-Bus path |
+|---|---|---|---|
+| TX (device → host) | `6e400003-b5a3-f393-e0a9-e50e24dcca9e` | Notify | `.../service0028/char0029` |
+| RX (host → device) | `6e400002-b5a3-f393-e0a9-e50e24dcca9e` | Write | `.../service0028/char002c` |
+
+The RX characteristic requires enabling the Client Characteristic Configuration
+Descriptor (CCCD, `0x2902`) on the TX characteristic before notifications flow.
+
+### Default serial parameters
+
+From `SerialConnectionPreference` defaults (index into the sorted combo lists):
+
+| Parameter | Value |
+|---|---|
+| Baud rate | 115200 (index 7) |
+| Data bits | 8 (index 3) |
+| Stop bits | 1 (index 0, `OneStop`) |
+| Parity | None (index 0) |
+
+---
+
+## 2. Wire Protocol: Petoi Token Protocol (ASCII)
+
+All traffic in both directions is **plain ASCII text**. Commands are sent as
+null-terminated strings written directly to the serial device; the firmware
+replies with human-readable ASCII strings (plain text, whitespace-separated
+values for multi-value responses).
+
+There is no framing delimiter on the outgoing side — the app sends the string
+bytes as-is (`msg.c_str()`, `msg.length()`). The firmware implicitly treats a
+newline or a new token as a message boundary.
+
+> **Note:** The source also contains a binary `SerialDataPacket` structure
+> (`DataPacket.h`, `DataPacketHandler.cpp`) with a version byte, length field,
+> two instruction bytes, error byte, type byte, and a 26-byte payload capped
+> with `\r\n`. This format is fully defined but **not wired into outgoing
+> traffic in this application**. All actual `sendCmdViaSerialPort` calls pass
+> plain ASCII strings, and incoming data is also parsed as plain text. The
+> binary protocol appears to be a design artifact or reserved for future use.
+
+---
+
+## 3. Command Reference
+
+### 3.1 Motion / Gait commands
+
+All motion commands use the token prefix `k` followed by a skill name.
+The app polls key state every **100 ms** and re-sends the current gait command
+whenever the state changes.
+
+| ASCII command | Action |
+|---|---|
+| `kwkF` | Walk forward |
+| `kwkL` | Walk left |
+| `kwkR` | Walk right |
+| `kbk` | Walk / crawl / run backward (shared) |
+| `kcrF` | Crawl forward |
+| `kcrL` | Crawl left |
+| `kcrR` | Crawl right |
+| `ktrF` | Trot (fast run) forward |
+| `ktrL` | Trot left |
+| `ktrR` | Trot right |
+| `kbalance` | Stand still / balance (sent on key release) |
+
+**Keyboard mapping** (keys held simultaneously select gait mode):
+
+| Key | Direction |
+|---|---|
+| `W` | Forward |
+| `S` | Backward |
+| `A` | Left |
+| `D` | Right |
+| `1` | Normal walk mode |
+| `2` | Trot/run mode |
+| `3` | Crawl mode |
+
+### 3.2 Posture / skill commands
+
+One-shot commands triggered by UI buttons. No parameters.
+
+| ASCII command | Posture / skill |
+|---|---|
+| `kbuttUp` | Butt up |
+| `kck` | Check around (look around) |
+| `kstr` | Stretch |
+| `khi` | Greeting / wave |
+| `kpee` | Pee pose |
+| `kpu` | Push up |
+| `krest` | Rest (lie down) |
+| `kstp` | Stepping in place |
+| `kbf` | Back flip |
+| `ksit` | Sit down |
+| `kbdF` | Bunny jump |
+| `kvt` | Stepping / vibrate |
+
+### 3.3 Calibration commands
+
+Calibration is a stateful session initiated with `c` and committed with `s`.
+
+| ASCII command | Effect |
+|---|---|
+| `c` | Enter calibration mode. Device responds with the 16 current offsets. |
+| `c<N> <deg>` | Adjust servo `N` by `deg` degrees (range −9 to +9, integer). Example: `c8 -3` |
+| `s` | Save calibration offsets to EEPROM and exit calibration mode. |
+
+**Servo numbering used for calibration:**
+
+| Servo index | Joint |
+|---|---|
+| 0 | Head |
+| 8 | Front-left upper leg |
+| 9 | Front-right upper leg |
+| 10 | Rear-left upper leg |
+| 11 | Rear-right upper leg |
+| 12 | Front-left lower leg |
+| 13 | Front-right lower leg |
+| 14 | Rear-left lower leg |
+| 15 | Rear-right lower leg |
+
+Servos 1–7 are defined in firmware but not exposed in this controller UI.
+
+**Calibration response format** (device → host, ASCII):
+
+```
+0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+<val0>, <val1>, <val2>, ... <val15>,
+```
+
+The app extracts the 16 comma-separated values and maps them back to servos
+0, 8–15 (indices 1–4 and 5–8 in the UI dropdown respectively).
+
+### 3.4 Terminal / custom commands
+
+The UI exposes a raw terminal input and a custom-action table (persisted in
+`actions.json` as `[{"name": "...", "cmd": "..."}]`). Any string entered there
+is sent verbatim, allowing direct use of any firmware token not covered above.
+
+---
+
+## 4. Binary DataPacket structure (defined, not used for TX)
+
+Documented here for completeness in case the firmware sends structured
+responses in this format.
+
+```
+Offset  Size  Field
+0       1     version  — always 0x01
+1       1     dataLen  — total packet size (header 8 bytes + payload + 2 bytes \r\n)
+2       1     ins0     — command category (see below)
+3       1     ins1     — sub-command
+4       1     error    — error code
+5       1     type     — payload data type
+6..N    ≤24   rest     — payload bytes
+N+0     1     0x0D (\r)
+N+1     1     0x0A (\n)
+```
+
+Maximum packet size: **32 bytes**.
+
+**ins0 categories:**
+
+| Value | Constant | Meaning |
+|---|---|---|
+| `0x00` | `CMD_PETOI` | Unsolicited device signal |
+| `0x01` | `CMD_DC` | Device control command |
+| `0x02` | `CMD_MOTION` | Motion command |
+| `0x03` | `CMD_SERVO` | Raw servo command |
+
+**DC sub-commands (`CMD_DC`):**
+
+| ins1 | Constant | Effect |
+|---|---|---|
+| `0xF0` | `DC_PETOI_HELLO` | Establish connection |
+| `0xFF` | `DC_PETOI_BYE` | Disconnect |
+| `0x00/01/02/03` | `DC_LEDS_*` | LED off / on / flash on / flash off |
+| `0x0C` | `DC_LEDS_STATUS` | Query LED state |
+| `0x10/11` | `DC_GYRO_OFF/ON` | Gyro control |
+| `0x20/21` | `DC_SERVOS_OFF/ON` | All servos off / on |
+| `0x30/31` | `DC_SPEAKER_RPT/PLY` | Upload / play melody |
+| `0x40/41/4F` | `DC_BUZZER_*` | Buzzer stop / once / continuous |
+
+**Data type constants:**
+
+| Value | Type |
+|---|---|
+| `0x11` | unsigned char |
+| `0x12` | char |
+| `0x13` | unsigned int |
+| `0x14` | int |
+| `0x15` | unsigned long |
+| `0x16` | long |
+| `0x17` | float |
+| `0x18` | double |
+| `0x00` | none |
+
+---
+
+## 5. Source file map
+
+| File | Role |
+|---|---|
+| `src/DataPacket/Definitions.h` | All protocol constants (opcodes, status codes) |
+| `src/DataPacket/DataPacket.h` | `SerialDataPacket` struct definition |
+| `src/DataPacket/DataPacketHandler.cpp` | Binary packet assembler / validator |
+| `src/Serial/QSerialMessageQueue.cpp` | QSerialPort wrapper with receive queue |
+| `src/Serial/RawMessage.cpp` | Heap-allocated byte buffer for queued messages |
+| `src/Main/Components/Serials/UiSerialHandler.cpp` | Connect / send / receive + 10 ms poll timer |
+| `src/Main/Components/DefaultControls/UiMotionControl.cpp` | Key→gait state machine, 100 ms dispatch timer |
+| `src/Main/Components/Calibration/UiCalibrationCheck.cpp` | Calibration session + servo angle tracking |
+| `src/Main/Components/Calibration/CalibFeedbackProcedure.cpp` | Regex parser for calibration response text |
+| `src/Main/Components/CustomCmds/UiCustomActions.cpp` | User-defined command table |
+| `src/Main/Components/CustomCmds/JsonParementer.cpp` | Persist custom commands to `actions.json` |
+| `src/Main/MainWindow_apx.cpp` | Qt signal/slot wiring + button handlers |
+| `src/Config/GlobalConfig.h` | File name constants (`preference.json`, `actions.json`) |

--- a/config/bittle.json5
+++ b/config/bittle.json5
@@ -1,0 +1,317 @@
+{
+  version: "v1.0.3",
+  hertz: 1,
+  name: "bittle",
+  api_key: "${OM_API_KEY:-openmind_free}",
+  system_prompt_base: "You are controlling a Petoi Bittle quadruped over Bluetooth LE. Use the specific Bittle action that matches the user's requested motion, posture, or skill. Only use calibration actions when the user explicitly asks to calibrate a servo. Calibration servo indexes are 0 and 8 through 15, and adjustment degrees must be an integer from -9 through 9.",
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  system_prompt_examples: "Examples:\n\n1. If a person says 'walk forward', call bittle_walk_forward.\n\n2. If a person says 'sit', call bittle_sit.\n\n3. If a person says 'look around', call bittle_check_around.\n\n4. If a person explicitly says 'calibrate servo 8 down 3 degrees', call bittle_adjust_calibration with servo_index=8 and degrees=-3.",
+  agent_inputs: [
+    {
+      type: "GoogleASRInput",
+      config: {
+        enable_tts_interrupt: false,
+      },
+    },
+    {
+      type: "ConversationHistoryInput",
+      config: {
+        max_rounds: 3,
+      },
+    },
+  ],
+  cortex_llm: {
+    type: "OpenAILLM",
+    config: {
+      agent_name: "Bittle",
+      history_length: 10,
+    },
+  },
+  agent_actions: [
+    {
+      name: "bittle",
+      llm_label: "bittle_walk_forward",
+      connector: "ble",
+      config: {
+        command: "kwkF",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_walk_left",
+      connector: "ble",
+      config: {
+        command: "kwkL",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_walk_right",
+      connector: "ble",
+      config: {
+        command: "kwkR",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_walk_backward",
+      connector: "ble",
+      config: {
+        command: "kbk",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_crawl_forward",
+      connector: "ble",
+      config: {
+        command: "kcrF",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_crawl_left",
+      connector: "ble",
+      config: {
+        command: "kcrL",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_crawl_right",
+      connector: "ble",
+      config: {
+        command: "kcrR",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_trot_forward",
+      connector: "ble",
+      config: {
+        command: "ktrF",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_trot_left",
+      connector: "ble",
+      config: {
+        command: "ktrL",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_trot_right",
+      connector: "ble",
+      config: {
+        command: "ktrR",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_balance",
+      connector: "ble",
+      config: {
+        command: "kbalance",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_butt_up",
+      connector: "ble",
+      config: {
+        command: "kbuttUp",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_check_around",
+      connector: "ble",
+      config: {
+        command: "kck",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_stretch",
+      connector: "ble",
+      config: {
+        command: "kstr",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_greeting",
+      connector: "ble",
+      config: {
+        command: "khi",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_pee_pose",
+      connector: "ble",
+      config: {
+        command: "kpee",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_push_up",
+      connector: "ble",
+      config: {
+        command: "kpu",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_rest",
+      connector: "ble",
+      config: {
+        command: "krest",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_step_in_place",
+      connector: "ble",
+      config: {
+        command: "kstp",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_back_flip",
+      connector: "ble",
+      config: {
+        command: "kbf",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_sit",
+      connector: "ble",
+      config: {
+        command: "ksit",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_bunny_jump",
+      connector: "ble",
+      config: {
+        command: "kbdF",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_vibrate",
+      connector: "ble",
+      config: {
+        command: "kvt",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_enter_calibration",
+      connector: "ble",
+      config: {
+        command: "c",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "adjust_bittle_calibration",
+      llm_label: "bittle_adjust_calibration",
+      connector: "ble",
+      config: {
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+    {
+      name: "bittle",
+      llm_label: "bittle_save_calibration",
+      connector: "ble",
+      config: {
+        command: "s",
+        device_address: "${BITTLE_BLE_ADDRESS:-}",
+        device_name: "${BITTLE_BLE_NAME:-BittleA6_SSP}",
+        simulate: "${BITTLE_SIMULATE:-false}",
+      },
+    },
+  ],
+}

--- a/src/actions/adjust_bittle_calibration/connector/ble.py
+++ b/src/actions/adjust_bittle_calibration/connector/ble.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from actions.adjust_bittle_calibration.interface import BittleCalibrationAdjustmentInput
+from actions.base import ActionConfig, ActionConnector
+from actions.calibrate_bittle.connector.ble import (
+    MAX_CALIBRATION_DEGREES,
+    MIN_CALIBRATION_DEGREES,
+    VALID_CALIBRATION_SERVOS,
+)
+from providers.bittle_ble_provider import (
+    DEFAULT_BITTLE_DEVICE_NAME,
+    NUS_RX_CHARACTERISTIC_UUID,
+    NUS_TX_CHARACTERISTIC_UUID,
+    bittle_settings_from_config,
+    get_bittle_ble_provider,
+)
+
+
+class BittleBLECalibrationAdjustmentConfig(ActionConfig):
+    """
+    Configuration for Petoi Bittle BLE calibration adjustment connector.
+    """
+
+    device_address: Optional[str] = Field(default=None, description="Bittle BLE address or identifier")
+    device_name: Optional[str] = Field(default=DEFAULT_BITTLE_DEVICE_NAME, description="Advertised Bittle BLE name")
+    tx_characteristic_uuid: str = Field(default=NUS_TX_CHARACTERISTIC_UUID, description="NUS TX notify UUID")
+    rx_characteristic_uuid: str = Field(default=NUS_RX_CHARACTERISTIC_UUID, description="NUS RX write UUID")
+    connect_timeout: float = Field(default=10.0, description="BLE connect or scan timeout in seconds")
+    write_with_response: bool = Field(default=True, description="Write BLE commands with response")
+    command_suffix: str = Field(default="", description="Optional suffix appended to each ASCII command")
+    simulate: bool = Field(default=False, description="Log commands without opening BLE")
+
+
+class BittleBLECalibrationAdjustmentConnector(
+    ActionConnector[BittleBLECalibrationAdjustmentConfig, BittleCalibrationAdjustmentInput]
+):
+    """
+    BLE connector for Petoi Bittle c<N> <deg> calibration adjustment commands.
+    """
+
+    def __init__(self, config: BittleBLECalibrationAdjustmentConfig):
+        super().__init__(config)
+        self.provider = get_bittle_ble_provider(bittle_settings_from_config(config))
+
+    async def connect(self, output_interface: BittleCalibrationAdjustmentInput) -> None:
+        servo_index = int(output_interface.servo_index)
+        degrees = int(output_interface.degrees)
+        if servo_index not in VALID_CALIBRATION_SERVOS:
+            raise ValueError(
+                "Bittle calibration servo_index must be one of "
+                f"{sorted(VALID_CALIBRATION_SERVOS)}, got {servo_index}"
+            )
+        if degrees < MIN_CALIBRATION_DEGREES or degrees > MAX_CALIBRATION_DEGREES:
+            raise ValueError(
+                "Bittle calibration degrees must be between "
+                f"{MIN_CALIBRATION_DEGREES} and {MAX_CALIBRATION_DEGREES}, got {degrees}"
+            )
+
+        command = f"c{servo_index} {degrees}"
+        logging.info("Bittle calibration adjustment command: %s", command)
+        await self.provider.send_command(command)
+
+    def stop(self) -> None:
+        """
+        Connection cleanup is left to process teardown because providers can be shared.
+        """
+        pass

--- a/src/actions/adjust_bittle_calibration/interface.py
+++ b/src/actions/adjust_bittle_calibration/interface.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from actions.base import Interface
+
+
+@dataclass
+class BittleCalibrationAdjustmentInput:
+    """
+    Input interface for adjusting one Petoi Bittle calibration servo.
+
+    Parameters
+    ----------
+    servo_index : int
+        Servo index to adjust. Valid Petoi UI-exposed servos are 0 and 8 through 15.
+    degrees : int
+        Integer adjustment in degrees. Valid range is -9 through 9.
+    """
+
+    servo_index: int
+    degrees: int
+
+
+@dataclass
+class BittleCalibrationAdjustment(
+    Interface[BittleCalibrationAdjustmentInput, BittleCalibrationAdjustmentInput]
+):
+    """
+    Adjust one Petoi Bittle calibration servo over BLE.
+    """
+
+    input: BittleCalibrationAdjustmentInput
+    output: BittleCalibrationAdjustmentInput

--- a/src/actions/bittle/connector/ble.py
+++ b/src/actions/bittle/connector/ble.py
@@ -1,0 +1,52 @@
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from actions.base import ActionConfig, ActionConnector
+from actions.bittle.interface import BittleInput
+from providers.bittle_ble_provider import (
+    DEFAULT_BITTLE_DEVICE_NAME,
+    NUS_RX_CHARACTERISTIC_UUID,
+    NUS_TX_CHARACTERISTIC_UUID,
+    bittle_settings_from_config,
+    get_bittle_ble_provider,
+)
+
+
+class BittleConfiguredBLEConfig(ActionConfig):
+    """
+    Configuration for a single Petoi Bittle BLE command action.
+    """
+
+    command: str = Field(description="Petoi ASCII token to send, such as kwkF, kbalance, or ksit")
+    device_address: Optional[str] = Field(default=None, description="Bittle BLE address or identifier")
+    device_name: Optional[str] = Field(default=DEFAULT_BITTLE_DEVICE_NAME, description="Advertised Bittle BLE name")
+    tx_characteristic_uuid: str = Field(default=NUS_TX_CHARACTERISTIC_UUID, description="NUS TX notify UUID")
+    rx_characteristic_uuid: str = Field(default=NUS_RX_CHARACTERISTIC_UUID, description="NUS RX write UUID")
+    connect_timeout: float = Field(default=10.0, description="BLE connect or scan timeout in seconds")
+    write_with_response: bool = Field(default=True, description="Write BLE commands with response")
+    command_suffix: str = Field(default="", description="Optional suffix appended to each ASCII command")
+    simulate: bool = Field(default=False, description="Log commands without opening BLE")
+
+
+class BittleConfiguredBLEConnector(ActionConnector[BittleConfiguredBLEConfig, BittleInput]):
+    """
+    BLE connector for one configured Petoi Bittle ASCII token.
+    """
+
+    def __init__(self, config: BittleConfiguredBLEConfig):
+        super().__init__(config)
+        if not self.config.command:
+            raise ValueError("Bittle configured action requires config.command")
+        self.provider = get_bittle_ble_provider(bittle_settings_from_config(config))
+
+    async def connect(self, output_interface: BittleInput) -> None:
+        logging.info("Bittle configured command: %s", self.config.command)
+        await self.provider.send_command(self.config.command)
+
+    def stop(self) -> None:
+        """
+        Connection cleanup is left to process teardown because providers can be shared.
+        """
+        pass

--- a/src/actions/bittle/interface.py
+++ b/src/actions/bittle/interface.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from actions.base import Interface
+
+
+@dataclass
+class BittleInput:
+    """
+    Empty input for a configured Petoi Bittle command.
+    """
+
+
+@dataclass
+class Bittle(Interface[BittleInput, BittleInput]):
+    """
+    Send one configured Petoi Bittle ASCII token over BLE.
+    """
+
+    input: BittleInput
+    output: BittleInput

--- a/src/actions/calibrate_bittle/connector/ble.py
+++ b/src/actions/calibrate_bittle/connector/ble.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from actions.base import ActionConfig, ActionConnector
+from actions.calibrate_bittle.interface import BittleCalibrationInput, BittleCalibrationOperation
+from providers.bittle_ble_provider import (
+    DEFAULT_BITTLE_DEVICE_NAME,
+    NUS_RX_CHARACTERISTIC_UUID,
+    NUS_TX_CHARACTERISTIC_UUID,
+    bittle_settings_from_config,
+    get_bittle_ble_provider,
+)
+
+VALID_CALIBRATION_SERVOS = {0, 8, 9, 10, 11, 12, 13, 14, 15}
+MIN_CALIBRATION_DEGREES = -9
+MAX_CALIBRATION_DEGREES = 9
+
+
+class BittleBLECalibrationConfig(ActionConfig):
+    """
+    Configuration for Petoi Bittle BLE calibration connector.
+    """
+
+    device_address: Optional[str] = Field(default=None, description="Bittle BLE address or identifier")
+    device_name: Optional[str] = Field(default=DEFAULT_BITTLE_DEVICE_NAME, description="Advertised Bittle BLE name")
+    tx_characteristic_uuid: str = Field(default=NUS_TX_CHARACTERISTIC_UUID, description="NUS TX notify UUID")
+    rx_characteristic_uuid: str = Field(default=NUS_RX_CHARACTERISTIC_UUID, description="NUS RX write UUID")
+    connect_timeout: float = Field(default=10.0, description="BLE connect or scan timeout in seconds")
+    write_with_response: bool = Field(default=True, description="Write BLE commands with response")
+    command_suffix: str = Field(default="", description="Optional suffix appended to each ASCII command")
+    simulate: bool = Field(default=False, description="Log commands without opening BLE")
+
+
+class BittleBLECalibrationConnector(ActionConnector[BittleBLECalibrationConfig, BittleCalibrationInput]):
+    """
+    BLE connector for Petoi Bittle calibration commands.
+    """
+
+    def __init__(self, config: BittleBLECalibrationConfig):
+        super().__init__(config)
+        self.provider = get_bittle_ble_provider(bittle_settings_from_config(config))
+
+    async def connect(self, output_interface: BittleCalibrationInput) -> None:
+        operation = BittleCalibrationOperation(output_interface.operation)
+
+        if operation == BittleCalibrationOperation.ENTER:
+            command = "c"
+        elif operation == BittleCalibrationOperation.SAVE:
+            command = "s"
+        else:
+            servo_index = int(output_interface.servo_index)
+            degrees = int(output_interface.degrees)
+            if servo_index not in VALID_CALIBRATION_SERVOS:
+                raise ValueError(
+                    "Bittle calibration servo_index must be one of "
+                    f"{sorted(VALID_CALIBRATION_SERVOS)}, got {servo_index}"
+                )
+            if degrees < MIN_CALIBRATION_DEGREES or degrees > MAX_CALIBRATION_DEGREES:
+                raise ValueError(
+                    "Bittle calibration degrees must be between "
+                    f"{MIN_CALIBRATION_DEGREES} and {MAX_CALIBRATION_DEGREES}, got {degrees}"
+                )
+            command = f"c{servo_index} {degrees}"
+
+        logging.info("Bittle calibration command: %s -> %s", operation.value, command)
+        await self.provider.send_command(command)
+
+    def stop(self) -> None:
+        """
+        Connection cleanup is left to process teardown because providers can be shared.
+        """
+        pass

--- a/src/actions/calibrate_bittle/interface.py
+++ b/src/actions/calibrate_bittle/interface.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from actions.base import Interface
+
+
+class BittleCalibrationOperation(str, Enum):
+    """
+    Petoi Bittle calibration operations.
+    """
+
+    ENTER = "enter calibration"
+    ADJUST = "adjust servo"
+    SAVE = "save calibration"
+
+
+@dataclass
+class BittleCalibrationInput:
+    """
+    Input interface for Petoi Bittle calibration.
+
+    Parameters
+    ----------
+    operation : BittleCalibrationOperation
+        Calibration operation to run: enter calibration, adjust servo, or save calibration.
+    servo_index : int
+        Servo index for adjust servo. Valid Petoi UI-exposed servos are 0 and 8 through 15.
+    degrees : int
+        Integer adjustment in degrees for adjust servo. Valid range is -9 through 9.
+    """
+
+    operation: BittleCalibrationOperation
+    servo_index: int = 0
+    degrees: int = 0
+
+
+@dataclass
+class BittleCalibration(Interface[BittleCalibrationInput, BittleCalibrationInput]):
+    """
+    Run documented Petoi Bittle calibration commands over BLE: enter calibration, adjust servo, or save calibration.
+    Servo adjustment is limited to servo indexes 0 and 8 through 15, with integer degree changes from -9 through 9.
+    """
+
+    input: BittleCalibrationInput
+    output: BittleCalibrationInput

--- a/src/actions/move_bittle/connector/ble.py
+++ b/src/actions/move_bittle/connector/ble.py
@@ -1,0 +1,90 @@
+import logging
+from typing import Optional
+
+from pydantic import Field
+
+from actions.base import ActionConfig, ActionConnector
+from actions.move_bittle.interface import BittleMoveAction, BittleMoveInput
+from providers.bittle_ble_provider import (
+    DEFAULT_BITTLE_DEVICE_NAME,
+    NUS_RX_CHARACTERISTIC_UUID,
+    NUS_TX_CHARACTERISTIC_UUID,
+    bittle_settings_from_config,
+    get_bittle_ble_provider,
+)
+
+
+class BittleBLEConfig(ActionConfig):
+    """
+    Configuration for Petoi Bittle BLE action connectors.
+
+    Parameters
+    ----------
+    device_address : Optional[str]
+        BLE MAC address or platform-specific BLE identifier. If omitted, the connector scans by device_name.
+    device_name : Optional[str]
+        Advertised BLE device name to scan for.
+    command_suffix : str
+        Optional command suffix. The Petoi controller sends ASCII tokens as-is, so the default is empty.
+    simulate : bool
+        If true, commands are logged and captured without opening BLE.
+    """
+
+    device_address: Optional[str] = Field(default=None, description="Bittle BLE address or identifier")
+    device_name: Optional[str] = Field(default=DEFAULT_BITTLE_DEVICE_NAME, description="Advertised Bittle BLE name")
+    tx_characteristic_uuid: str = Field(default=NUS_TX_CHARACTERISTIC_UUID, description="NUS TX notify UUID")
+    rx_characteristic_uuid: str = Field(default=NUS_RX_CHARACTERISTIC_UUID, description="NUS RX write UUID")
+    connect_timeout: float = Field(default=10.0, description="BLE connect or scan timeout in seconds")
+    write_with_response: bool = Field(default=True, description="Write BLE commands with response")
+    command_suffix: str = Field(default="", description="Optional suffix appended to each ASCII command")
+    simulate: bool = Field(default=False, description="Log commands without opening BLE")
+
+
+BITTLE_MOVE_COMMANDS: dict[BittleMoveAction, str] = {
+    BittleMoveAction.WALK_FORWARD: "kwkF",
+    BittleMoveAction.WALK_LEFT: "kwkL",
+    BittleMoveAction.WALK_RIGHT: "kwkR",
+    BittleMoveAction.WALK_BACKWARD: "kbk",
+    BittleMoveAction.CRAWL_FORWARD: "kcrF",
+    BittleMoveAction.CRAWL_LEFT: "kcrL",
+    BittleMoveAction.CRAWL_RIGHT: "kcrR",
+    BittleMoveAction.TROT_FORWARD: "ktrF",
+    BittleMoveAction.TROT_LEFT: "ktrL",
+    BittleMoveAction.TROT_RIGHT: "ktrR",
+    BittleMoveAction.STAND_STILL: "kbalance",
+    BittleMoveAction.BALANCE: "kbalance",
+    BittleMoveAction.BUTT_UP: "kbuttUp",
+    BittleMoveAction.CHECK_AROUND: "kck",
+    BittleMoveAction.STRETCH: "kstr",
+    BittleMoveAction.GREETING: "khi",
+    BittleMoveAction.PEE_POSE: "kpee",
+    BittleMoveAction.PUSH_UP: "kpu",
+    BittleMoveAction.REST: "krest",
+    BittleMoveAction.STEP_IN_PLACE: "kstp",
+    BittleMoveAction.BACK_FLIP: "kbf",
+    BittleMoveAction.SIT: "ksit",
+    BittleMoveAction.BUNNY_JUMP: "kbdF",
+    BittleMoveAction.VIBRATE: "kvt",
+}
+
+
+class BittleBLEMoveConnector(ActionConnector[BittleBLEConfig, BittleMoveInput]):
+    """
+    BLE connector for Petoi Bittle movement, gait, posture, and skill commands.
+    """
+
+    def __init__(self, config: BittleBLEConfig):
+        super().__init__(config)
+        self.provider = get_bittle_ble_provider(bittle_settings_from_config(config))
+
+    async def connect(self, output_interface: BittleMoveInput) -> None:
+        action = BittleMoveAction(output_interface.action)
+        command = BITTLE_MOVE_COMMANDS[action]
+        logging.info("Bittle move command: %s -> %s", action.value, command)
+        await self.provider.send_command(command)
+
+    def stop(self) -> None:
+        """
+        Connection cleanup is left to process teardown because providers can be shared.
+        """
+        pass

--- a/src/actions/move_bittle/interface.py
+++ b/src/actions/move_bittle/interface.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from actions.base import Interface
+
+
+class BittleMoveAction(str, Enum):
+    """
+    Petoi Bittle gait, posture, and skill commands supported by the ASCII token protocol.
+    """
+
+    WALK_FORWARD = "walk forward"
+    WALK_LEFT = "walk left"
+    WALK_RIGHT = "walk right"
+    WALK_BACKWARD = "walk backward"
+    CRAWL_FORWARD = "crawl forward"
+    CRAWL_LEFT = "crawl left"
+    CRAWL_RIGHT = "crawl right"
+    TROT_FORWARD = "trot forward"
+    TROT_LEFT = "trot left"
+    TROT_RIGHT = "trot right"
+    STAND_STILL = "stand still"
+    BALANCE = "balance"
+    BUTT_UP = "butt up"
+    CHECK_AROUND = "check around"
+    STRETCH = "stretch"
+    GREETING = "greeting"
+    PEE_POSE = "pee pose"
+    PUSH_UP = "push up"
+    REST = "rest"
+    STEP_IN_PLACE = "step in place"
+    BACK_FLIP = "back flip"
+    SIT = "sit"
+    BUNNY_JUMP = "bunny jump"
+    VIBRATE = "vibrate"
+
+
+@dataclass
+class BittleMoveInput:
+    """
+    Input interface for Petoi Bittle movement.
+
+    Parameters
+    ----------
+    action : BittleMoveAction
+        The gait, posture, or skill command to execute on the Bittle robot. Supported actions are walk forward,
+        walk left, walk right, walk backward, crawl forward, crawl left, crawl right, trot forward, trot left,
+        trot right, stand still, balance, butt up, check around, stretch, greeting, pee pose, push up, rest,
+        step in place, back flip, sit, bunny jump, and vibrate.
+    """
+
+    action: BittleMoveAction
+
+
+@dataclass
+class BittleMove(Interface[BittleMoveInput, BittleMoveInput]):
+    """
+    Move or pose a Petoi Bittle robot using documented Petoi ASCII gait, posture, and skill tokens.
+    """
+
+    input: BittleMoveInput
+    output: BittleMoveInput

--- a/src/actions/orchestrator.py
+++ b/src/actions/orchestrator.py
@@ -326,6 +326,11 @@ class ActionOrchestrator:
         input_type = T.get_type_hints(agent_action.interface)["input"]
         input_type_hints = T.get_type_hints(input_type)
 
+        if not input_type_hints:
+            input_interface = input_type()
+            await agent_action.connector.connect(input_interface)
+            return input_interface
+
         converted_params = {}
         for key, value in input_params.items():
             if key in input_type_hints:

--- a/src/providers/bittle_ble_provider.py
+++ b/src/providers/bittle_ble_provider.py
@@ -1,0 +1,208 @@
+import asyncio
+import logging
+import threading
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Deque, Optional
+
+from bleak import BleakClient, BleakScanner
+
+NUS_TX_CHARACTERISTIC_UUID = "6e400003-b5a3-f393-e0a9-e50e24dcca9e"
+NUS_RX_CHARACTERISTIC_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+DEFAULT_BITTLE_DEVICE_NAME = "BittleA6_SSP"
+
+
+@dataclass(frozen=True)
+class BittleBLESettings:
+    """
+    Connection settings for Petoi Bittle over Nordic UART Service.
+    """
+
+    device_address: Optional[str] = None
+    device_name: Optional[str] = DEFAULT_BITTLE_DEVICE_NAME
+    tx_characteristic_uuid: str = NUS_TX_CHARACTERISTIC_UUID
+    rx_characteristic_uuid: str = NUS_RX_CHARACTERISTIC_UUID
+    connect_timeout: float = 10.0
+    write_with_response: bool = True
+    command_suffix: str = ""
+    simulate: bool = False
+
+
+def _none_if_empty(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def bittle_settings_from_config(config: Any) -> BittleBLESettings:
+    """
+    Build Bittle BLE settings from an action connector config object.
+    """
+    return BittleBLESettings(
+        device_address=_none_if_empty(getattr(config, "device_address", None)),
+        device_name=_none_if_empty(getattr(config, "device_name", DEFAULT_BITTLE_DEVICE_NAME)),
+        tx_characteristic_uuid=str(
+            getattr(config, "tx_characteristic_uuid", NUS_TX_CHARACTERISTIC_UUID)
+            or NUS_TX_CHARACTERISTIC_UUID
+        ),
+        rx_characteristic_uuid=str(
+            getattr(config, "rx_characteristic_uuid", NUS_RX_CHARACTERISTIC_UUID)
+            or NUS_RX_CHARACTERISTIC_UUID
+        ),
+        connect_timeout=float(getattr(config, "connect_timeout", 10.0)),
+        write_with_response=bool(getattr(config, "write_with_response", True)),
+        command_suffix=str(getattr(config, "command_suffix", "")),
+        simulate=bool(getattr(config, "simulate", False)),
+    )
+
+
+class BittleBLEProvider:
+    """
+    Async BLE/NUS transport for Petoi Bittle's ASCII token protocol.
+    """
+
+    def __init__(self, settings: BittleBLESettings):
+        self.settings = settings
+        self._client: Optional[BleakClient] = None
+        self._connect_lock: Optional[asyncio.Lock] = None
+        self._connect_lock_loop: Optional[asyncio.AbstractEventLoop] = None
+        self.received_messages: Deque[str] = deque(maxlen=100)
+        self.sent_commands: Deque[str] = deque(maxlen=100)
+        self.sent_payloads: Deque[bytes] = deque(maxlen=100)
+
+    def _lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        if self._connect_lock is None or self._connect_lock_loop is not loop:
+            self._connect_lock = asyncio.Lock()
+            self._connect_lock_loop = loop
+        return self._connect_lock
+
+    async def _resolve_device(self) -> Any:
+        if self.settings.device_address:
+            return self.settings.device_address
+
+        if not self.settings.device_name:
+            raise ValueError("Bittle BLE connection requires either device_address or device_name")
+
+        logging.info("Scanning for Bittle BLE device named %s", self.settings.device_name)
+
+        def matches(device: Any, advertisement_data: Any) -> bool:
+            names = (
+                getattr(device, "name", None),
+                getattr(advertisement_data, "local_name", None),
+            )
+            return any(name == self.settings.device_name for name in names if name)
+
+        device = await BleakScanner.find_device_by_filter(matches, timeout=self.settings.connect_timeout)
+        if device is None:
+            raise RuntimeError(f"Could not find Bittle BLE device named {self.settings.device_name!r}")
+        return device
+
+    async def connect(self) -> None:
+        """
+        Lazily connect to the Bittle BLE UART service and enable notifications.
+        """
+        if self.settings.simulate:
+            return
+
+        if self._client is not None and self._client.is_connected:
+            return
+
+        async with self._lock():
+            if self._client is not None and self._client.is_connected:
+                return
+
+            device = await self._resolve_device()
+            client = BleakClient(device, timeout=self.settings.connect_timeout)
+            await client.connect()
+            self._client = client
+
+            try:
+                await client.start_notify(self.settings.tx_characteristic_uuid, self._handle_notification)
+            except Exception:
+                logging.exception("Connected to Bittle, but failed to enable TX notifications")
+                raise
+
+            logging.info("Connected to Bittle BLE device")
+
+    def _encode_command(self, command: str) -> bytes:
+        wire_command = f"{command}{self.settings.command_suffix}"
+        try:
+            return wire_command.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ValueError(f"Bittle commands must be ASCII: {command!r}") from exc
+
+    async def send_command(self, command: str) -> None:
+        """
+        Send one Petoi ASCII token command to the RX characteristic.
+        """
+        if not command:
+            raise ValueError("Bittle command cannot be empty")
+
+        payload = self._encode_command(command)
+
+        if self.settings.simulate:
+            logging.info("Simulating Bittle BLE command: %s", command)
+            self.sent_commands.append(command)
+            self.sent_payloads.append(payload)
+            return
+
+        await self.connect()
+        if self._client is None or not self._client.is_connected:
+            raise RuntimeError("Bittle BLE client is not connected")
+
+        await self._client.write_gatt_char(
+            self.settings.rx_characteristic_uuid,
+            payload,
+            response=self.settings.write_with_response,
+        )
+        self.sent_commands.append(command)
+        self.sent_payloads.append(payload)
+        logging.info("Sent Bittle BLE command: %s", command)
+
+    def _handle_notification(self, _sender: Any, data: bytearray) -> None:
+        message = bytes(data).decode("ascii", errors="replace")
+        self.received_messages.append(message)
+        logging.debug("Bittle BLE notification: %s", message)
+
+    async def disconnect(self) -> None:
+        """
+        Close the BLE connection if it is open.
+        """
+        if self._client is None:
+            return
+
+        try:
+            if self._client.is_connected:
+                try:
+                    await self._client.stop_notify(self.settings.tx_characteristic_uuid)
+                except Exception:
+                    logging.debug("Ignoring Bittle notify stop failure", exc_info=True)
+                await self._client.disconnect()
+        finally:
+            self._client = None
+
+
+_provider_registry: dict[BittleBLESettings, BittleBLEProvider] = {}
+_provider_registry_lock = threading.Lock()
+
+
+def get_bittle_ble_provider(settings: BittleBLESettings) -> BittleBLEProvider:
+    """
+    Return one BLE provider per settings tuple so action connectors share a connection.
+    """
+    with _provider_registry_lock:
+        provider = _provider_registry.get(settings)
+        if provider is None:
+            provider = BittleBLEProvider(settings)
+            _provider_registry[settings] = provider
+        return provider
+
+
+def reset_bittle_ble_providers() -> None:
+    """
+    Clear provider registry. Intended for tests and process teardown paths.
+    """
+    with _provider_registry_lock:
+        _provider_registry.clear()

--- a/tests/actions/test_bittle_actions.py
+++ b/tests/actions/test_bittle_actions.py
@@ -1,0 +1,89 @@
+import pytest
+
+from actions.adjust_bittle_calibration.connector.ble import (
+    BittleBLECalibrationAdjustmentConfig,
+    BittleBLECalibrationAdjustmentConnector,
+)
+from actions.adjust_bittle_calibration.interface import BittleCalibrationAdjustmentInput
+from actions.bittle.connector.ble import BittleConfiguredBLEConfig, BittleConfiguredBLEConnector
+from actions.bittle.interface import BittleInput
+from actions.calibrate_bittle.connector.ble import BittleBLECalibrationConfig, BittleBLECalibrationConnector
+from actions.calibrate_bittle.interface import BittleCalibrationInput, BittleCalibrationOperation
+from actions.move_bittle.connector.ble import BITTLE_MOVE_COMMANDS, BittleBLEConfig, BittleBLEMoveConnector
+from actions.move_bittle.interface import BittleMoveInput
+from providers.bittle_ble_provider import reset_bittle_ble_providers
+
+
+@pytest.fixture(autouse=True)
+def reset_bittle_providers():
+    reset_bittle_ble_providers()
+    yield
+    reset_bittle_ble_providers()
+
+
+@pytest.mark.asyncio
+async def test_bittle_move_connector_exposes_protocol_commands():
+    connector = BittleBLEMoveConnector(BittleBLEConfig(simulate=True))
+
+    for action in BITTLE_MOVE_COMMANDS:
+        await connector.connect(BittleMoveInput(action=action))
+
+    assert list(connector.provider.sent_commands) == list(BITTLE_MOVE_COMMANDS.values())
+
+
+@pytest.mark.asyncio
+async def test_bittle_configured_connector_sends_command_from_config():
+    connector = BittleConfiguredBLEConnector(BittleConfiguredBLEConfig(command="kwkF", simulate=True))
+
+    await connector.connect(BittleInput())
+
+    assert list(connector.provider.sent_commands) == ["kwkF"]
+
+
+@pytest.mark.asyncio
+async def test_bittle_calibration_connector_maps_session_adjust_and_save():
+    connector = BittleBLECalibrationConnector(BittleBLECalibrationConfig(simulate=True))
+
+    await connector.connect(BittleCalibrationInput(operation=BittleCalibrationOperation.ENTER))
+    await connector.connect(
+        BittleCalibrationInput(
+            operation=BittleCalibrationOperation.ADJUST,
+            servo_index=8,
+            degrees=-3,
+        )
+    )
+    await connector.connect(BittleCalibrationInput(operation=BittleCalibrationOperation.SAVE))
+
+    assert list(connector.provider.sent_commands) == ["c", "c8 -3", "s"]
+
+
+@pytest.mark.asyncio
+async def test_bittle_calibration_adjustment_connector_uses_servo_and_degrees_only():
+    connector = BittleBLECalibrationAdjustmentConnector(BittleBLECalibrationAdjustmentConfig(simulate=True))
+
+    await connector.connect(BittleCalibrationAdjustmentInput(servo_index=8, degrees=-3))
+
+    assert list(connector.provider.sent_commands) == ["c8 -3"]
+
+
+@pytest.mark.asyncio
+async def test_bittle_calibration_connector_validates_servo_and_degrees():
+    connector = BittleBLECalibrationConnector(BittleBLECalibrationConfig(simulate=True))
+
+    with pytest.raises(ValueError, match="servo_index"):
+        await connector.connect(
+            BittleCalibrationInput(
+                operation=BittleCalibrationOperation.ADJUST,
+                servo_index=7,
+                degrees=0,
+            )
+        )
+
+    with pytest.raises(ValueError, match="degrees"):
+        await connector.connect(
+            BittleCalibrationInput(
+                operation=BittleCalibrationOperation.ADJUST,
+                servo_index=8,
+                degrees=10,
+            )
+        )


### PR DESCRIPTION
## Summary
- add Petoi Bittle BLE protocol reference
- expose documented Bittle movement and calibration actions
- remove the raw Bittle command action from the config/runtime surface

## Testing
- Demoed at hackathon