### PR TITLE
Bump om1-modules to newer commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "fastapi==0.135.3",
     "uvicorn==0.34.0",
     "websockets==13.1",
-    "om1-modules @ git+https://github.com/OpenMind/om1-modules.git@c6007316fd39fc385d6313bdd5526a3e7940c087",
+    "om1-modules @ git+https://github.com/OpenMind/om1-modules.git@4ee799e25843b8c0984cc2bd008fab23ebded343",
     "aiohttp==3.13.4",
     "pynput==1.8.1",
     "dimo-python-sdk @ git+https://github.com/openminddev/dimo-python-sdk.git@6b47fcd28654a4145cedee649a0999a8eb08a2f6",

--- a/uv.lock
+++ b/uv.lock
@@ -2391,7 +2391,7 @@ requires-dist = [
     { name = "mcp", specifier = "==1.26.0" },
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "numpy", specifier = "==1.26.4" },
-    { name = "om1-modules", git = "https://github.com/OpenMind/om1-modules.git?rev=c6007316fd39fc385d6313bdd5526a3e7940c087" },
+    { name = "om1-modules", git = "https://github.com/OpenMind/om1-modules.git?rev=4ee799e25843b8c0984cc2bd008fab23ebded343" },
     { name = "openai", specifier = "==1.60.1" },
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "osascript", marker = "extra == 'macos'" },
@@ -2433,7 +2433,7 @@ dev = [
 [[package]]
 name = "om1-modules"
 version = "0.1.0"
-source = { git = "https://github.com/OpenMind/om1-modules.git?rev=c6007316fd39fc385d6313bdd5526a3e7940c087#c6007316fd39fc385d6313bdd5526a3e7940c087" }
+source = { git = "https://github.com/OpenMind/om1-modules.git?rev=4ee799e25843b8c0984cc2bd008fab23ebded343#4ee799e25843b8c0984cc2bd008fab23ebded343" }
 dependencies = [
     { name = "av" },
     { name = "eclipse-zenoh" },


### PR DESCRIPTION
Update om1-modules git dependency to commit 4ee799e25843b8c0984cc2bd008fab23ebded343 in pyproject.toml and refresh uv.lock to match. Pins the project to the updated om1-modules revision to incorporate upstream changes.