### PR TITLE
Point Grafana dashboards to /etc/grafana/dashboards

### DIFF
--- a/grafana/Dockerfile.grafana
+++ b/grafana/Dockerfile.grafana
@@ -1,3 +1,3 @@
 FROM grafana/grafana:latest
 COPY grafana/provisioning /etc/grafana/provisioning
-COPY grafana/dashboards /var/lib/grafana/dashboards
+COPY grafana/dashboards /etc/grafana/dashboards

--- a/grafana/provisioning/dashboards/default.yml
+++ b/grafana/provisioning/dashboards/default.yml
@@ -9,5 +9,5 @@ providers:
     updateIntervalSeconds: 10
     allowUiUpdates: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /etc/grafana/dashboards
       foldersFromFilesStructure: false


### PR DESCRIPTION
Update Dockerfile to copy dashboards into /etc/grafana/dashboards and modify provisioning/default.yml to use the same path. Keeps dashboard files and provisioning configuration consistent so Grafana loads dashboards from /etc/grafana/dashboards instead of /var/lib/grafana/dashboards.