### PR TITLE
Add Grafana Dockerfile and multi-arch release workflow

### DIFF
--- a/.github/workflows/grafana-release.yml
+++ b/.github/workflows/grafana-release.yml
@@ -1,4 +1,4 @@
-name: "OM1 Release Workflow"
+name: "Grafana Release Workflow"
 
 on:
   push:
@@ -19,15 +19,6 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell
-          sudo rm -rf /usr/local/share/chromium /usr/local/lib/node_modules
-          sudo docker system prune -af
-          sudo apt-get clean
-          df -h
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -49,7 +40,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: public.ecr.aws/b8k9c8n5/openmind/om1
+          images: public.ecr.aws/b8k9c8n5/openmind/grafana
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -62,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: grafana/Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
@@ -76,15 +68,6 @@ jobs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/boost /usr/local/graalvm /usr/local/share/powershell
-          sudo rm -rf /usr/local/share/chromium /usr/local/lib/node_modules
-          sudo docker system prune -af
-          sudo apt-get clean
-          df -h
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -106,7 +89,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: public.ecr.aws/b8k9c8n5/openmind/om1
+          images: public.ecr.aws/b8k9c8n5/openmind/grafana
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -119,6 +102,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: grafana/Dockerfile
           push: true
           platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
@@ -133,7 +117,7 @@ jobs:
     needs: [ build-amd64, build-arm64 ]
     environment:
       name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production' || 'staging' }}
-      url: https://gallery.ecr.aws/b8k9c8n5/openmind/om1
+      url: https://gallery.ecr.aws/b8k9c8n5/openmind/grafana
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -170,6 +154,6 @@ jobs:
 
             docker buildx imagetools create \
               --tag $tag \
-              public.ecr.aws/b8k9c8n5/openmind/om1@${{ needs.build-amd64.outputs.image-digest }} \
-              public.ecr.aws/b8k9c8n5/openmind/om1@${{ needs.build-arm64.outputs.image-digest }}
+              public.ecr.aws/b8k9c8n5/openmind/grafana@${{ needs.build-amd64.outputs.image-digest }} \
+              public.ecr.aws/b8k9c8n5/openmind/grafana@${{ needs.build-arm64.outputs.image-digest }}
           done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
       - "3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,14 @@ services:
 
   grafana:
     image: grafana/grafana:latest
+    build:
+      context: .
+      dockerfile: grafana/Dockerfile
     container_name: grafana
     ports:
       - "3000:3000"
     volumes:
       - grafana-data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning
-      - ./grafana/dashboards:/var/lib/grafana/dashboards
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=admin

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/grafana:latest
+COPY grafana/provisioning /etc/grafana/provisioning
+COPY grafana/dashboards /var/lib/grafana/dashboards


### PR DESCRIPTION
This pull request introduces a new release workflow for building and publishing multi-architecture Docker images for Grafana, along with related changes to the Docker build and configuration. The main focus is to automate and standardize the release process for the Grafana service, ensuring both AMD64 and ARM64 images are built, pushed, and published to Amazon ECR Public, and to move provisioning and dashboard configuration into the Docker image itself.

**Release Workflow Automation:**

- Added a new GitHub Actions workflow (`.github/workflows/grafana-release.yml`) to build and push multi-architecture (AMD64 and ARM64) Docker images for Grafana, and to create and publish a manifest list to Amazon ECR Public. This workflow is triggered on pushes to `main`, tags, and manual dispatches.
- Updated the existing release workflow name to "OM1 Release Workflow" for clarity.

**Docker Image and Compose Configuration:**

- Added a new `grafana/Dockerfile` that copies provisioning and dashboard configuration into the image, enabling consistent setup across deployments.
- Updated the `docker-compose.yml` to build the Grafana image using the new Dockerfile and removed volume mounts for provisioning and dashboards, since these are now included in the image itself.