### PR TITLE
Add ElevenLabs ASR plugins

### DIFF
--- a/src/inputs/plugins/elevenlabs_asr.py
+++ b/src/inputs/plugins/elevenlabs_asr.py
@@ -12,10 +12,6 @@ from inputs.base.loop import FuserInput
 from prometheus import (
     om1_asr_latency,
     om1_asr_latency_last,
-    om1_asr_speech_duration,
-    om1_asr_speech_duration_last,
-    om1_asr_utterance_end_latency,
-    om1_asr_utterance_end_latency_last,
 )
 from providers.asr_provider import ASRProvider
 from providers.io_provider import IOProvider
@@ -24,30 +20,30 @@ from providers.teleops_conversation_provider import TeleopsConversationProvider
 from zenoh_msgs import ASRText, open_zenoh_session, prepare_header
 
 LANGUAGE_CODE_MAP: dict = {
-    "english": "en-US",
-    "chinese": "cmn-Hans-CN",
-    "german": "de-DE",
-    "french": "fr-FR",
-    "japanese": "ja-JP",
-    "korean": "ko-KR",
-    "spanish": "es-ES",
-    "italian": "it-IT",
-    "portuguese": "pt-BR",
-    "russian": "ru-RU",
-    "arabic": "ar-SA",
+    "auto": "auto",
+    "english": "en",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "italian": "it",
+    "portuguese": "pt",
+    "japanese": "ja",
+    "korean": "ko",
+    "chinese": "zh",
+    "dutch": "nl",
+    "polish": "pl",
+    "russian": "ru",
 }
 
 
-class GoogleASRSensorConfig(SensorConfig):
+class ElevenLabsASRSensorConfig(SensorConfig):
     """
-    Configuration for Google ASR Sensor.
+    Configuration for ElevenLabs ASR Sensor.
 
     Parameters
     ----------
     api_key : Optional[str]
         API Key.
-    api_version : str
-        API version to use for the ASR service.
     rate : int
         Sampling rate.
     chunk : int
@@ -59,7 +55,7 @@ class GoogleASRSensorConfig(SensorConfig):
     microphone_name : Optional[str]
         Microphone Name.
     language : str
-        Language for speech recognition.
+        Language for speech recognition (supports BCP-47 codes or auto-detection).
     alternative_languages : Optional[List[str]]
         List of alternative languages for multilingual speech recognition. If None (default), no alternative languages will be used.
     remote_input : bool
@@ -67,17 +63,12 @@ class GoogleASRSensorConfig(SensorConfig):
     """
 
     api_key: Optional[str] = Field(default=None, description="API Key")
-    api_version: str = Field(default="v2", description="API version to use for the ASR service")
     rate: int = Field(default=48000, description="Sampling rate")
     chunk: int = Field(default=4800, description="Chunk size")
     base_url: Optional[str] = Field(default=None, description="Base URL for the ASR service")
     microphone_device_id: Optional[int] = Field(default=None, description="Microphone Device ID")
     microphone_name: Optional[str] = Field(default=None, description="Microphone Name")
-    language: str = Field(default="english", description="Language for speech recognition")
-    alternative_languages: Optional[List[str]] = Field(
-        default=None,
-        description="List of alternative languages for multilingual speech recognition",
-    )
+    language: str = Field(default="auto", description="Language for speech recognition")
     remote_input: bool = Field(default=False, description="Whether to use remote input")
     enable_tts_interrupt: bool = Field(
         default=False,
@@ -85,22 +76,22 @@ class GoogleASRSensorConfig(SensorConfig):
     )
 
 
-class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
+class ElevenLabsASRInput(FuserInput[ElevenLabsASRSensorConfig, Optional[str]]):
     """
-    Google Automatic Speech Recognition (ASR) input handler.
+    ElevenLabs Automatic Speech Recognition (ASR) input handler.
 
     This class manages the input stream from an ASR service, buffering messages
     and providing text conversion capabilities.
     """
 
-    def __init__(self, config: GoogleASRSensorConfig):
+    def __init__(self, config: ElevenLabsASRSensorConfig):
         """
-        Initialize GoogleASRInput instance.
+        Initialize ElevenLabsASRInput instance.
 
         Parameters
         ----------
-        config : GoogleASRSensorConfig
-            Configuration for the Google ASR input
+        config : ElevenLabsASRSensorConfig
+            Configuration for the ElevenLabs ASR input
         """
         super().__init__(config)
 
@@ -119,12 +110,7 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         rate = self.config.rate
         chunk = self.config.chunk
 
-        api_version = self.config.api_version.strip().lower()
-        if api_version not in ["v1", "v2"]:
-            logging.warning(f"API version {api_version} not recognized. Defaulting to v2.")
-            api_version = "v2"
-
-        base_url = self.config.base_url or f"wss://api.openmind.com/api/core/google/asr/{api_version}?api_key={api_key}"
+        base_url = self.config.base_url or f"wss://api.openmind.com/api/core/elevenlabs/asr?api_key={api_key}"
 
         microphone_device_id = self.config.microphone_device_id
         microphone_name = self.config.microphone_name
@@ -133,29 +119,12 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
 
         if language not in LANGUAGE_CODE_MAP:
             logging.error(
-                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
+                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to auto"
             )
-            language = "english"
+            language = "auto"
 
-        language_code = LANGUAGE_CODE_MAP.get(language, "en-US")
-        logging.info(f"Using language code {language_code} for Google ASR")
-
-        alternative_languages = self.config.alternative_languages or []
-        alternative_language_codes = []
-
-        if api_version == "v1" and len(alternative_languages) > 0:
-            for alt_lang in alternative_languages:
-                alt_lang = alt_lang.strip().lower()
-                if alt_lang in LANGUAGE_CODE_MAP:
-                    alt_code = LANGUAGE_CODE_MAP[alt_lang]
-                    alternative_language_codes.append(alt_code)
-                    logging.info(f"Adding alternative language code {alt_code} for language {alt_lang}")
-                else:
-                    logging.warning(f"Alternative language {alt_lang} not supported. Skipping.")
-        elif api_version == "v2" and len(alternative_languages) > 0:
-            logging.warning(
-                "Alternative languages are not supported in API version v2. Ignoring alternative languages."
-            )
+        language_code = LANGUAGE_CODE_MAP.get(language, "auto")
+        logging.info(f"Using language code {language_code} for ElevenLabs ASR")
 
         remote_input = self.config.remote_input
         enable_tts_interrupt = self.config.enable_tts_interrupt
@@ -167,7 +136,6 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             device_id=microphone_device_id,
             microphone_name=microphone_name,
             language_code=language_code,
-            alternative_language_codes=alternative_language_codes,
             remote_input=remote_input,
             enable_tts_interrupt=enable_tts_interrupt,
         )
@@ -200,7 +168,6 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         # Timing variable to measure latency from speech start to final transcript or end of utterance
         self._speech_start_time: Optional[float] = None
         self._language = language
-        self._api_version = api_version
 
     def _handle_asr_message(self, raw_message: str):
         """
@@ -218,45 +185,25 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             json_message: Dict = json.loads(raw_message)
 
             msg_type = json_message.get("type")
-            if msg_type == "speech_start":
+            if msg_type == "partial":
                 self._speech_start_time = time.time()
 
-            elif msg_type == "speech_end":
-                if self._speech_start_time is not None:
-                    duration = time.time() - self._speech_start_time
-                    om1_asr_speech_duration.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).observe(duration)
-                    om1_asr_speech_duration_last.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).set(duration)
-
-            elif msg_type == "end_of_utterance":
-                if self._speech_start_time is not None:
-                    latency = time.time() - self._speech_start_time
-                    om1_asr_utterance_end_latency.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).observe(latency)
-                    om1_asr_utterance_end_latency_last.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).set(latency)
-
-            if "asr_reply" in json_message:
+            if "asr_reply" in json_message and msg_type == "committed":
                 asr_reply = json_message["asr_reply"]
                 if len(asr_reply.split()) > 1:
-                    # Observe ASR latency from speech start to final transcript
                     if self._speech_start_time is not None:
                         latency = time.time() - self._speech_start_time
-                        om1_asr_latency.labels(
-                            model="google", language=self._language, api_version=self._api_version
-                        ).observe(latency)
-                        om1_asr_latency_last.labels(
-                            model="google", language=self._language, api_version=self._api_version
-                        ).set(latency)
+                        om1_asr_latency.labels(model="elevenlabs", language=self._language, api_version="v1").observe(
+                            latency
+                        )
+                        om1_asr_latency_last.labels(model="elevenlabs", language=self._language, api_version="v1").set(
+                            latency
+                        )
 
                         self._speech_start_time = None
                     self.message_buffer.put_nowait(asr_reply)
                     logging.info("Detected ASR message: %s", asr_reply)
+
         except json.JSONDecodeError:
             pass
 
@@ -307,7 +254,6 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         pending_message = await self._raw_to_text(raw_input)
         if pending_message is None:
             if len(self.messages) != 0:
-                # Skip sleep if there's already a message in the messages buffer
                 self.global_sleep_ticker_provider.skip_sleep = True
 
         if pending_message is not None:
@@ -356,7 +302,7 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         """
         Stop the ASR input.
         """
-        logging.info("Stopping GoogleASRInput, disabling callback")
+        logging.info("Stopping ElevenLabsASRInput, disabling callback")
 
         self._stopped = True
 

--- a/src/inputs/plugins/elevenlabs_asr_rtsp.py
+++ b/src/inputs/plugins/elevenlabs_asr_rtsp.py
@@ -12,95 +12,80 @@ from inputs.base.loop import FuserInput
 from prometheus import (
     om1_asr_latency,
     om1_asr_latency_last,
-    om1_asr_speech_duration,
-    om1_asr_speech_duration_last,
-    om1_asr_utterance_end_latency,
-    om1_asr_utterance_end_latency_last,
 )
-from providers.asr_provider import ASRProvider
+from providers.asr_rtsp_provider import ASRRTSPProvider
 from providers.io_provider import IOProvider
 from providers.sleep_ticker_provider import SleepTickerProvider
 from providers.teleops_conversation_provider import TeleopsConversationProvider
 from zenoh_msgs import ASRText, open_zenoh_session, prepare_header
 
 LANGUAGE_CODE_MAP: dict = {
-    "english": "en-US",
-    "chinese": "cmn-Hans-CN",
-    "german": "de-DE",
-    "french": "fr-FR",
-    "japanese": "ja-JP",
-    "korean": "ko-KR",
-    "spanish": "es-ES",
-    "italian": "it-IT",
-    "portuguese": "pt-BR",
-    "russian": "ru-RU",
-    "arabic": "ar-SA",
+    "auto": "auto",
+    "english": "en",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "italian": "it",
+    "portuguese": "pt",
+    "japanese": "ja",
+    "korean": "ko",
+    "chinese": "zh",
+    "dutch": "nl",
+    "polish": "pl",
+    "russian": "ru",
 }
 
 
-class GoogleASRSensorConfig(SensorConfig):
+class ElevenLabsASRRTSPSensorConfig(SensorConfig):
     """
-    Configuration for Google ASR Sensor.
+    Configuration for ElevenLabs ASR RTSP Sensor.
 
     Parameters
     ----------
     api_key : Optional[str]
         API Key.
-    api_version : str
-        API version to use for the ASR service.
+    rtsp_url : str
+        RTSP URL for the audio stream.
     rate : int
-        Sampling rate.
+        Audio sampling rate.
     chunk : int
-        Chunk size.
+        Audio chunk size in bytes.
     base_url : Optional[str]
         Base URL for the ASR service.
-    microphone_device_id : Optional[int]
-        Microphone Device ID.
-    microphone_name : Optional[str]
-        Microphone Name.
     language : str
-        Language for speech recognition.
-    alternative_languages : Optional[List[str]]
-        List of alternative languages for multilingual speech recognition. If None (default), no alternative languages will be used.
-    remote_input : bool
-        Whether to use remote input.
+        Language for speech recognition (supports BCP-47 codes or auto-detection).
+    enable_tts_interrupt : bool
+        Enable TTS interrupt (does not mute mic during TTS playback).
     """
 
     api_key: Optional[str] = Field(default=None, description="API Key")
-    api_version: str = Field(default="v2", description="API version to use for the ASR service")
-    rate: int = Field(default=48000, description="Sampling rate")
-    chunk: int = Field(default=4800, description="Chunk size")
-    base_url: Optional[str] = Field(default=None, description="Base URL for the ASR service")
-    microphone_device_id: Optional[int] = Field(default=None, description="Microphone Device ID")
-    microphone_name: Optional[str] = Field(default=None, description="Microphone Name")
-    language: str = Field(default="english", description="Language for speech recognition")
-    alternative_languages: Optional[List[str]] = Field(
-        default=None,
-        description="List of alternative languages for multilingual speech recognition",
+    rtsp_url: str = Field(
+        default="rtsp://localhost:8554/audio",
+        description="RTSP URL for the audio stream",
     )
-    remote_input: bool = Field(default=False, description="Whether to use remote input")
+    rate: int = Field(default=16000, description="Audio sampling rate")
+    chunk: int = Field(default=1600, description="Audio chunk size in bytes")
+    base_url: Optional[str] = Field(default=None, description="Base URL for the ASR service")
+    language: str = Field(default="auto", description="Language for speech recognition")
     enable_tts_interrupt: bool = Field(
         default=False,
         description="Enable TTS interrupt (does not mute mic during TTS playback)",
     )
 
 
-class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
+class ElevenLabsASRRTSPInput(FuserInput[ElevenLabsASRRTSPSensorConfig, Optional[str]]):
     """
-    Google Automatic Speech Recognition (ASR) input handler.
-
-    This class manages the input stream from an ASR service, buffering messages
-    and providing text conversion capabilities.
+    ElevenLabs ASR RTSP input handler for processing speech recognition from RTSP audio streams.
     """
 
-    def __init__(self, config: GoogleASRSensorConfig):
+    def __init__(self, config: ElevenLabsASRRTSPSensorConfig):
         """
-        Initialize GoogleASRInput instance.
+        Initialize the ElevenLabs ASR RTSP input handler.
 
         Parameters
         ----------
-        config : GoogleASRSensorConfig
-            Configuration for the Google ASR input
+        config : ElevenLabsASRRTSPSensorConfig
+            Configuration for the ASR RTSP input handler.
         """
         super().__init__(config)
 
@@ -116,59 +101,30 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
 
         # Initialize ASR provider
         api_key = self.config.api_key
+        rtsp_url = self.config.rtsp_url
         rate = self.config.rate
-        chunk = self.config.chunk
 
-        api_version = self.config.api_version.strip().lower()
-        if api_version not in ["v1", "v2"]:
-            logging.warning(f"API version {api_version} not recognized. Defaulting to v2.")
-            api_version = "v2"
-
-        base_url = self.config.base_url or f"wss://api.openmind.com/api/core/google/asr/{api_version}?api_key={api_key}"
-
-        microphone_device_id = self.config.microphone_device_id
-        microphone_name = self.config.microphone_name
+        base_url = self.config.base_url or f"wss://api.openmind.com/api/core/elevenlabs/asr?api_key={api_key}"
 
         language = self.config.language.strip().lower()
 
         if language not in LANGUAGE_CODE_MAP:
             logging.error(
-                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to English"
+                f"Language {language} not supported. Current supported languages are : {list(LANGUAGE_CODE_MAP.keys())}. Defaulting to auto"
             )
-            language = "english"
+            language = "auto"
 
-        language_code = LANGUAGE_CODE_MAP.get(language, "en-US")
-        logging.info(f"Using language code {language_code} for Google ASR")
+        language_code = LANGUAGE_CODE_MAP.get(language, "auto")
+        logging.info(f"Using language code {language_code} for ElevenLabs ASR")
 
-        alternative_languages = self.config.alternative_languages or []
-        alternative_language_codes = []
-
-        if api_version == "v1" and len(alternative_languages) > 0:
-            for alt_lang in alternative_languages:
-                alt_lang = alt_lang.strip().lower()
-                if alt_lang in LANGUAGE_CODE_MAP:
-                    alt_code = LANGUAGE_CODE_MAP[alt_lang]
-                    alternative_language_codes.append(alt_code)
-                    logging.info(f"Adding alternative language code {alt_code} for language {alt_lang}")
-                else:
-                    logging.warning(f"Alternative language {alt_lang} not supported. Skipping.")
-        elif api_version == "v2" and len(alternative_languages) > 0:
-            logging.warning(
-                "Alternative languages are not supported in API version v2. Ignoring alternative languages."
-            )
-
-        remote_input = self.config.remote_input
         enable_tts_interrupt = self.config.enable_tts_interrupt
 
-        self.asr: ASRProvider = ASRProvider(
+        self.asr: ASRRTSPProvider = ASRRTSPProvider(
+            rtsp_url=rtsp_url,
             rate=rate,
-            chunk=chunk,
+            chunk=self.config.chunk,
             ws_url=base_url,
-            device_id=microphone_device_id,
-            microphone_name=microphone_name,
             language_code=language_code,
-            alternative_language_codes=alternative_language_codes,
-            remote_input=remote_input,
             enable_tts_interrupt=enable_tts_interrupt,
         )
         self.asr.start()
@@ -200,16 +156,15 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         # Timing variable to measure latency from speech start to final transcript or end of utterance
         self._speech_start_time: Optional[float] = None
         self._language = language
-        self._api_version = api_version
 
     def _handle_asr_message(self, raw_message: str):
         """
-        Process incoming ASR messages.
+        Process incoming ASR messages from the ASR provider.
 
         Parameters
         ----------
         raw_message : str
-            Raw message received from ASR service
+            The raw ASR message received from the provider
         """
         if self._stopped:
             return
@@ -218,43 +173,23 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
             json_message: Dict = json.loads(raw_message)
 
             msg_type = json_message.get("type")
-            if msg_type == "speech_start":
+            if msg_type == "partial":
                 self._speech_start_time = time.time()
 
-            elif msg_type == "speech_end":
-                if self._speech_start_time is not None:
-                    duration = time.time() - self._speech_start_time
-                    om1_asr_speech_duration.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).observe(duration)
-                    om1_asr_speech_duration_last.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).set(duration)
-
-            elif msg_type == "end_of_utterance":
-                if self._speech_start_time is not None:
-                    latency = time.time() - self._speech_start_time
-                    om1_asr_utterance_end_latency.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).observe(latency)
-                    om1_asr_utterance_end_latency_last.labels(
-                        model="google", language=self._language, api_version=self._api_version
-                    ).set(latency)
-
-            if "asr_reply" in json_message:
+            if "asr_reply" in json_message and msg_type == "committed":
                 asr_reply = json_message["asr_reply"]
                 if len(asr_reply.split()) > 1:
                     # Observe ASR latency from speech start to final transcript
                     if self._speech_start_time is not None:
                         latency = time.time() - self._speech_start_time
-                        om1_asr_latency.labels(
-                            model="google", language=self._language, api_version=self._api_version
-                        ).observe(latency)
-                        om1_asr_latency_last.labels(
-                            model="google", language=self._language, api_version=self._api_version
-                        ).set(latency)
-
+                        om1_asr_latency.labels(model="elevenlabs", language=self._language, api_version="v1").observe(
+                            latency
+                        )
+                        om1_asr_latency_last.labels(model="elevenlabs", language=self._language, api_version="v1").set(
+                            latency
+                        )
                         self._speech_start_time = None
+
                     self.message_buffer.put_nowait(asr_reply)
                     logging.info("Detected ASR message: %s", asr_reply)
         except json.JSONDecodeError:
@@ -269,6 +204,9 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         Optional[str]
             Message from the buffer if available, None otherwise
         """
+        if self._stopped:
+            return
+
         try:
             message = self.message_buffer.get_nowait()
             return message
@@ -283,12 +221,12 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         Parameters
         ----------
         raw_input : Optional[str]
-            Raw input to be processed
+            Raw input string to be processed
 
         Returns
         -------
         Optional[Message]
-            Processed message or None if input is None
+            Timestamped message containing the processed input
         """
         if raw_input is None:
             return None
@@ -307,7 +245,6 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
         pending_message = await self._raw_to_text(raw_input)
         if pending_message is None:
             if len(self.messages) != 0:
-                # Skip sleep if there's already a message in the messages buffer
                 self.global_sleep_ticker_provider.skip_sleep = True
 
         if pending_message is not None:
@@ -354,9 +291,9 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
 
     def stop(self):
         """
-        Stop the ASR input.
+        Stop the ASR input handler and clean up resources.
         """
-        logging.info("Stopping GoogleASRInput, disabling callback")
+        logging.info("Stopping ElevenLabsASRRTSPInput, disabling callback")
 
         self._stopped = True
 
@@ -388,14 +325,3 @@ class GoogleASRInput(FuserInput[GoogleASRSensorConfig, Optional[str]]):
                 logging.info("Zenoh ASR session closed")
             except Exception as e:
                 logging.warning(f"Failed to close Zenoh ASR session: {e}")
-
-        # TODO:
-        # Consider sending the TTS status multiple times to ASR provider to ensure that
-        # the ASR provider properly receives the interrupt signal,
-        # especially in cases where the mode switch happens during TTS playback
-        # if self.asr:
-        #     try:
-        #         self.asr.stop()
-        #         logging.info("ASR provider stopped")
-        #     except Exception as e:
-        #         logging.warning(f"Failed to stop ASR provider: {e}")

--- a/src/inputs/plugins/google_asr_rtsp.py
+++ b/src/inputs/plugins/google_asr_rtsp.py
@@ -209,21 +209,21 @@ class GoogleASRRTSPInput(FuserInput[GoogleASRRTSPSensorConfig, Optional[str]]):
             elif msg_type == "speech_end":
                 if self._speech_start_time is not None:
                     duration = time.time() - self._speech_start_time
-                    om1_asr_speech_duration.labels(language=self._language, api_version=self._api_version).observe(
-                        duration
-                    )
-                    om1_asr_speech_duration_last.labels(language=self._language, api_version=self._api_version).set(
-                        duration
-                    )
+                    om1_asr_speech_duration.labels(
+                        model="google", language=self._language, api_version=self._api_version
+                    ).observe(duration)
+                    om1_asr_speech_duration_last.labels(
+                        model="google", language=self._language, api_version=self._api_version
+                    ).set(duration)
 
             elif msg_type == "end_of_utterance":
                 if self._speech_start_time is not None:
                     latency = time.time() - self._speech_start_time
                     om1_asr_utterance_end_latency.labels(
-                        language=self._language, api_version=self._api_version
+                        model="google", language=self._language, api_version=self._api_version
                     ).observe(latency)
                     om1_asr_utterance_end_latency_last.labels(
-                        language=self._language, api_version=self._api_version
+                        model="google", language=self._language, api_version=self._api_version
                     ).set(latency)
 
             if "asr_reply" in json_message:
@@ -232,8 +232,12 @@ class GoogleASRRTSPInput(FuserInput[GoogleASRRTSPSensorConfig, Optional[str]]):
                     # Observe ASR latency from speech start to final transcript
                     if self._speech_start_time is not None:
                         latency = time.time() - self._speech_start_time
-                        om1_asr_latency.labels(language=self._language, api_version=self._api_version).observe(latency)
-                        om1_asr_latency_last.labels(language=self._language, api_version=self._api_version).set(latency)
+                        om1_asr_latency.labels(
+                            model="google", language=self._language, api_version=self._api_version
+                        ).observe(latency)
+                        om1_asr_latency_last.labels(
+                            model="google", language=self._language, api_version=self._api_version
+                        ).set(latency)
                         self._speech_start_time = None
 
                     self.message_buffer.put_nowait(asr_reply)

--- a/src/prometheus/__init__.py
+++ b/src/prometheus/__init__.py
@@ -19,35 +19,35 @@ om1_llm_latency_last = Gauge(
 om1_asr_latency = Histogram(
     "om1_asr_latency_seconds",
     "Latency from speech activity start to final transcript in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )
 
 om1_asr_speech_duration = Histogram(
     "om1_asr_speech_duration_seconds",
     "Duration of speech activity from speech_start to speech_end in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )
 
 om1_asr_utterance_end_latency = Histogram(
     "om1_asr_utterance_end_latency_seconds",
     "Latency from speech activity start to end_of_utterance detection in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )
 
 om1_asr_latency_last = Gauge(
     "om1_asr_latency_last_seconds",
     "Most recent latency from speech activity start to final transcript in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )
 
 om1_asr_speech_duration_last = Gauge(
     "om1_asr_speech_duration_last_seconds",
     "Most recent duration of speech activity from speech_start to speech_end in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )
 
 om1_asr_utterance_end_latency_last = Gauge(
     "om1_asr_utterance_end_latency_last_seconds",
     "Most recent latency from speech activity start to end_of_utterance detection in seconds",
-    ["language", "api_version"],
+    ["model", "language", "api_version"],
 )

--- a/tests/inputs/plugins/test_elevenlabs_asr.py
+++ b/tests/inputs/plugins/test_elevenlabs_asr.py
@@ -1,0 +1,718 @@
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inputs.base import Message
+from inputs.plugins.elevenlabs_asr import ElevenLabsASRInput, ElevenLabsASRSensorConfig
+
+
+def test_initialization_defaults():
+    """Test basic initialization with default config."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_cls.return_value = mock_asr_instance
+        mock_session = MagicMock()
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        assert hasattr(sensor, "messages")
+        assert isinstance(sensor.messages, list)
+        assert sensor.descriptor_for_LLM == "Voice"
+        assert sensor._stopped is False
+        assert sensor._speech_start_time is None
+        mock_asr_instance.start.assert_called_once()
+        mock_asr_instance.register_message_callback.assert_called_once_with(sensor._handle_asr_message)
+
+
+def test_initialization_with_custom_config():
+    """Test initialization with custom configuration values."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_cls.return_value = mock_asr_instance
+
+        config = ElevenLabsASRSensorConfig(
+            api_key="test_key",
+            rate=16000,
+            chunk=8192,
+            base_url="wss://custom.example.com/asr",
+            microphone_device_id=2,
+            microphone_name="my_mic",
+            language="english",
+            remote_input=True,
+            enable_tts_interrupt=True,
+        )
+        ElevenLabsASRInput(config=config)
+
+        mock_asr_cls.assert_called_once_with(
+            rate=16000,
+            chunk=8192,
+            ws_url="wss://custom.example.com/asr",
+            device_id=2,
+            microphone_name="my_mic",
+            language_code="en",
+            remote_input=True,
+            enable_tts_interrupt=True,
+        )
+
+
+def test_initialization_default_base_url_uses_api_key():
+    """Test that default base_url includes the api_key."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_cls.return_value = mock_asr_instance
+
+        config = ElevenLabsASRSensorConfig(api_key="my_secret_key")
+        ElevenLabsASRInput(config=config)
+
+        call_kwargs = mock_asr_cls.call_args.kwargs
+        assert "my_secret_key" in call_kwargs["ws_url"]
+
+
+def test_initialization_unsupported_language_falls_back_to_auto():
+    """Test that unsupported language defaults to auto."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_cls.return_value = mock_asr_instance
+
+        config = ElevenLabsASRSensorConfig(language="klingon")
+        ElevenLabsASRInput(config=config)
+
+        call_kwargs = mock_asr_cls.call_args.kwargs
+        assert call_kwargs["language_code"] == "auto"
+
+
+def test_initialization_zenoh_failure():
+    """Test initialization when Zenoh fails – sensor is still usable."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_zenoh.side_effect = Exception("Zenoh not available")
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        assert sensor.session is None
+        assert sensor.asr_publisher is None
+
+
+def test_initialization_zenoh_publisher_declared():
+    """Test that Zenoh publisher is declared on the correct topic."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_session.declare_publisher.return_value = mock_publisher
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        mock_session.declare_publisher.assert_called_once_with("om/asr/text")
+        assert sensor.asr_publisher is mock_publisher
+
+
+# ---------------------------------------------------------------------------
+# _handle_asr_message tests
+# ---------------------------------------------------------------------------
+
+
+def test_handle_asr_message_committed_multi_word():
+    """committed message with >1 word is queued."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world test"})
+        sensor._handle_asr_message(raw)
+
+        assert not sensor.message_buffer.empty()
+        assert sensor.message_buffer.get_nowait() == "hello world test"
+
+
+def test_handle_asr_message_committed_single_word_ignored():
+    """committed message with a single word is NOT queued."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello"})
+        sensor._handle_asr_message(raw)
+
+        assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_partial_sets_speech_start_time():
+    """partial message sets _speech_start_time."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        before = time.time()
+        raw = json.dumps({"type": "partial", "asr_reply": ""})
+        sensor._handle_asr_message(raw)
+        after = time.time()
+
+        assert sensor._speech_start_time is not None
+        assert before <= sensor._speech_start_time <= after
+
+
+def test_handle_asr_message_committed_records_latency():
+    """committed message records latency and resets _speech_start_time."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+        patch("inputs.plugins.elevenlabs_asr.om1_asr_latency") as mock_latency,
+        patch("inputs.plugins.elevenlabs_asr.om1_asr_latency_last") as mock_latency_last,
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor._speech_start_time = time.time() - 0.5  # 500 ms ago
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world"})
+        sensor._handle_asr_message(raw)
+
+        mock_latency.labels.assert_called_once()
+        mock_latency_last.labels.assert_called_once()
+        assert sensor._speech_start_time is None
+
+
+def test_handle_asr_message_stopped_ignores_message():
+    """When _stopped is True, messages are not queued."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor._stopped = True
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world test"})
+        sensor._handle_asr_message(raw)
+
+        assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_invalid_json():
+    """Invalid JSON is silently ignored."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor._handle_asr_message("not valid json!!!")
+
+        assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_no_asr_reply_field():
+    """Message without asr_reply field is ignored."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        raw = json.dumps({"type": "committed", "other_key": "other_value"})
+        sensor._handle_asr_message(raw)
+
+        assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_no_speech_start_time_skips_latency():
+    """committed message with no prior partial does not call latency metrics."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+        patch("inputs.plugins.elevenlabs_asr.om1_asr_latency") as mock_latency,
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        assert sensor._speech_start_time is None
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world"})
+        sensor._handle_asr_message(raw)
+
+        mock_latency.labels.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_message_when_available():
+    """_poll returns the next message from the queue."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        await sensor.message_buffer.put("hi there")
+        result = await sensor._poll()
+        assert result == "hi there"
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_none_when_empty():
+    """_poll returns None when the queue is empty."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        with patch("inputs.plugins.elevenlabs_asr.asyncio.sleep", new=AsyncMock()):
+            result = await sensor._poll()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_poll_sleeps_when_empty():
+    """_poll calls asyncio.sleep(0.01) when the queue is empty."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        with patch("inputs.plugins.elevenlabs_asr.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await sensor._poll()
+            mock_sleep.assert_called_once_with(0.01)
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_returns_none():
+    """_raw_to_text(None) returns None."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        result = await sensor._raw_to_text(None)
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_valid_input():
+    """_raw_to_text returns a Message with correct content and timestamp."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+        patch("inputs.plugins.elevenlabs_asr.time.time", return_value=999.0),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        result = await sensor._raw_to_text("hello world")
+        assert result is not None
+        assert isinstance(result, Message)
+        assert result.message == "hello world"
+        assert result.timestamp == 999.0
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_wrapper_first_message():
+    """raw_to_text appends first message to empty buffer."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        await sensor.raw_to_text("first message")
+
+        assert len(sensor.messages) == 1
+        assert sensor.messages[0] == "first message"
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_wrapper_appends_to_existing():
+    """raw_to_text appends subsequent message to existing entry."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.messages.append("first part")
+
+        await sensor.raw_to_text("second part")
+
+        assert len(sensor.messages) == 1
+        assert sensor.messages[0] == "first part second part"
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_sets_skip_sleep_when_messages_exist():
+    """raw_to_text(None) sets skip_sleep=True when messages buffer is non-empty."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider") as mock_sleep_ticker_cls,
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_sleep_ticker = MagicMock()
+        mock_sleep_ticker_cls.return_value = mock_sleep_ticker
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.messages.append("some existing message")
+
+        await sensor.raw_to_text(None)
+
+        assert mock_sleep_ticker.skip_sleep is True
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_does_not_set_skip_sleep_when_buffer_empty():
+    """raw_to_text(None) does not touch skip_sleep when messages buffer is empty."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider") as mock_sleep_ticker_cls,
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_sleep_ticker = MagicMock()
+        mock_sleep_ticker.skip_sleep = False
+        mock_sleep_ticker_cls.return_value = mock_sleep_ticker
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        await sensor.raw_to_text(None)
+
+        assert mock_sleep_ticker.skip_sleep is False
+
+
+def test_formatted_latest_buffer_empty():
+    """Returns None when messages buffer is empty."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        assert sensor.formatted_latest_buffer() is None
+
+
+def test_formatted_latest_buffer_formats_and_clears():
+    """Returns formatted string and clears the buffer."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider") as mock_io_cls,
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider") as mock_conv_cls,
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        mock_io = MagicMock()
+        mock_io_cls.return_value = mock_io
+        mock_conv = MagicMock()
+        mock_conv_cls.return_value = mock_conv
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.messages.append("hello world how are you")
+
+        result = sensor.formatted_latest_buffer()
+
+        assert result is not None
+        assert "Voice" in result
+        assert "hello world how are you" in result
+        assert len(sensor.messages) == 0
+
+        mock_io.add_input.assert_called_once_with("Voice", "hello world how are you", pytest.approx(time.time(), abs=2))
+        mock_io.add_mode_transition_input.assert_called_once_with("hello world how are you")
+        mock_conv.store_user_message.assert_called_once_with("hello world how are you")
+
+
+def test_formatted_latest_buffer_publishes_to_zenoh():
+    """When Zenoh is initialised, formatted_latest_buffer publishes the message."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+        patch("inputs.plugins.elevenlabs_asr.ASRText") as mock_asr_text_cls,
+        patch("inputs.plugins.elevenlabs_asr.prepare_header") as mock_header,
+    ):
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_session.declare_publisher.return_value = mock_publisher
+        mock_zenoh.return_value = mock_session
+
+        mock_asr_msg = MagicMock()
+        mock_asr_msg.serialize.return_value = b"serialized_payload"
+        mock_asr_text_cls.return_value = mock_asr_msg
+        mock_header.return_value = {"id": "uuid-test"}
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.messages.append("publish this message")
+
+        result = sensor.formatted_latest_buffer()
+
+        assert result is not None
+        mock_publisher.put.assert_called_once_with(b"serialized_payload")
+
+
+def test_formatted_latest_buffer_zenoh_publish_failure_does_not_raise():
+    """Zenoh publish failure is logged but does not propagate."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_publisher.put.side_effect = Exception("publish error")
+        mock_session.declare_publisher.return_value = mock_publisher
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.messages.append("some message")
+
+        result = sensor.formatted_latest_buffer()
+        assert result is not None  # still returns the formatted string
+
+
+def test_stop_sets_stopped_and_clears_buffers():
+    """stop() sets _stopped, drains queue, and clears messages."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_cls.return_value = mock_asr_instance
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_session.declare_publisher.return_value = mock_publisher
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor.message_buffer.put_nowait("msg1")
+        sensor.message_buffer.put_nowait("msg2")
+        sensor.messages.append("buffered")
+
+        sensor.stop()
+
+        assert sensor._stopped is True
+        assert sensor.message_buffer.empty()
+        assert len(sensor.messages) == 0
+        mock_asr_instance.unregister_message_callback.assert_called_once()
+        mock_publisher.undeclare.assert_called_once()
+        mock_session.close.assert_called_once()
+
+
+def test_stop_without_zenoh():
+    """stop() succeeds gracefully when Zenoh was never initialized."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_zenoh.side_effect = Exception("Zenoh not available")
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor.stop()
+        assert sensor._stopped is True
+
+
+def test_stop_asr_unregister_failure_does_not_raise():
+    """stop() handles ASR unregister failure gracefully."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider") as mock_asr_cls,
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_asr_instance = MagicMock()
+        mock_asr_instance.unregister_message_callback.side_effect = Exception("unregister error")
+        mock_asr_cls.return_value = mock_asr_instance
+        mock_session = MagicMock()
+        mock_session.declare_publisher.return_value = MagicMock()
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor.stop()
+        assert sensor._stopped is True
+
+
+def test_stop_zenoh_undeclare_failure_does_not_raise():
+    """stop() handles Zenoh undeclare failure gracefully."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_publisher.undeclare.side_effect = Exception("undeclare error")
+        mock_session.declare_publisher.return_value = mock_publisher
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor.stop()
+        assert sensor._stopped is True
+        mock_session.close.assert_called_once()
+
+
+def test_stop_zenoh_close_failure_does_not_raise():
+    """stop() handles Zenoh session close failure gracefully."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session") as mock_zenoh,
+    ):
+        mock_session = MagicMock()
+        mock_session.close.side_effect = Exception("close error")
+        mock_session.declare_publisher.return_value = MagicMock()
+        mock_zenoh.return_value = mock_session
+
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+
+        sensor.stop()
+        assert sensor._stopped is True
+
+
+def test_stopped_sensor_ignores_further_messages():
+    """After stop(), _handle_asr_message silently drops new messages."""
+    with (
+        patch("inputs.plugins.elevenlabs_asr.IOProvider"),
+        patch("inputs.plugins.elevenlabs_asr.ASRProvider"),
+        patch("inputs.plugins.elevenlabs_asr.SleepTickerProvider"),
+        patch("inputs.plugins.elevenlabs_asr.TeleopsConversationProvider"),
+        patch("inputs.plugins.elevenlabs_asr.open_zenoh_session"),
+    ):
+        config = ElevenLabsASRSensorConfig()
+        sensor = ElevenLabsASRInput(config=config)
+        sensor.stop()
+
+        sensor._handle_asr_message(json.dumps({"type": "committed", "asr_reply": "hello world"}))
+
+        assert sensor.message_buffer.empty()

--- a/tests/inputs/plugins/test_elevenlabs_asr_rtsp.py
+++ b/tests/inputs/plugins/test_elevenlabs_asr_rtsp.py
@@ -1,0 +1,957 @@
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inputs.base import Message
+from inputs.plugins.elevenlabs_asr_rtsp import ElevenLabsASRRTSPInput, ElevenLabsASRRTSPSensorConfig
+
+
+@pytest.fixture
+def mock_io_provider():
+    with patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider") as mock_cls:
+        mock_instance = MagicMock()
+        mock_cls.return_value = mock_instance
+        yield mock_instance
+
+
+@pytest.fixture
+def mock_asr_provider():
+    mock_constructor = MagicMock()
+    mock_instance = MagicMock()
+    mock_constructor.return_value = mock_instance
+    return mock_constructor, mock_instance
+
+
+@pytest.fixture
+def mock_sleep_ticker_provider():
+    mock_constructor = MagicMock()
+    mock_instance = MagicMock()
+    mock_constructor.return_value = mock_instance
+    return mock_constructor, mock_instance
+
+
+@pytest.fixture
+def mock_teleops_conversation_provider():
+    mock_constructor = MagicMock()
+    mock_instance = MagicMock()
+    mock_constructor.return_value = mock_instance
+    return mock_constructor, mock_instance
+
+
+@pytest.fixture
+def mock_zenoh():
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session") as mock_open_session,
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRText") as mock_asr_text,
+        patch("inputs.plugins.elevenlabs_asr_rtsp.prepare_header") as mock_prepare_header,
+    ):
+        mock_session = MagicMock()
+        mock_publisher = MagicMock()
+        mock_open_session.return_value = mock_session
+        mock_session.declare_publisher.return_value = mock_publisher
+
+        yield {
+            "open_session": mock_open_session,
+            "session": mock_session,
+            "publisher": mock_publisher,
+            "asr_text_cls": mock_asr_text,
+            "prepare_header": mock_prepare_header,
+        }
+
+
+def _build_sensor(
+    config, mock_io_provider, mock_asr_provider, mock_sleep_ticker_provider, mock_teleops_conv_provider, mock_zenoh
+):
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conv_provider
+    mock_asr_constructor, _ = mock_asr_provider
+    mock_sleep_constructor, _ = mock_sleep_ticker_provider
+    mock_conv_constructor, _ = mock_teleops_conv_provider
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        return ElevenLabsASRRTSPInput(config=config)
+
+
+def test_initialization_creates_providers_and_buffers(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Initialization wires up all providers and Zenoh publisher."""
+    mock_asr_constructor, mock_asr_instance = mock_asr_provider
+    mock_sleep_constructor, _ = mock_sleep_ticker_provider
+    mock_conv_constructor, _ = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", new=mock_asr_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", new=mock_sleep_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", new=mock_conv_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    assert sensor.descriptor_for_LLM == "Voice"
+    assert isinstance(sensor.messages, list)
+    assert hasattr(sensor, "message_buffer")
+    assert sensor._stopped is False
+    assert sensor._speech_start_time is None
+    assert sensor.session is mock_zenoh["session"]
+    assert sensor.asr_publisher is mock_zenoh["publisher"]
+    mock_asr_instance.start.assert_called_once()
+    mock_asr_instance.register_message_callback.assert_called_once_with(sensor._handle_asr_message)
+    mock_zenoh["session"].declare_publisher.assert_called_once_with("om/asr/text")
+
+
+def test_initialization_default_base_url_uses_api_key(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """When base_url is not set, the default URL embeds the api_key."""
+    mock_asr_constructor, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig(api_key="my_secret_key")
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", new=mock_asr_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        ElevenLabsASRRTSPInput(config=config)
+
+    call_kwargs = mock_asr_constructor.call_args.kwargs
+    assert "my_secret_key" in call_kwargs["ws_url"]
+
+
+def test_initialization_unsupported_language_falls_back_to_auto(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Unsupported language value defaults language_code to 'auto'."""
+    mock_asr_constructor, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig(language="klingon")
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", new=mock_asr_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        ElevenLabsASRRTSPInput(config=config)
+
+    call_kwargs = mock_asr_constructor.call_args.kwargs
+    assert call_kwargs["language_code"] == "auto"
+
+
+def test_initialization_zenoh_failure(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+):
+    """When Zenoh fails to initialize, session and publisher are None."""
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", side_effect=Exception("Zenoh down")),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    assert sensor.session is None
+    assert sensor.asr_publisher is None
+
+
+def test_handle_asr_message_committed_multi_word(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """committed message with >1 word is queued."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    raw = json.dumps({"type": "committed", "asr_reply": "hello world test"})
+    sensor._handle_asr_message(raw)
+
+    assert not sensor.message_buffer.empty()
+    assert sensor.message_buffer.get_nowait() == "hello world test"
+
+
+def test_handle_asr_message_committed_single_word_ignored(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """committed message with a single word is NOT queued."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    raw = json.dumps({"type": "committed", "asr_reply": "hello"})
+    sensor._handle_asr_message(raw)
+
+    assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_partial_sets_speech_start_time(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """partial message records speech start time."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    before = time.time()
+    raw = json.dumps({"type": "partial", "asr_reply": ""})
+    sensor._handle_asr_message(raw)
+    after = time.time()
+
+    assert sensor._speech_start_time is not None
+    assert before <= sensor._speech_start_time <= after
+
+
+def test_handle_asr_message_committed_records_latency_and_resets(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """committed message records latency metrics and resets _speech_start_time."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.om1_asr_latency") as mock_latency,
+        patch("inputs.plugins.elevenlabs_asr_rtsp.om1_asr_latency_last") as mock_latency_last,
+    ):
+        sensor._speech_start_time = time.time() - 0.5
+
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world"})
+        sensor._handle_asr_message(raw)
+
+        mock_latency.labels.assert_called_once()
+        mock_latency_last.labels.assert_called_once()
+        assert sensor._speech_start_time is None
+
+
+def test_handle_asr_message_no_speech_start_time_skips_latency(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """committed without a prior partial does not call latency metrics."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    with patch("inputs.plugins.elevenlabs_asr_rtsp.om1_asr_latency") as mock_latency:
+        assert sensor._speech_start_time is None
+        raw = json.dumps({"type": "committed", "asr_reply": "hello world"})
+        sensor._handle_asr_message(raw)
+        mock_latency.labels.assert_not_called()
+
+
+def test_handle_asr_message_stopped_ignores_message(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """When _stopped is True, messages are silently dropped."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+    sensor._stopped = True
+
+    raw = json.dumps({"type": "committed", "asr_reply": "hello world test"})
+    sensor._handle_asr_message(raw)
+
+    assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_invalid_json(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Invalid JSON is silently ignored."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor._handle_asr_message("not valid json!!!")
+    assert sensor.message_buffer.empty()
+
+
+def test_handle_asr_message_no_asr_reply_field(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """committed message without asr_reply field is ignored."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    raw = json.dumps({"type": "committed", "other_key": "value"})
+    sensor._handle_asr_message(raw)
+
+    assert sensor.message_buffer.empty()
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_message_when_available(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_poll returns the next message from the queue."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor.message_buffer.put_nowait("hi there")
+    result = await sensor._poll()
+    assert result == "hi there"
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_none_when_empty(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_poll returns None when the queue is empty."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    result = await sensor._poll()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_poll_sleeps_when_empty(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_poll calls asyncio.sleep(0.01) when the queue is empty."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    with patch("inputs.plugins.elevenlabs_asr_rtsp.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await sensor._poll()
+        mock_sleep.assert_called_once_with(0.01)
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_none_when_stopped(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_poll returns None immediately when sensor is stopped."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+    sensor._stopped = True
+    sensor.message_buffer.put_nowait("should be ignored")
+
+    result = await sensor._poll()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _raw_to_text / raw_to_text tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_returns_none(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_raw_to_text(None) returns None."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    result = await sensor._raw_to_text(None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_valid_string(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """_raw_to_text returns a Message with correct content and timestamp."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    before = time.time()
+    result = await sensor._raw_to_text("hello world")
+    after = time.time()
+
+    assert result is not None
+    assert isinstance(result, Message)
+    assert result.message == "hello world"
+    assert before <= result.timestamp <= after
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_wrapper_first_message(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """raw_to_text appends first message to empty buffer."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    await sensor.raw_to_text("first message")
+
+    assert len(sensor.messages) == 1
+    assert sensor.messages[0] == "first message"
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_wrapper_appends_to_existing(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """raw_to_text concatenates subsequent message to existing buffer entry."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+    sensor.messages.append("first part")
+
+    await sensor.raw_to_text("second part")
+
+    assert len(sensor.messages) == 1
+    assert sensor.messages[0] == "first part second part"
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_sets_skip_sleep_when_messages_exist(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """raw_to_text(None) sets skip_sleep=True when buffer is non-empty."""
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    sensor.messages.append("existing message")
+    mock_sleep_ticker_instance.skip_sleep = False
+
+    await sensor.raw_to_text(None)
+
+    assert mock_sleep_ticker_instance.skip_sleep is True
+
+
+@pytest.mark.asyncio
+async def test_raw_to_text_none_does_not_set_skip_sleep_when_buffer_empty(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """raw_to_text(None) does not touch skip_sleep when buffer is empty."""
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    mock_sleep_ticker_instance.skip_sleep = False
+
+    await sensor.raw_to_text(None)
+
+    assert mock_sleep_ticker_instance.skip_sleep is False
+
+
+def test_formatted_latest_buffer_empty(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Returns None when messages buffer is empty."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    assert sensor.formatted_latest_buffer() is None
+
+
+def test_formatted_latest_buffer_formats_and_clears(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Returns formatted string, calls IO/conversation providers, and clears buffer."""
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+    fixed_timestamp = 1234.0
+
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+        patch("time.time", return_value=fixed_timestamp),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+        msg_content = "final transcription result"
+        sensor.messages = [msg_content]
+        result = sensor.formatted_latest_buffer()
+
+    assert result is not None
+    assert "Voice" in result
+    assert msg_content in result
+    assert len(sensor.messages) == 0
+
+    mock_io_provider.add_input.assert_called_once_with("Voice", msg_content, fixed_timestamp)
+    mock_io_provider.add_mode_transition_input.assert_called_once_with(msg_content)
+    mock_teleops_conv_instance.store_user_message.assert_called_once_with(msg_content)
+
+
+def test_formatted_latest_buffer_publishes_to_zenoh(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """When Zenoh is available, formatted_latest_buffer publishes the message."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    mock_asr_msg = MagicMock()
+    mock_asr_msg.serialize.return_value = b"serialized_payload"
+    mock_zenoh["asr_text_cls"].return_value = mock_asr_msg
+
+    sensor.messages.append("publish this")
+    result = sensor.formatted_latest_buffer()
+
+    assert result is not None
+    mock_zenoh["publisher"].put.assert_called_once_with(b"serialized_payload")
+
+
+def test_formatted_latest_buffer_zenoh_publish_failure_does_not_raise(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """Zenoh publish errors are logged but do not propagate."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+    mock_zenoh["publisher"].put.side_effect = Exception("publish error")
+
+    sensor.messages.append("some message")
+    result = sensor.formatted_latest_buffer()
+
+    assert result is not None
+
+
+def test_stop_sets_stopped_and_clears_buffers(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """stop() sets _stopped, drains queue, clears messages, and tears down resources."""
+    mock_asr_constructor, mock_asr_instance = mock_asr_provider
+    mock_sleep_constructor, _ = mock_sleep_ticker_provider
+    mock_conv_constructor, _ = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", new=mock_asr_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", new=mock_sleep_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", new=mock_conv_constructor),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", mock_zenoh["open_session"]),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    sensor.message_buffer.put_nowait("msg1")
+    sensor.message_buffer.put_nowait("msg2")
+    sensor.messages.append("buffered")
+
+    sensor.stop()
+
+    assert sensor._stopped is True
+    assert sensor.message_buffer.empty()
+    assert len(sensor.messages) == 0
+    mock_asr_instance.unregister_message_callback.assert_called_once()
+    mock_zenoh["publisher"].undeclare.assert_called_once()
+    mock_zenoh["session"].close.assert_called_once()
+
+
+def test_stop_without_zenoh(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+):
+    """stop() succeeds gracefully when Zenoh was never initialized."""
+    _, mock_asr_instance = mock_asr_provider
+    _, mock_sleep_ticker_instance = mock_sleep_ticker_provider
+    _, mock_teleops_conv_instance = mock_teleops_conversation_provider
+
+    config = ElevenLabsASRRTSPSensorConfig()
+    with (
+        patch("inputs.plugins.elevenlabs_asr_rtsp.IOProvider", return_value=mock_io_provider),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.ASRRTSPProvider", return_value=mock_asr_instance),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.SleepTickerProvider", return_value=mock_sleep_ticker_instance),
+        patch(
+            "inputs.plugins.elevenlabs_asr_rtsp.TeleopsConversationProvider", return_value=mock_teleops_conv_instance
+        ),
+        patch("inputs.plugins.elevenlabs_asr_rtsp.open_zenoh_session", side_effect=Exception("Zenoh down")),
+    ):
+        sensor = ElevenLabsASRRTSPInput(config=config)
+
+    sensor.stop()
+    assert sensor._stopped is True
+
+
+def test_stop_asr_unregister_failure_does_not_raise(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """stop() handles ASR unregister failure gracefully."""
+    _, mock_asr_instance = mock_asr_provider
+    mock_asr_instance.unregister_message_callback.side_effect = Exception("unregister error")
+
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor.stop()
+    assert sensor._stopped is True
+
+
+def test_stop_zenoh_undeclare_failure_does_not_raise(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """stop() handles Zenoh undeclare failure gracefully and still closes session."""
+    mock_zenoh["publisher"].undeclare.side_effect = Exception("undeclare error")
+
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor.stop()
+    assert sensor._stopped is True
+    mock_zenoh["session"].close.assert_called_once()
+
+
+def test_stop_zenoh_close_failure_does_not_raise(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """stop() handles Zenoh session close failure gracefully."""
+    mock_zenoh["session"].close.side_effect = Exception("close error")
+
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor.stop()
+    assert sensor._stopped is True
+
+
+def test_stop_all_failures_does_not_raise(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """stop() handles all resource teardown failures gracefully."""
+    _, mock_asr_instance = mock_asr_provider
+    mock_asr_instance.unregister_message_callback.side_effect = Exception("unregister error")
+    mock_zenoh["publisher"].undeclare.side_effect = Exception("undeclare error")
+    mock_zenoh["session"].close.side_effect = Exception("close error")
+
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+
+    sensor.stop()
+    assert sensor._stopped is True
+
+
+def test_stopped_sensor_ignores_further_messages(
+    mock_io_provider,
+    mock_asr_provider,
+    mock_sleep_ticker_provider,
+    mock_teleops_conversation_provider,
+    mock_zenoh,
+):
+    """After stop(), _handle_asr_message silently drops new messages."""
+    sensor = _build_sensor(
+        ElevenLabsASRRTSPSensorConfig(),
+        mock_io_provider,
+        mock_asr_provider,
+        mock_sleep_ticker_provider,
+        mock_teleops_conversation_provider,
+        mock_zenoh,
+    )
+    sensor.stop()
+
+    sensor._handle_asr_message(json.dumps({"type": "committed", "asr_reply": "hello world"}))
+
+    assert sensor.message_buffer.empty()


### PR DESCRIPTION
Introduce ElevenLabs ASR input plugins: microphone (elevenlabs_asr.py) and RTSP (elevenlabs_asr_rtsp.py). Plugins implement FuserInput handlers, Zenoh publishing, IO/conversation provider integration, latency tracking and graceful stop logic. Add comprehensive unit tests for the ElevenLabs plugins under tests/inputs/plugins. Update Prometheus metrics to include a new "model" label (src/prometheus/__init__.py) and adjust Google ASR implementations to set model="google" when recording ASR metrics.
