### PR TITLE
Add localization schema & remember_location API

### DIFF
--- a/config/unitree_go2_modes_cloud.json5
+++ b/config/unitree_go2_modes_cloud.json5
@@ -91,7 +91,7 @@
       display_name: "SLAM Exploration",
       description: "Autonomous navigation and mapping mode",
       system_prompt_base: "You are Bits in exploration mode. Your mission is to:\n1. Navigate the environment safely\n2. Map and understand the surroundings using LIDAR and visual data\n3. Avoid obstacles and maintain spatial awareness\n4. Report interesting discoveries and landmarks\n5. Only remember a location when the user explicitly asks you to (for example, when they say 'remember this location')\n\nWhile exploring, describe where you are and what you see in simple, natural language. If you encounter people detected by the Face Presence Sensor (e.g., 'In Camera View: 2 known (wendy and bob).'), greet them by name once (e.g., 'Hi wendy and bob!').\n\nDo NOT store or tag any location automatically—only invoke the 'remember_location' action after an explicit user request.",
-      hertz: 1,
+      hertz: 0.001,
       agent_inputs: [
         {
           type: "UnitreeGo2OdomZenoh",
@@ -133,6 +133,9 @@
           name: "remember_location",
           llm_label: "remember_location",
           connector: "unitree_go2_location",
+          config: {
+            base_url: "https://api.openmind.com/api/core/simulation/orchestrator/maps/locations/add/slam",
+          },
         },
       ],
       backgrounds: [
@@ -292,7 +295,7 @@
         {
           name: "move_go2_autonomy",
           llm_label: "move",
-          connector: "unitree_om_path_sdk",
+          connector: "unitree_om_path_sdk_zenoh",
         },
         {
           name: "navigate_location",

--- a/src/actions/remember_location/connector/unitree_go2_location.py
+++ b/src/actions/remember_location/connector/unitree_go2_location.py
@@ -28,6 +28,10 @@ class UnitreeGo2RememberLocationConfig(ActionConfig):
         default="http://localhost:5000/maps/locations/add/slam",
         description="The base URL for the remember location API.",
     )
+    api_key: str = Field(
+        default="",
+        description="API key for OpenMind API authentication",
+    )
     timeout: int = Field(
         default=5,
         description="Timeout for the HTTP requests in seconds.",
@@ -55,6 +59,7 @@ class UnitreeGo2RememberLocationConnector(ActionConnector[UnitreeGo2RememberLoca
         super().__init__(config)
 
         self.base_url = self.config.base_url
+        self.api_key = self.config.api_key
         self.timeout = self.config.timeout
         self.map_name = self.config.map_name
 
@@ -79,7 +84,7 @@ class UnitreeGo2RememberLocationConnector(ActionConnector[UnitreeGo2RememberLoca
             "description": getattr(output_interface, "description", ""),
         }
 
-        headers = {"Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", "x-api-key": self.api_key}
 
         try:
             async with aiohttp.ClientSession() as session:

--- a/src/providers/unitree_go2_lidar_localization_provider.py
+++ b/src/providers/unitree_go2_lidar_localization_provider.py
@@ -47,17 +47,14 @@ class UnitreeGo2LidarLocalizationProvider(ZenohListenerProvider):
             The Zenoh sample received, which should have a 'payload' attribute.
         """
         if data.payload:
-            logging.info(
-                "Received lidar localization message with payload size: %d bytes", len(data.payload.to_bytes())
-            )
             message: nav_msgs.LidarLocalization = nav_msgs.LidarLocalization.deserialize(data.payload.to_bytes())
-            logging.info("Received Lidar Localization message: %s", message)
+            logging.debug("Received Lidar Localization message: %s", message)
 
             quality_percent = message.quality_percent
             self.localization_status = quality_percent >= self.quality_tolerance
             self.localization_pose = message.pose
 
-            logging.info(
+            logging.debug(
                 "Localization Status: %s, Pose: %s",
                 self.localization_status,
                 self.localization_pose,

--- a/src/providers/unitree_go2_lidar_localization_provider.py
+++ b/src/providers/unitree_go2_lidar_localization_provider.py
@@ -18,7 +18,7 @@ class UnitreeGo2LidarLocalizationProvider(ZenohListenerProvider):
     def __init__(
         self,
         topic: str = "om/localization_pose",
-        quality_tolerance: float = 0.9,
+        quality_tolerance: float = 0.7,
     ):
         """
         Initialize the Lidar Localization Provider with a specific topic.
@@ -28,7 +28,7 @@ class UnitreeGo2LidarLocalizationProvider(ZenohListenerProvider):
         topic : str, optional
             The topic on which to subscribe for lidar localization messages (default is "om/localization_pose").
         quality_tolerance : float, optional
-            The tolerance for localization quality percent (default is 0.9).
+            The tolerance for localization quality percent (default is 0.7).
         """
         super().__init__(topic)
         logging.info("Lidar Localization Provider initialized with topic: %s", topic)
@@ -47,14 +47,17 @@ class UnitreeGo2LidarLocalizationProvider(ZenohListenerProvider):
             The Zenoh sample received, which should have a 'payload' attribute.
         """
         if data.payload:
+            logging.info(
+                "Received lidar localization message with payload size: %d bytes", len(data.payload.to_bytes())
+            )
             message: nav_msgs.LidarLocalization = nav_msgs.LidarLocalization.deserialize(data.payload.to_bytes())
-            logging.debug("Received Lidar Localization message: %s", message)
+            logging.info("Received Lidar Localization message: %s", message)
 
             quality_percent = message.quality_percent
             self.localization_status = quality_percent >= self.quality_tolerance
             self.localization_pose = message.pose
 
-            logging.debug(
+            logging.info(
                 "Localization Status: %s, Pose: %s",
                 self.localization_status,
                 self.localization_pose,

--- a/src/zenoh_msgs/cloud_session/topic_schemas.py
+++ b/src/zenoh_msgs/cloud_session/topic_schemas.py
@@ -18,6 +18,10 @@ CLOUD_TOPICS: set[str] = {
     "camera/realsense2_camera_node/depth/image_rect_isaac_sim_raw",
     "camera/realsense2_camera_node/depth/camera_info",
     "rgb_image",
+    # Navigation
+    "goal_pose",
+    "navigate_to_pose/_action/status",
+    "navigate_to_pose/_action/cancel_goal",
     # Unitree
     "lowstate",
     "lf/lowstate",

--- a/src/zenoh_msgs/cloud_session/topic_schemas.py
+++ b/src/zenoh_msgs/cloud_session/topic_schemas.py
@@ -40,6 +40,7 @@ topic_schemas = [
     ("om/asr/text", "om_api/msg/OMASRText"),
     ("om/avatar/request", "om_api/msg/OMAvatarFaceRequest"),
     ("om/avatar/response", "om_api/msg/OMAvatarFaceResponse"),
+    ("om/localization_pose", "nav_msgs/msg/LidarLocalization"),
     ("image", "sensor_msgs/msg/Image"),
 ]
 

--- a/tests/providers/test_unitree_go2_lidar_localization_provider.py
+++ b/tests/providers/test_unitree_go2_lidar_localization_provider.py
@@ -46,7 +46,7 @@ def test_initialization_defaults(mock_zenoh):
     provider = UnitreeGo2LidarLocalizationProvider()
 
     assert provider.sub_topic == "om/localization_pose"
-    assert provider.quality_tolerance == 0.9
+    assert provider.quality_tolerance == 0.7
 
 
 def test_singleton_pattern(mock_zenoh):


### PR DESCRIPTION
Configure SLAM/exploration mode and connectors for cloud remember_location integration; update LIDAR localization behavior and logging.

- config: lower SLAM exploration hertz (1 -> 0.001), add remember_location connector config pointing at OpenMind API, and switch move connector to zenoh variant.
- actions: add api_key config to UnitreeGo2 remember_location connector and include x-api-key header on requests.
- provider: relax lidar localization quality_tolerance from 0.9 to 0.7 and increase logging verbosity (log payload size and messages as info).
- messaging: add topic schema for om/localization_pose -> nav_msgs/msg/LidarLocalization.
- session: promote routing logs from debug to info for clarity.

These changes enable cloud-based location saving with API auth, make localization more tolerant, and improve observability.
