### PR TITLE
fix: use eth_abi to decode governance response in GovernanceEthereum

### DIFF
--- a/src/inputs/plugins/ethereum_governance.py
+++ b/src/inputs/plugins/ethereum_governance.py
@@ -4,6 +4,8 @@ import time
 from typing import Optional
 
 import aiohttp
+from eth_abi import decode as abi_decode
+from eth_abi.exceptions import DecodingError
 
 from inputs.base import Message, SensorConfig
 from inputs.base.loop import FuserInput
@@ -101,20 +103,17 @@ class GovernanceEthereum(FuserInput[SensorConfig, Optional[str]]):
         try:
             response_bytes = bytes.fromhex(hex_response)
 
-            # Read offsets and string length
-            # offset = int.from_bytes(response_bytes[:32], "big")
-            string_length = int.from_bytes(response_bytes[96:128], "big")
-
-            # Extract and decode string
-            string_bytes = response_bytes[128 : 128 + string_length]
-            decoded_string = string_bytes.decode("utf-8")
+            # Decode the ABI-encoded response as a single dynamic string.
+            # Using eth_abi (from web3) instead of manual offset/length
+            # parsing avoids silent failures when the ABI layout shifts.
+            (decoded_string,) = abi_decode(["string"], response_bytes)
 
             # Remove unexpected control characters (like \x19)
             cleaned_string = "".join(ch for ch in decoded_string if ch.isprintable())
 
             return cleaned_string
 
-        except Exception as e:
+        except (DecodingError, ValueError, UnicodeDecodeError) as e:
             logging.error(f"Decoding error: {e}")
             return None
 


### PR DESCRIPTION
## Summary

Fixes the fragile manual ABI decoding in `GovernanceEthereum.decode_eth_response` (issue #1824).

## Problem

The old `decode_eth_response` parsed the eth_call result by hand, reading the string length from a hard-coded byte offset (`response_bytes[96:128]`) and slicing from a fixed position. This assumes a specific ABI layout — if the response layout shifts, it silently returns wrong data rather than failing loudly.

## Fix

Replace the manual parsing with `eth_abi.decode(["string"], ...)` (eth_abi ships with the existing `web3==7.6.0` dependency, so no new dependency is added). This decodes the ABI-encoded response correctly regardless of offset.

## Scope (intentionally minimal)

- **Only one source file changed** (`src/inputs/plugins/ethereum_governance.py`): the import and the body of `decode_eth_response`.
- **No test files touched** — the existing 16 tests in `tests/inputs/plugins/test_ethereum_governance.py` all pass unchanged.
- No public API change, async flow untouched, no behavior change for valid responses (verified by round-trip encode/decode).

This is a much smaller, more focused version of my earlier attempt (#2069), which got stuck on test-file structure. This time the test files are left exactly as-is.

All checks pass locally: ruff, ruff format, typos, and pytest (16 passed).