### PR TITLE
update teleops status provider

### DIFF
--- a/src/backgrounds/plugins/agent_teleops_status.py
+++ b/src/backgrounds/plugins/agent_teleops_status.py
@@ -88,6 +88,7 @@ class AgentTeleopsStatusBackground(Background[AgentTeleopsStatusConfig]):
                 {
                     "machine_name": self.config.machine_name,
                     "update_time": current_time,
+                    "om1_heartbeat": current_time,
                     "battery_status": {
                         "battery_level": self.config.battery_level,
                         "voltage": self.config.voltage,

--- a/src/inputs/plugins/turtlebot4_battery.py
+++ b/src/inputs/plugins/turtlebot4_battery.py
@@ -137,6 +137,7 @@ class TurtleBot4Battery(FuserInput[TurtleBot4BatteryConfig, List[str]]):
             TeleopsStatus(
                 machine_name="TurtleBot4",
                 update_time=str(time.time()),
+                om1_heartbeat=str(time.time()),
                 battery_status=BatteryStatus(
                     battery_level=self.battery_percentage,
                     temperature=self.battery_temperature,

--- a/src/inputs/plugins/unitree_g1_basic.py
+++ b/src/inputs/plugins/unitree_g1_basic.py
@@ -191,6 +191,7 @@ class UnitreeG1Basic(FuserInput[UnitreeG1BasicConfig, List[float]]):
             TeleopsStatus(
                 machine_name="UnitreeG1",
                 update_time=str(time.time()),
+                om1_heartbeat=str(time.time()),
                 battery_status=BatteryStatus(
                     battery_level=self.battery_percentage,
                     temperature=self.battery_temperature,

--- a/src/inputs/plugins/unitree_go2_battery.py
+++ b/src/inputs/plugins/unitree_go2_battery.py
@@ -161,6 +161,7 @@ class UnitreeGo2Battery(FuserInput[UnitreeGo2BatteryConfig, List[float]]):
             TeleopsStatus(
                 machine_name="UnitreeGo2",
                 update_time=str(time.time()),
+                om1_heartbeat=str(time.time()),
                 battery_status=BatteryStatus(
                     battery_level=self.battery_percentage,
                     temperature=self.battery_t,

--- a/src/providers/teleops_status_provider.py
+++ b/src/providers/teleops_status_provider.py
@@ -163,6 +163,7 @@ class TeleopsStatus:
     action_status: ActionStatus = field(default_factory=lambda: ActionStatus(ActionType.AI, time.time()))
     machine_name: str = "unknown"
     video_connected: bool = False
+    om1_heartbeat: str = ""
 
     def to_dict(self) -> dict:
         """
@@ -176,6 +177,7 @@ class TeleopsStatus:
         return {
             "machine_name": self.machine_name,
             "update_time": self.update_time,
+            "om1_heartbeat": self.om1_heartbeat,
             "battery_status": self.battery_status.to_dict(),
             "action_status": self.action_status.to_dict(),
             "video_connected": self.video_connected,
@@ -197,6 +199,7 @@ class TeleopsStatus:
             action_status=ActionStatus.from_dict(data.get("action_status", {})),
             machine_name=data.get("machine_name", "unknown"),
             video_connected=data.get("video_connected", False),
+            om1_heartbeat=data.get("om1_heartbeat", ""),
         )
 
 

--- a/tests/providers/test_teleops_status_provider.py
+++ b/tests/providers/test_teleops_status_provider.py
@@ -187,6 +187,7 @@ def test_teleops_status_creation():
     assert status.action_status == action
     assert status.machine_name == "robot1"
     assert status.video_connected is True
+    assert status.om1_heartbeat == ""
 
 
 def test_teleops_status_to_dict():
@@ -213,6 +214,7 @@ def test_teleops_status_to_dict():
     assert result["update_time"] == "2024-01-01T00:00:00"
     assert result["machine_name"] == "robot1"
     assert result["video_connected"] is False
+    assert result["om1_heartbeat"] == ""
     assert isinstance(result["battery_status"], dict)
     assert isinstance(result["action_status"], dict)
 
@@ -240,6 +242,28 @@ def test_teleops_status_from_dict():
     assert status.video_connected is True
     assert status.battery_status.battery_level == 90.0
     assert status.action_status.action == ActionType.TELEOPS
+    assert status.om1_heartbeat == ""
+
+
+def test_teleops_status_with_heartbeat():
+    """Test TeleopsStatus creation and serialization with om1_heartbeat."""
+    status = TeleopsStatus(
+        update_time="1700000000",
+        battery_status=BatteryStatus(
+            battery_level=0.0, temperature=0.0, voltage=0.0, timestamp=""
+        ),
+        machine_name="robot-hb",
+        om1_heartbeat="1700000000",
+    )
+
+    assert status.om1_heartbeat == "1700000000"
+
+    result = status.to_dict()
+    assert result["om1_heartbeat"] == "1700000000"
+
+    restored = TeleopsStatus.from_dict(result)
+    assert restored.om1_heartbeat == "1700000000"
+    assert restored.machine_name == "robot-hb"
 
 
 @pytest.fixture

--- a/tests/providers/test_teleops_status_provider.py
+++ b/tests/providers/test_teleops_status_provider.py
@@ -249,9 +249,7 @@ def test_teleops_status_with_heartbeat():
     """Test TeleopsStatus creation and serialization with om1_heartbeat."""
     status = TeleopsStatus(
         update_time="1700000000",
-        battery_status=BatteryStatus(
-            battery_level=0.0, temperature=0.0, voltage=0.0, timestamp=""
-        ),
+        battery_status=BatteryStatus(battery_level=0.0, temperature=0.0, voltage=0.0, timestamp=""),
         machine_name="robot-hb",
         om1_heartbeat="1700000000",
     )


### PR DESCRIPTION
This pull request adds support for an `om1_heartbeat` field to the `TeleopsStatus` data structure and ensures that it is correctly handled throughout the codebase. The changes ensure that the heartbeat timestamp is included in status reports from various robot battery plugins, the provider, and is properly tested.

Key changes include:

**TeleopsStatus data model updates:**

* Added a new `om1_heartbeat` field to the `TeleopsStatus` class in `src/providers/teleops_status_provider.py`, updated its `to_dict` and `from_dict` methods to serialize and deserialize this field. [[1]](diffhunk://#diff-4d17beb04b7209f5f9376904bed1da470d7c26cff57c8384cfe54cac24ac0853R166) [[2]](diffhunk://#diff-4d17beb04b7209f5f9376904bed1da470d7c26cff57c8384cfe54cac24ac0853R180) [[3]](diffhunk://#diff-4d17beb04b7209f5f9376904bed1da470d7c26cff57c8384cfe54cac24ac0853R202)

**Status reporting updates:**

* Updated the status reporting in battery plugins (`turtlebot4_battery.py`, `unitree_g1_basic.py`, `unitree_go2_battery.py`) to include the current time as the `om1_heartbeat` value when creating `TeleopsStatus` instances. [[1]](diffhunk://#diff-3d6958f9a95f2451077fb8a8f4e5b4c69c42636f07072499e326ccd7157361deR140) [[2]](diffhunk://#diff-59dbcda11b9c4513851558de931c9d83369c76fb847312e782815f35afb89be6R194) [[3]](diffhunk://#diff-3560a2de9de5150b118754c158e95c66843712a9191287736c7605aa1fc846a3R164)
* Modified the agent teleops status plugin to add the `om1_heartbeat` field to the status dictionary.

**Testing improvements:**

* Extended and added tests in `tests/providers/test_teleops_status_provider.py` to verify correct handling of the new `om1_heartbeat` field, including its default value, serialization, deserialization, and explicit assignment. [[1]](diffhunk://#diff-8e5db4d19ca81916dda2a4b8fa5c8452012aee576b16bcd54f4669125fec46a7R190) [[2]](diffhunk://#diff-8e5db4d19ca81916dda2a4b8fa5c8452012aee576b16bcd54f4669125fec46a7R217) [[3]](diffhunk://#diff-8e5db4d19ca81916dda2a4b8fa5c8452012aee576b16bcd54f4669125fec46a7R245-R266)