### PR TITLE
Add knowledge base Prometheus metrics and dashboard panels

### DIFF
--- a/grafana/dashboards/om1-dashboard.json
+++ b/grafana/dashboards/om1-dashboard.json
@@ -1210,6 +1210,670 @@
         }
       }
     },
+    "panel-19": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "om1_kb_query_latency_last_seconds",
+                      "legendFormat": "Query"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Most recent knowledge base query latency (embedding + search)",
+        "id": 19,
+        "links": [],
+        "title": "KB Query Latency (Last)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 2,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.3
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-20": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "om1_kb_embed_latency_last_seconds",
+                      "legendFormat": "Embed"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Most recent embedding-step latency within a KB query",
+        "id": 20,
+        "links": [],
+        "title": "KB Embed Latency (Last)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 2,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 0.25
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.75
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "area",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "auto",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-22": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (status) (om1_kb_queries_total)",
+                      "legendFormat": "{{status}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "Total KB queries since startup, by outcome",
+        "id": 22,
+        "links": [],
+        "title": "KB Queries (Total)",
+        "vizConfig": {
+          "group": "stat",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "thresholds"
+                },
+                "decimals": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "blue",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byFrameRefID",
+                    "options": "A"
+                  },
+                  "properties": []
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "error"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "horizontal",
+              "percentChangeColorMode": "standard",
+              "reduceOptions": {
+                "calcs": [
+                  "lastNotNull"
+                ],
+                "fields": "",
+                "values": false
+              },
+              "showPercentChange": false,
+              "textMode": "value_and_name",
+              "wideLayout": true
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-23": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "histogram_quantile(0.5, sum by (le) (rate(om1_kb_query_latency_seconds_bucket[5m])))",
+                      "legendFormat": "Query P50"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "histogram_quantile(0.95, sum by (le) (rate(om1_kb_query_latency_seconds_bucket[5m])))",
+                      "legendFormat": "Query P95"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "B"
+                }
+              },
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "histogram_quantile(0.95, sum by (le) (rate(om1_kb_embed_latency_seconds_bucket[5m])))",
+                      "legendFormat": "Embed P95"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "C"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "KB query and embedding-step latency percentiles (5min window)",
+        "id": 23,
+        "links": [],
+        "title": "KB Latency Percentiles",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 10,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-24": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (status) (rate(om1_kb_queries_total[1m])) * 60",
+                      "legendFormat": "{{status}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "KB queries per minute, split by success / error",
+        "id": 24,
+        "links": [],
+        "title": "KB Queries per Minute",
+        "vizConfig": {
+          "group": "timeseries",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "barWidthFactor": 0.6,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "showValues": false,
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "error"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "legend": {
+                "calcs": [
+                  "mean",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "none"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
+    "panel-25": {
+      "kind": "Panel",
+      "spec": {
+        "data": {
+          "kind": "QueryGroup",
+          "spec": {
+            "queries": [
+              {
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "query": {
+                    "datasource": {
+                      "name": "prometheus"
+                    },
+                    "group": "prometheus",
+                    "kind": "DataQuery",
+                    "spec": {
+                      "expr": "sum by (le) (rate(om1_kb_query_latency_seconds_bucket[1m]))",
+                      "format": "heatmap",
+                      "legendFormat": "{{le}}"
+                    },
+                    "version": "v0"
+                  },
+                  "refId": "A"
+                }
+              }
+            ],
+            "queryOptions": {},
+            "transformations": []
+          }
+        },
+        "description": "KB query latency distribution heatmap",
+        "id": 25,
+        "links": [],
+        "title": "KB Query Latency Distribution",
+        "vizConfig": {
+          "group": "heatmap",
+          "kind": "VizConfig",
+          "spec": {
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "scaleDistribution": {
+                    "type": "linear"
+                  }
+                }
+              },
+              "overrides": []
+            },
+            "options": {
+              "annotations": {
+                "clustering": -1,
+                "multiLane": false
+              },
+              "calculate": false,
+              "cellGap": 1,
+              "color": {
+                "exponent": 0.5,
+                "fill": "dark-orange",
+                "mode": "scheme",
+                "reverse": false,
+                "scale": "exponential",
+                "scheme": "Spectral",
+                "steps": 64
+              },
+              "exemplars": {
+                "color": "rgba(255,0,255,0.7)"
+              },
+              "filterValues": {
+                "le": 1e-9
+              },
+              "legend": {
+                "show": true
+              },
+              "rowsFrame": {
+                "layout": "auto"
+              },
+              "tooltip": {
+                "mode": "single",
+                "showColorScale": false,
+                "yHistogram": false
+              },
+              "yAxis": {
+                "axisPlacement": "left",
+                "reverse": false,
+                "unit": "s"
+              }
+            }
+          },
+          "version": "13.0.1+security-01"
+        }
+      }
+    },
     "panel-2": {
       "kind": "Panel",
       "spec": {
@@ -2414,6 +3078,84 @@
             "width": 24,
             "x": 0,
             "y": 53
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-19"
+            },
+            "height": 4,
+            "width": 8,
+            "x": 0,
+            "y": 61
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-20"
+            },
+            "height": 4,
+            "width": 8,
+            "x": 8,
+            "y": 61
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-22"
+            },
+            "height": 4,
+            "width": 8,
+            "x": 16,
+            "y": 61
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-23"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 0,
+            "y": 65
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-24"
+            },
+            "height": 8,
+            "width": 12,
+            "x": 12,
+            "y": 65
+          }
+        },
+        {
+          "kind": "GridLayoutItem",
+          "spec": {
+            "element": {
+              "kind": "ElementReference",
+              "name": "panel-25"
+            },
+            "height": 9,
+            "width": 24,
+            "x": 0,
+            "y": 73
           }
         }
       ]

--- a/internal/knowledgebase/knowledgebase.go
+++ b/internal/knowledgebase/knowledgebase.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/coder/hnsw"
 	"github.com/openmind/om1/internal/config"
+	"github.com/openmind/om1/internal/metrics"
 )
 
 // defaultTopK is the default number of results to return for a query if not specified in the KB spec.
@@ -78,12 +80,20 @@ func NewKnowledgeBase(spec *config.KBSpec) (*KnowledgeBase, error) {
 }
 
 // Query embeds the question, searches the graph for the nearest documents.
-func (kb *KnowledgeBase) Query(ctx context.Context, question string, topK int) ([]string, error) {
+func (kb *KnowledgeBase) Query(ctx context.Context, question string, topK int) (results []string, err error) {
+	start := time.Now()
+	embedSeconds := -1.0
+	defer func() {
+		metrics.RecordKBQuery(embedSeconds, time.Since(start).Seconds(), err == nil)
+	}()
+
 	if topK <= 0 {
 		topK = kb.topK
 	}
 
+	embedStart := time.Now()
 	queryVec, err := kb.embedder.Embed(ctx, question)
+	embedSeconds = time.Since(embedStart).Seconds()
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
 	}
@@ -98,7 +108,7 @@ func (kb *KnowledgeBase) Query(ctx context.Context, question string, topK int) (
 
 	nodes := kb.graph.Search(queryVec, searchK)
 
-	results := make([]string, 0, topK)
+	results = make([]string, 0, topK)
 	seen := make(map[string]struct{}, topK)
 	for _, node := range nodes {
 		doc, ok := kb.docs[node.Key]

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -78,6 +78,32 @@ var (
 	}, []string{"model", "endpoint"})
 )
 
+// Knowledge base metrics.
+var (
+	KBQueryLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "om1_kb_query_latency_seconds",
+		Help: "Latency of a knowledge base query (embedding plus search) in seconds",
+	})
+	KBQueryLatencyLast = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "om1_kb_query_latency_last_seconds",
+		Help: "Most recent knowledge base query latency in seconds",
+	})
+
+	KBEmbedLatency = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: "om1_kb_embed_latency_seconds",
+		Help: "Latency of the embedding step of a knowledge base query in seconds",
+	})
+	KBEmbedLatencyLast = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "om1_kb_embed_latency_last_seconds",
+		Help: "Most recent knowledge base embedding-step latency in seconds",
+	})
+
+	KBQueries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "om1_kb_queries_total",
+		Help: "Total number of knowledge base queries by outcome",
+	}, []string{"status"})
+)
+
 // HTTP metrics.
 var (
 	HTTPProxyParse = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -124,6 +150,9 @@ func init() {
 		ASRSpeechDuration, ASRSpeechDurationLast,
 		ASRUtteranceEndLatency, ASRUtteranceEndLatencyLast,
 		TTSLatency, TTSLatencyLast,
+		KBQueryLatency, KBQueryLatencyLast,
+		KBEmbedLatency, KBEmbedLatencyLast,
+		KBQueries,
 		HTTPProxyParse, HTTPProxyParseLast,
 		HTTPUpstreamTotal, HTTPUpstreamTotalLast,
 		HTTPUpstreamTTFB, HTTPUpstreamTTFBLast,
@@ -148,6 +177,26 @@ func RecordHTTPTiming(host, path, method string, statusCode int, proxyParseMs, u
 	observe(HTTPUpstreamTotal, HTTPUpstreamTotalLast, upstreamTotalMs)
 	observe(HTTPUpstreamTTFB, HTTPUpstreamTTFBLast, upstreamTTFBMs)
 	observe(HTTPProxyTotal, HTTPProxyTotalLast, proxyTotalMs)
+}
+
+// RecordKBQuery records metrics for a single knowledge base query.
+// querySeconds is the total query latency; ok reports whether the query
+// succeeded. embedSeconds is the latency of the embedding step, or a negative
+// value when the embedding step did not complete (so it is not recorded).
+func RecordKBQuery(embedSeconds, querySeconds float64, ok bool) {
+	status := "success"
+	if !ok {
+		status = "error"
+	}
+	KBQueries.WithLabelValues(status).Inc()
+
+	KBQueryLatency.Observe(querySeconds)
+	KBQueryLatencyLast.Set(querySeconds)
+
+	if embedSeconds >= 0 {
+		KBEmbedLatency.Observe(embedSeconds)
+		KBEmbedLatencyLast.Set(embedSeconds)
+	}
 }
 
 // StartServer starts the HTTP server that exposes the Prometheus metrics on port 9090.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -179,10 +179,7 @@ func RecordHTTPTiming(host, path, method string, statusCode int, proxyParseMs, u
 	observe(HTTPProxyTotal, HTTPProxyTotalLast, proxyTotalMs)
 }
 
-// RecordKBQuery records metrics for a single knowledge base query.
-// querySeconds is the total query latency; ok reports whether the query
-// succeeded. embedSeconds is the latency of the embedding step, or a negative
-// value when the embedding step did not complete (so it is not recorded).
+// RecordKBQuery records the latency of a knowledge base query.
 func RecordKBQuery(embedSeconds, querySeconds float64, ok bool) {
 	status := "success"
 	if !ok {


### PR DESCRIPTION
## Summary

Instruments knowledge base queries with Prometheus metrics and surfaces them in the Grafana dashboard, following the existing `om1_*` metric conventions.

### New metrics (`internal/metrics/metrics.go`)
- `om1_kb_query_latency_seconds` (+ `_last` gauge) — total query latency (embedding + HNSW search)
- `om1_kb_embed_latency_seconds` (+ `_last` gauge) — latency of the embedding sub-step
- `om1_kb_queries_total{status="success|error"}` — query count by outcome

A `RecordKBQuery(embedSeconds, querySeconds, ok)` helper mirrors the existing `RecordHTTPTiming` style. All metrics are unlabeled (aside from the counter's `status`) to keep things simple.

### Instrumentation (`internal/knowledgebase/knowledgebase.go`)
`KnowledgeBase.Query` now uses named returns + a `defer` so every exit path (embed error, empty index, success) records latency, the embed sub-step, and success/error outcome. The embed step is timed separately; if it doesn't complete, its latency is skipped rather than recorded as zero.

### Dashboard (`grafana/dashboards/om1-dashboard.json`)
Adds a Knowledge Base section: KB query/embed "last" stat tiles, total-queries-by-outcome tile, latency percentiles (query P50/P95 + embed P95), queries-per-minute split by success/error, and a query-latency distribution heatmap.

## Testing
- `go build` / `go vet` pass for `internal/metrics` and `internal/knowledgebase`.
- Dashboard JSON validated (well-formed; all layout items resolve to elements).

> Note: exercising the metrics end-to-end requires an embedding service on `:8100` (configurable via `KB_BASE_URL`), which is external to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)