### PR TITLE
Manage Prometheus server startup and update om1-modules revision

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "fastapi==0.135.3",
     "uvicorn==0.34.0",
     "websockets==13.1",
-    "om1-modules @ git+https://github.com/OpenMind/om1-modules.git@04c4dce845f0af2e4f34e6c6e4bcbb278920f33c",
+    "om1-modules @ git+https://github.com/OpenMind/om1-modules.git@c6007316fd39fc385d6313bdd5526a3e7940c087",
     "aiohttp==3.13.4",
     "pynput==1.8.1",
     "dimo-python-sdk @ git+https://github.com/openminddev/dimo-python-sdk.git@6b47fcd28654a4145cedee649a0999a8eb08a2f6",

--- a/src/prometheus/__init__.py
+++ b/src/prometheus/__init__.py
@@ -1,6 +1,38 @@
+import atexit
+import logging
+
 from prometheus_client import Gauge, Histogram, start_http_server
 
-start_http_server(9090)
+_prometheus_server = None
+_prometheus_thread = None
+
+
+def _stop_prometheus_server():
+    """
+    Stop the Prometheus server on program exit.
+    """
+    global _prometheus_server, _prometheus_thread
+    if _prometheus_server is not None:
+        try:
+            _prometheus_server.shutdown()
+            if _prometheus_thread is not None:
+                _prometheus_thread.join(timeout=2.0)
+            logging.info("Prometheus metrics server stopped")
+        except Exception as e:
+            logging.warning(f"Error stopping Prometheus server: {e}")
+
+
+try:
+    result = start_http_server(9090)
+    _prometheus_server, _prometheus_thread = result
+
+    atexit.register(_stop_prometheus_server)
+    logging.info("Prometheus metrics server started on port 9090")
+except OSError as e:
+    if "Address already in use" in str(e):
+        logging.warning("Prometheus port 9090 already in use, reusing existing server")
+    else:
+        raise
 
 # LLM Metrics
 om1_llm_latency = Histogram(
@@ -50,52 +82,4 @@ om1_asr_utterance_end_latency_last = Gauge(
     "om1_asr_utterance_end_latency_last_seconds",
     "Most recent latency from speech activity start to end_of_utterance detection in seconds",
     ["model", "language", "api_version"],
-)
-
-om1_http_request_duration_seconds = Histogram(
-    "om1_http_request_duration_seconds",
-    "Total HTTP request duration (client-side) in seconds",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_upstream_total_seconds = Histogram(
-    "om1_http_upstream_total_seconds",
-    "Upstream total time in seconds (from x-upstream-total-ms header)",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_upstream_ttfb_seconds = Histogram(
-    "om1_http_upstream_ttfb_seconds",
-    "Upstream TTFB in seconds (from x-upstream-ttfb-ms header)",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_proxy_total_seconds = Histogram(
-    "om1_http_proxy_total_seconds",
-    "Proxy total time in seconds (from x-proxy-total-ms header)",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_request_duration_last_seconds = Gauge(
-    "om1_http_request_duration_last_seconds",
-    "Most recent HTTP request duration (client-side) in seconds",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_upstream_total_last_seconds = Gauge(
-    "om1_http_upstream_total_last_seconds",
-    "Most recent upstream total time in seconds",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_upstream_ttfb_last_seconds = Gauge(
-    "om1_http_upstream_ttfb_last_seconds",
-    "Most recent upstream TTFB in seconds",
-    ["host", "path", "method", "status_code"],
-)
-
-om1_http_proxy_total_last_seconds = Gauge(
-    "om1_http_proxy_total_last_seconds",
-    "Most recent proxy total time in seconds",
-    ["host", "path", "method", "status_code"],
 )

--- a/src/providers/httpx.py
+++ b/src/providers/httpx.py
@@ -2,8 +2,7 @@ import logging
 import time
 
 import httpx
-
-from prometheus import (
+from om1_utils.prometheus import (
     om1_http_proxy_total_last_seconds,
     om1_http_proxy_total_seconds,
     om1_http_request_duration_last_seconds,

--- a/uv.lock
+++ b/uv.lock
@@ -2391,7 +2391,7 @@ requires-dist = [
     { name = "mcp", specifier = "==1.26.0" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "numpy", specifier = "==1.26.4" },
-    { name = "om1-modules", git = "https://github.com/OpenMind/om1-modules.git?rev=04c4dce845f0af2e4f34e6c6e4bcbb278920f33c" },
+    { name = "om1-modules", git = "https://github.com/OpenMind/om1-modules.git?rev=c6007316fd39fc385d6313bdd5526a3e7940c087" },
     { name = "openai", specifier = "==1.60.1" },
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "osascript", marker = "extra == 'macos'" },
@@ -2433,7 +2433,7 @@ dev = [
 [[package]]
 name = "om1-modules"
 version = "0.1.0"
-source = { git = "https://github.com/OpenMind/om1-modules.git?rev=04c4dce845f0af2e4f34e6c6e4bcbb278920f33c#04c4dce845f0af2e4f34e6c6e4bcbb278920f33c" }
+source = { git = "https://github.com/OpenMind/om1-modules.git?rev=c6007316fd39fc385d6313bdd5526a3e7940c087#c6007316fd39fc385d6313bdd5526a3e7940c087" }
 dependencies = [
     { name = "av" },
     { name = "eclipse-zenoh" },


### PR DESCRIPTION
This pull request introduces several updates to the Prometheus metrics integration and dependency management. The most significant changes are improvements to the Prometheus server's lifecycle management, error handling, and a refactor of how Prometheus metrics are imported and defined.

**Prometheus server lifecycle and error handling:**

* Enhanced the Prometheus server startup in `src/prometheus/__init__.py` to handle the "address already in use" error gracefully, log server status, and ensure the server is cleanly shut down on program exit using `atexit` hooks.

**Metrics refactor and cleanup:**

* Removed several HTTP-related Prometheus metrics (both `Histogram` and `Gauge` types) from `src/prometheus/__init__.py`, including `om1_http_request_duration_seconds`, `om1_http_upstream_total_seconds`, `om1_http_upstream_ttfb_seconds`, `om1_http_proxy_total_seconds`, and their corresponding "last" gauges, simplifying the metrics exposed by the service.

**Dependency and import changes:**

* Updated the `om1-modules` dependency in `pyproject.toml` to a newer commit, ensuring the latest features and bug fixes are included.
* Changed the import path for Prometheus metrics in `src/providers/httpx.py` from `prometheus` to `om1_utils.prometheus`, reflecting a likely project structure or packaging change.