### PR TITLE
Update Gemini models, defaults and local endpoint

### DIFF
--- a/docs/api-reference/endpoints/llm.md
+++ b/docs/api-reference/endpoints/llm.md
@@ -53,10 +53,9 @@ deepseek-chat
 ### Google Gemini Models
 
 ```
+gemini-3.5-flash
 gemini-3.1-pro-preview
-gemini-3.1-flash-lite-preview
-gemini-3-pro-preview
-gemini-3-flash-preview
+gemini-3.1-flash-lite
 gemini-2.5-flash
 gemini-2.5-flash-lite
 gemini-2.5-pro

--- a/docs/api-reference/introduction.md
+++ b/docs/api-reference/introduction.md
@@ -53,10 +53,9 @@ For developer walkthrough and support reach out to: support@openmind.com
 
 | Service                               | Input Price (per 1M tokens) | Output Price (per 1M tokens) |
 |---------------------------------------|-----------------------------|------------------------------|
+| Gemini 3.5 Flash                      | 12500 OMCU                  | 90000 OMCU                   |
 | Gemini 3.1 Pro Preview                | 40000 OMCU                  | 180000 OMCU                  |
-| Gemini 3.1 Flash Lite Preview         | 2500 OMCU                   | 15000 OMCU                   |
-| Gemini 3 Pro Preview                  | 40000 OMCU                  | 180000 OMCU                  |
-| Gemini 3 Flash Preview                | 10000 OMCU                  | 30000 OMCU                   |
+| Gemini 3.1 Flash Lite                 | 2500 OMCU                   | 15000 OMCU                   |
 | Gemini 2.5 Flash                      | 3000 OMCU                   | 25000 OMCU                   |
 | Gemini 2.5 Flash Lite                 | 1000 OMCU                   | 4000 OMCU                    |
 | Gemini 2.5 Pro                        | 25000 OMCU                  | 150000 OMCU                  |

--- a/docs/developing/5_llms.md
+++ b/docs/developing/5_llms.md
@@ -218,7 +218,7 @@ DEEPSEEK_SUPPORTED_MODELS = ["deepseek-chat"]
 ```
 
 ```python
-GEMINI_SUPPORTED_MODELS = ["gemini-3.1-pro-preview", "gemini-3.1-flash-lite-preview", "gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro"]
+GEMINI_SUPPORTED_MODELS = ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3.1-flash-lite",  "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-pro"]
 ```
 
 ```python

--- a/src/inputs/plugins/vlm_gemini.py
+++ b/src/inputs/plugins/vlm_gemini.py
@@ -51,8 +51,8 @@ class VLMGeminiConfig(SensorConfig):
         default="gemini-2.5-flash",
         description="Gemini model id; supported (server-side): "
         "gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, "
-        "gemini-3-flash-preview, gemini-3-pro-preview, "
-        "gemini-3.1-flash-lite-preview, gemini-3.1-pro-preview",
+        "gemini-3.1-flash-lite, gemini-3.1-pro-preview"
+        "gemini-3.5-flash",
     )
     max_tokens: int = Field(
         default=1024,

--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -23,10 +23,9 @@ class GeminiModel(str, Enum):
     GEMINI_2_5_FLASH = "gemini-2.5-flash"
     GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
     GEMINI_2_5_PRO = "gemini-2.5-pro"
-    GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview"
-    GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
     GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
-    GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview"
+    GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite"
+    GEMINI_3_5_FLASH = "gemini-3.5-flash"
 
 
 class GeminiConfig(LLMConfig):
@@ -37,7 +36,7 @@ class GeminiConfig(LLMConfig):
         description="Base URL for the Gemini API endpoint",
     )
     model: T.Optional[T.Union[GeminiModel, str]] = Field(
-        default=GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
+        default=GeminiModel.GEMINI_3_1_FLASH_LITE,
         description="Gemini model to use",
     )
 
@@ -71,7 +70,8 @@ class GeminiLLM(LLM[R]):
         if not config.model:
             self._config.model = GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW
 
-        self.base_url = config.base_url or "https://api.openmind.com/api/core/gemini"
+        # self.base_url = config.base_url or "https://api.openmind.com/api/core/gemini"
+        self.base_url = "http://localhost:3000/api/core/gemini"
         self._client = openai.AsyncOpenAI(
             base_url=self.base_url,
             api_key=config.api_key,
@@ -115,7 +115,7 @@ class GeminiLLM(LLM[R]):
             formatted_messages.append({"role": "user", "content": prompt})
 
             response = await self._client.chat.completions.create(
-                model=self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
+                model=self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE,
                 messages=T.cast(T.Any, formatted_messages),
                 tools=T.cast(T.Any, self.function_schemas),
                 tool_choice="auto",
@@ -129,11 +129,11 @@ class GeminiLLM(LLM[R]):
             message = response.choices[0].message
             latency = time.time() - llm_start_time
             om1_llm_latency.labels(
-                model=str(self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW),
+                model=str(self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE),
                 endpoint=str(self.base_url),
             ).observe(latency)
             om1_llm_latency_last.labels(
-                model=str(self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW),
+                model=str(self._config.model or GeminiModel.GEMINI_3_1_FLASH_LITE),
                 endpoint=str(self.base_url),
             ).set(latency)
 

--- a/src/llm/plugins/gemini_llm.py
+++ b/src/llm/plugins/gemini_llm.py
@@ -68,10 +68,9 @@ class GeminiLLM(LLM[R]):
         if not config.api_key:
             raise ValueError("config file missing api_key")
         if not config.model:
-            self._config.model = GeminiModel.GEMINI_3_1_FLASH_LITE_PREVIEW
+            self._config.model = GeminiModel.GEMINI_3_1_FLASH_LITE
 
-        # self.base_url = config.base_url or "https://api.openmind.com/api/core/gemini"
-        self.base_url = "http://localhost:3000/api/core/gemini"
+        self.base_url = config.base_url or "https://api.openmind.com/api/core/gemini"
         self._client = openai.AsyncOpenAI(
             base_url=self.base_url,
             api_key=config.api_key,

--- a/tests/llm/plugins/test_gemini_llm.py
+++ b/tests/llm/plugins/test_gemini_llm.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from llm.output_model import Action, CortexOutputModel
-from llm.plugins.gemini_llm import GeminiConfig, GeminiLLM
+from llm.plugins.gemini_llm import GeminiConfig, GeminiLLM, GeminiModel
 
 
 class DummyOutputModel(BaseModel):
@@ -152,7 +152,7 @@ async def test_init_without_model():
     """When the test model is None, use the default value"""
     config = GeminiConfig(api_key="test_key", model=None)
     llm = GeminiLLM(config)
-    assert llm._config.model == "gemini-3.1-flash-lite-preview"
+    assert llm._config.model == GeminiModel.GEMINI_3_1_FLASH_LITE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replace preview Gemini model names with stable variants and add gemini-3.5-flash across docs and code. Updates include: docs (endpoints, introduction, developer guide) to reflect new supported models and pricing entry; GeminiModel enum and GEMINI_SUPPORTED_MODELS list to include gemini-3.5-flash and use gemini-3.1-flash-lite; default model changed to gemini-3.1-flash-lite; metrics and chat call sites updated to use the new default; GeminiLLM base_url switched to a local test endpoint (previous production URL is commented out). These changes align code and documentation with the revised Gemini model names and local testing setup.