### PR TITLE
Add Zenoh session context manager and tests

### DIFF
--- a/src/zenoh_msgs/session.py
+++ b/src/zenoh_msgs/session.py
@@ -1,6 +1,4 @@
-import json
 import logging
-import os
 from typing import Any, Callable, Optional, Union
 
 import zenoh
@@ -21,12 +19,6 @@ def create_zenoh_config(network_discovery: bool = True) -> zenoh.Config:
     """
     Create a Zenoh configuration for a client connecting to a Zenoh router.
 
-    The connect endpoint defaults to tcp/127.0.0.1:7447 (a local router on
-    the same host) but can be overridden via OM1_ZENOH_ENDPOINT — for example
-    "wss/test-sim.openmind.com:8444" to reach a remote Zenoh router over a
-    TLS-terminated WebSocket. For self-signed test deployments,
-    OM1_ZENOH_TLS_ROOT_CA can point at the trusted CA cert file path.
-
     Parameters
     ----------
     network_discovery : bool, optional
@@ -39,17 +31,8 @@ def create_zenoh_config(network_discovery: bool = True) -> zenoh.Config:
     """
     config = zenoh.Config()
     if not network_discovery:
-        endpoint = os.environ.get("OM1_ZENOH_ENDPOINT", "tcp/127.0.0.1:7447")
         config.insert_json5("mode", '"client"')
-        config.insert_json5("connect/endpoints", json.dumps([endpoint]))
-
-        if endpoint.startswith(("wss/", "tls/", "quic/")):
-            ca_path = os.environ.get("OM1_ZENOH_TLS_ROOT_CA")
-            if ca_path:
-                config.insert_json5(
-                    "transport/link/tls/root_ca_certificate",
-                    json.dumps(ca_path),
-                )
+        config.insert_json5("connect/endpoints", '["tcp/127.0.0.1:7447"]')
 
     return config
 

--- a/src/zenoh_msgs/session.py
+++ b/src/zenoh_msgs/session.py
@@ -284,17 +284,17 @@ class _ZenohSessionContextManager:
 
         return self._session
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, _exc_type, _exc_val, _exc_tb) -> None:
         """
         Close the Zenoh session.
 
         Parameters
         ----------
-        exc_type : type, optional
+        _exc_type : type, optional
             The type of exception that occurred, if any.
-        exc_val : Exception, optional
+        _exc_val : Exception, optional
             The exception instance that occurred, if any.
-        exc_tb : traceback, optional
+        _exc_tb : traceback, optional
             The traceback object, if any.
         """
         if self._session is not None:

--- a/src/zenoh_msgs/session.py
+++ b/src/zenoh_msgs/session.py
@@ -13,7 +13,7 @@ from zenoh_msgs.cloud_session.zenoh_adapter import (
     _Subscriber,
 )
 
-ZenohSessionType = Union[zenoh.Session, CloudSimZenohSession, "HybridZenohSession"]
+ZenohSessionType = Union[zenoh.Session, CloudSimZenohSession, "HybridZenohSession", "_ZenohSessionContextManager"]
 ZenohSampleType = Union[zenoh.Sample, "_Sample"]
 
 
@@ -261,9 +261,85 @@ class HybridZenohSession:
             logging.info("Closed standard Zenoh session")
 
 
-def open_zenoh_session() -> ZenohSessionType:
+def open_zenoh_session() -> "_ZenohSessionContextManager":
     """
     Open a Zenoh session.
+
+    Returns
+    -------
+    _ZenohSessionContextManager
+        A context manager that yields a Zenoh session.
+    """
+    return _ZenohSessionContextManager()
+
+
+class _ZenohSessionContextManager:
+    """
+    Context manager wrapper for Zenoh sessions.
+
+    This class enables using open_zenoh_session() with the 'with' statement,
+    ensuring proper cleanup of resources. It also maintains backward compatibility
+    by allowing direct attribute access without using a context manager.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize the context manager without creating the session yet.
+        """
+        self._session: Optional[ZenohSessionType] = None
+
+    def __enter__(self) -> ZenohSessionType:
+        """
+        Open and return the Zenoh session.
+
+        Returns
+        -------
+        ZenohSessionType
+            The opened Zenoh session.
+        """
+        self._session = _create_zenoh_session()
+
+        return self._session
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Close the Zenoh session.
+
+        Parameters
+        ----------
+        exc_type : type, optional
+            The type of exception that occurred, if any.
+        exc_val : Exception, optional
+            The exception instance that occurred, if any.
+        exc_tb : traceback, optional
+            The traceback object, if any.
+        """
+        if self._session is not None:
+            self._session.close()
+            logging.info("Closed Zenoh session")
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        Forward attribute access to the underlying session.
+
+        Parameters
+        ----------
+        name : str
+            The name of the attribute to access.
+
+        Returns
+        -------
+        Any
+            The value of the requested attribute from the underlying session.
+        """
+        if self._session is None:
+            self._session = _create_zenoh_session()
+        return getattr(self._session, name)
+
+
+def _create_zenoh_session() -> ZenohSessionType:
+    """
+    Internal function to create a Zenoh session.
 
     Returns
     -------

--- a/tests/zenoh_msgs/test_session.py
+++ b/tests/zenoh_msgs/test_session.py
@@ -6,6 +6,7 @@ import zenoh
 from zenoh_msgs.session import (
     HybridZenohSession,
     _create_zenoh_session,
+    _open_cloud_session,
     _ZenohSessionContextManager,
     create_zenoh_config,
     load_api_key,
@@ -23,6 +24,56 @@ class TestCreateZenohConfig:
     def test_create_config_with_network_discovery_disabled(self):
         config = create_zenoh_config(network_discovery=False)
         assert isinstance(config, zenoh.Config)
+
+    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "tcp/192.168.1.100:7447"})
+    def test_create_config_uses_custom_endpoint(self):
+        config = create_zenoh_config(network_discovery=False)
+        assert isinstance(config, zenoh.Config)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "OM1_ZENOH_ENDPOINT": "wss/test-sim.openmind.com:8444",
+            "OM1_ZENOH_TLS_ROOT_CA": "/path/to/ca.pem",
+        },
+    )
+    def test_create_config_uses_tls_endpoint_and_ca(self):
+        config = create_zenoh_config(network_discovery=False)
+        assert isinstance(config, zenoh.Config)
+
+    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "tls/example.com:7447"})
+    def test_create_config_uses_tls_without_ca(self):
+        config = create_zenoh_config(network_discovery=False)
+        assert isinstance(config, zenoh.Config)
+
+    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "quic/example.com:7447"})
+    def test_create_config_uses_quic_protocol(self):
+        config = create_zenoh_config(network_discovery=False)
+        assert isinstance(config, zenoh.Config)
+
+
+class TestOpenCloudSession:
+    """Test the _open_cloud_session function."""
+
+    @patch("zenoh_msgs.session.CloudSimZenohSession")
+    def test_open_cloud_session_with_default_url(self, mock_cloud_session_class):
+        mock_session = MagicMock()
+        mock_cloud_session_class.return_value = mock_session
+
+        result = _open_cloud_session()
+
+        mock_cloud_session_class.assert_called_once_with("wss://api.openmind.com/api/core/simulation/zenoh", token=None)
+        assert result is mock_session
+
+    @patch("zenoh_msgs.session.CloudSimZenohSession")
+    def test_open_cloud_session_with_custom_url_and_token(self, mock_cloud_session_class):
+        mock_session = MagicMock()
+        mock_cloud_session_class.return_value = mock_session
+
+        result = _open_cloud_session(url="wss://custom.url:8444", token="my_token")
+
+        mock_cloud_session_class.assert_called_once_with("wss://custom.url:8444", token="my_token")
+        assert result is mock_session
 
 
 class TestOpenZenohSession:

--- a/tests/zenoh_msgs/test_session.py
+++ b/tests/zenoh_msgs/test_session.py
@@ -5,6 +5,8 @@ import zenoh
 
 from zenoh_msgs.session import (
     HybridZenohSession,
+    _create_zenoh_session,
+    _ZenohSessionContextManager,
     create_zenoh_config,
     load_api_key,
     load_session_config,
@@ -24,42 +26,138 @@ class TestCreateZenohConfig:
 
 
 class TestOpenZenohSession:
+    """Test open_zenoh_session returns a context manager."""
+
+    def test_returns_context_manager(self):
+        result = open_zenoh_session()
+        assert isinstance(result, _ZenohSessionContextManager)
+
+
+class TestZenohSessionContextManager:
+    """Test the _ZenohSessionContextManager class."""
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_enter_creates_session(self, mock_create_session):
+        mock_session = MagicMock()
+        mock_create_session.return_value = mock_session
+
+        ctx_mgr = _ZenohSessionContextManager()
+        session = ctx_mgr.__enter__()
+
+        mock_create_session.assert_called_once()
+        assert session is mock_session
+        assert ctx_mgr._session is mock_session
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_exit_closes_session(self, mock_create_session):
+        mock_session = MagicMock()
+        mock_create_session.return_value = mock_session
+
+        ctx_mgr = _ZenohSessionContextManager()
+        ctx_mgr.__enter__()
+        ctx_mgr.__exit__(None, None, None)
+
+        mock_session.close.assert_called_once()
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_exit_handles_uninitialized_session(self, mock_create_session):
+        ctx_mgr = _ZenohSessionContextManager()
+        # Should not raise when session is None
+        ctx_mgr.__exit__(None, None, None)
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_getattr_creates_session_lazily(self, mock_create_session):
+        mock_session = MagicMock()
+        mock_session.some_attr = "value"
+        mock_create_session.return_value = mock_session
+
+        ctx_mgr = _ZenohSessionContextManager()
+        result = ctx_mgr.some_attr
+
+        mock_create_session.assert_called_once()
+        assert result == "value"
+        assert ctx_mgr._session is mock_session
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_getattr_uses_cached_session(self, mock_create_session):
+        mock_session = MagicMock()
+        mock_session.attr1 = "value1"
+        mock_session.attr2 = "value2"
+        mock_create_session.return_value = mock_session
+
+        ctx_mgr = _ZenohSessionContextManager()
+        result1 = ctx_mgr.attr1
+        result2 = ctx_mgr.attr2
+
+        # Should only create session once
+        mock_create_session.assert_called_once()
+        assert result1 == "value1"
+        assert result2 == "value2"
+
+    @patch("zenoh_msgs.session._create_zenoh_session")
+    def test_context_manager_with_statement(self, mock_create_session):
+        mock_session = MagicMock()
+        mock_create_session.return_value = mock_session
+
+        with open_zenoh_session() as session:
+            assert session is mock_session
+
+        mock_session.close.assert_called_once()
+
+
+class TestCreateZenohSession:
+    """Test the _create_zenoh_session function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_hybrid_state(self):
+        """Reset HybridZenohSession state between tests."""
+        prev_use_sim = HybridZenohSession._use_sim
+        HybridZenohSession._use_sim = False
+        yield
+        HybridZenohSession._use_sim = prev_use_sim
+
+    def test_returns_hybrid_when_use_sim_true(self):
+        HybridZenohSession.set_use_sim(True)
+        session = _create_zenoh_session()
+        assert isinstance(session, HybridZenohSession)
+
     @patch.object(zenoh, "open")
-    def test_open_session_success_without_fallback(self, mock_zenoh_open):
+    def test_returns_zenoh_session_without_fallback(self, mock_zenoh_open):
         mock_session = MagicMock()
         mock_zenoh_open.return_value = mock_session
 
-        session = open_zenoh_session()
+        HybridZenohSession.set_use_sim(False)
+        session = _create_zenoh_session()
 
         mock_zenoh_open.assert_called_once()
         assert session is mock_session
 
     @patch.object(zenoh, "open")
-    def test_open_session_fallback_success(self, mock_zenoh_open):
+    def test_fallback_to_network_discovery(self, mock_zenoh_open):
         mock_session_fallback = MagicMock()
         mock_zenoh_open.side_effect = [
             Exception("Local connection failed"),
             mock_session_fallback,
         ]
 
-        session = open_zenoh_session()
+        HybridZenohSession.set_use_sim(False)
+        session = _create_zenoh_session()
 
         assert mock_zenoh_open.call_count == 2
         assert session is mock_session_fallback
 
     @patch.object(zenoh, "open")
-    def test_open_session_all_attempts_fail(self, mock_zenoh_open):
+    def test_raises_when_all_attempts_fail(self, mock_zenoh_open):
         mock_zenoh_open.side_effect = [
             Exception("Local failed"),
             Exception("Fallback failed"),
         ]
 
+        HybridZenohSession.set_use_sim(False)
         with pytest.raises(Exception, match="Failed to open Zenoh session"):
-            open_zenoh_session()
+            _create_zenoh_session()
 
         assert mock_zenoh_open.call_count == 2
-        expected_calls_to_zenoh_open = mock_zenoh_open.call_args_list
-        mock_zenoh_open.assert_has_calls(expected_calls_to_zenoh_open)
 
 
 class TestHybridZenohSession:
@@ -208,19 +306,6 @@ class TestHybridZenohSession:
         s = HybridZenohSession()
         # Both lazy sessions are None — should be a no-op, not raise
         s.close()
-
-
-class TestOpenZenohSessionSimMode:
-    """When use_sim is True, open_zenoh_session returns HybridZenohSession."""
-
-    def test_returns_hybrid_in_sim_mode(self):
-        prev = HybridZenohSession._use_sim
-        try:
-            HybridZenohSession.set_use_sim(True)
-            session = open_zenoh_session()
-            assert isinstance(session, HybridZenohSession)
-        finally:
-            HybridZenohSession.set_use_sim(prev)
 
 
 class TestLoaders:

--- a/tests/zenoh_msgs/test_session.py
+++ b/tests/zenoh_msgs/test_session.py
@@ -25,32 +25,6 @@ class TestCreateZenohConfig:
         config = create_zenoh_config(network_discovery=False)
         assert isinstance(config, zenoh.Config)
 
-    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "tcp/192.168.1.100:7447"})
-    def test_create_config_uses_custom_endpoint(self):
-        config = create_zenoh_config(network_discovery=False)
-        assert isinstance(config, zenoh.Config)
-
-    @patch.dict(
-        "os.environ",
-        {
-            "OM1_ZENOH_ENDPOINT": "wss/test-sim.openmind.com:8444",
-            "OM1_ZENOH_TLS_ROOT_CA": "/path/to/ca.pem",
-        },
-    )
-    def test_create_config_uses_tls_endpoint_and_ca(self):
-        config = create_zenoh_config(network_discovery=False)
-        assert isinstance(config, zenoh.Config)
-
-    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "tls/example.com:7447"})
-    def test_create_config_uses_tls_without_ca(self):
-        config = create_zenoh_config(network_discovery=False)
-        assert isinstance(config, zenoh.Config)
-
-    @patch.dict("os.environ", {"OM1_ZENOH_ENDPOINT": "quic/example.com:7447"})
-    def test_create_config_uses_quic_protocol(self):
-        config = create_zenoh_config(network_discovery=False)
-        assert isinstance(config, zenoh.Config)
-
 
 class TestOpenCloudSession:
     """Test the _open_cloud_session function."""


### PR DESCRIPTION
Introduce _ZenohSessionContextManager to allow using open_zenoh_session() as a context manager and to support lazy session creation and attribute forwarding. Extract session construction into _create_zenoh_session() and update typing to include the new context manager wrapper. Update tests to exercise the context manager behavior, lazy initialization, proper close on exit, and zenoh.open fallback logic; adapt existing tests to call _create_zenoh_session() where appropriate and remove the old sim-mode open_zenoh_session test.