### PR TITLE
Rename ASR model to provider and refactor aggregator to sensor core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Build artifacts
 build/
 
-# IDE
-.vscode/
-
 # Claude Code
 CLAUDE.md
 .claude/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "go.testFlags": ["-p", "8", "-v"],
+  "go.testEnvVars": {
+    "CGO_ENABLED": "1",
+    "CGO_CFLAGS": "-I${workspaceFolder}/.zenoh-c/include",
+    "CGO_LDFLAGS": "-L${workspaceFolder}/.zenoh-c/lib -lzenohc -Wl,-rpath,${workspaceFolder}/.zenoh-c/lib",
+    "DYLD_LIBRARY_PATH": "${workspaceFolder}/.zenoh-c/lib",
+    "LD_LIBRARY_PATH": "${workspaceFolder}/.zenoh-c/lib"
+  },
+  "go.buildFlags": [],
+  "go.buildTags": "integration"
+}

--- a/plugins/inputs/asr_common.go
+++ b/plugins/inputs/asr_common.go
@@ -19,8 +19,8 @@ import (
 	zenohsession "github.com/openmind/om1/internal/zenoh"
 )
 
-// cjkRegex matches CJK characters (Chinese, Japanese kana, Hangul) used to decide
-// the minimum-length threshold for accepting a transcript.
+// cjkRegex matches CJK characters (Chinese, Japanese kana, Hangul), which use a
+// shorter minimum-length threshold for accepting a transcript.
 var cjkRegex = regexp.MustCompile(`[\x{4e00}-\x{9fff}\x{3040}-\x{30ff}\x{ac00}-\x{d7af}]`)
 
 const asrZenohTopic = "om/asr/text"
@@ -46,27 +46,27 @@ type asrMessageParser func(s *transcriberStream, msg ASRMessage) string
 
 // asrCommonConfig holds the vendor-resolved configuration for a transcriberStream.
 type asrCommonConfig struct {
-	Name               string // log prefix, e.g. "GoogleASRInput"
-	Model              string // metric label, e.g. "google" / "elevenlabs"
-	APIVersion         string // metric label, e.g. "v1" / "v2"
-	WSURL              string // fully-built websocket endpoint
+	Name               string
+	Provider           string
+	APIVersion         string
+	WSURL              string
 	Rate               int
-	Language           string // friendly name, used as a metric label
+	Language           string
 	LanguageCode       string
 	AltCodes           []string
 	EnableTTSInterrupt bool
 	ParseMessage       asrMessageParser
 }
 
-// asrCommon couples the aggregator with a single vendor stream.
+// asrCommon couples the sensor core with a single vendor stream.
 type asrCommon struct {
-	*asrAggregator
+	*asrSensorCore
 	stream *transcriberStream
 }
 
-// asrAggregator owns the ASR sensor parts: the transcript channel read by the cortex loop,
-// the current-utterance buffer, lifecycle state, and the zenoh broadcast
-type asrAggregator struct {
+// asrSensorCore holds the parts shared by every ASR sensor: the transcript channel
+// read by the cortex loop, the utterance buffer, lifecycle state, and the zenoh broadcast.
+type asrSensorCore struct {
 	name string
 	log  *zap.Logger
 
@@ -84,12 +84,11 @@ type asrAggregator struct {
 	zenohPublisher *zenohsession.Publisher
 }
 
-// newAggregator constructs an asrAggregator, opening the (optional) zenoh publisher
-// used to broadcast transcripts on om/asr/text.
-func newAggregator(name string, enableTTSInterrupt bool) *asrAggregator {
+// newSensorCore builds the sensor core, initializing the zenoh publisher if possible.
+func newSensorCore(name string, enableTTSInterrupt bool) *asrSensorCore {
 	log := logger.Get()
 
-	a := &asrAggregator{
+	a := &asrSensorCore{
 		name:               name,
 		log:                log,
 		enableTTSInterrupt: enableTTSInterrupt,
@@ -114,9 +113,8 @@ func newAggregator(name string, enableTTSInterrupt bool) *asrAggregator {
 	return a
 }
 
-// pushTranscript delivers an accepted transcript to the cortex loop unless the
-// sensor has stopped.
-func (a *asrAggregator) pushTranscript(text string) {
+// pushTranscript accepts a transcript, pushing it onto the channel for the cortex loop.
+func (a *asrSensorCore) pushTranscript(text string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -140,13 +138,13 @@ func (a *asrAggregator) pushTranscript(text string) {
 
 // deliver is the default onTranscript handler for a single-provider stream: it
 // ignores the provider label and forwards every accepted transcript.
-func (a *asrAggregator) deliver(_ string, text string) {
+func (a *asrSensorCore) deliver(_ string, text string) {
 	a.pushTranscript(text)
 }
 
 // Poll returns the next accepted transcript, blocking until one is available or
 // ctx is cancelled.
-func (a *asrAggregator) Poll(ctx context.Context) (any, error) {
+func (a *asrSensorCore) Poll(ctx context.Context) (any, error) {
 	select {
 	case text, ok := <-a.transcriptCh:
 		if !ok {
@@ -160,7 +158,7 @@ func (a *asrAggregator) Poll(ctx context.Context) (any, error) {
 
 // pollLoop forwards transcripts from Poll onto out until ctx is cancelled or the
 // transcript channel closes.
-func (a *asrAggregator) pollLoop(ctx context.Context, out chan any) {
+func (a *asrSensorCore) pollLoop(ctx context.Context, out chan any) {
 	for {
 		raw, err := a.Poll(ctx)
 		if err != nil {
@@ -175,7 +173,7 @@ func (a *asrAggregator) pollLoop(ctx context.Context, out chan any) {
 }
 
 // RawToText appends an accepted transcript to the current utterance buffer.
-func (a *asrAggregator) RawToText(_ context.Context, raw any) (*inputs.Message, error) {
+func (a *asrSensorCore) RawToText(_ context.Context, raw any) (*inputs.Message, error) {
 	text, ok := raw.(string)
 	if !ok || text == "" {
 		return nil, nil
@@ -194,11 +192,11 @@ func (a *asrAggregator) RawToText(_ context.Context, raw any) (*inputs.Message, 
 }
 
 // TriggersTick reports that ASR input wakes the cortex loop.
-func (a *asrAggregator) TriggersTick() bool { return true }
+func (a *asrSensorCore) TriggersTick() bool { return true }
 
 // FormattedLatestBuffer returns the buffered utterance as a Voice block, records
 // it on the IO provider, broadcasts it over zenoh, and clears the buffer.
-func (a *asrAggregator) FormattedLatestBuffer() string {
+func (a *asrSensorCore) FormattedLatestBuffer() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -228,7 +226,7 @@ func (a *asrAggregator) FormattedLatestBuffer() string {
 
 // markStopped flips the stopped flag exactly once. It returns whether this call
 // was the first to stop the sensor and a snapshot of captureDone to wait on.
-func (a *asrAggregator) markStopped() (firstStop bool, captureDone chan struct{}) {
+func (a *asrSensorCore) markStopped() (firstStop bool, captureDone chan struct{}) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.stopped {
@@ -239,7 +237,7 @@ func (a *asrAggregator) markStopped() (firstStop bool, captureDone chan struct{}
 }
 
 // waitCapture waits up to 5s for the capture loop to finish.
-func (a *asrAggregator) waitCapture(captureDone chan struct{}) {
+func (a *asrSensorCore) waitCapture(captureDone chan struct{}) {
 	if captureDone == nil {
 		return
 	}
@@ -251,7 +249,7 @@ func (a *asrAggregator) waitCapture(captureDone chan struct{}) {
 }
 
 // closeZenoh drops the zenoh publisher and closes the session.
-func (a *asrAggregator) closeZenoh() {
+func (a *asrSensorCore) closeZenoh() {
 	if a.zenohPublisher != nil {
 		a.zenohPublisher.Drop()
 		a.zenohPublisher = nil
@@ -265,11 +263,11 @@ func (a *asrAggregator) closeZenoh() {
 }
 
 // newASRCommon constructs an asrCommon from a vendor-resolved config, building the
-// aggregator (with zenoh publisher) and the single websocket stream.
+// sensor core (with zenoh publisher) and the single websocket stream.
 func newASRCommon(cfg asrCommonConfig) *asrCommon {
-	agg := newAggregator(cfg.Name, cfg.EnableTTSInterrupt)
+	agg := newSensorCore(cfg.Name, cfg.EnableTTSInterrupt)
 	agg.log.Info(cfg.Name+": initializing",
-		zap.String("model", cfg.Model),
+		zap.String("provider", cfg.Provider),
 		zap.String("language", cfg.Language),
 		zap.String("language_code", cfg.LanguageCode),
 		zap.String("api_version", cfg.APIVersion),
@@ -279,7 +277,7 @@ func newASRCommon(cfg asrCommonConfig) *asrCommon {
 
 	stream := newTranscriberStream(cfg, agg.log, agg.deliver)
 
-	return &asrCommon{asrAggregator: agg, stream: stream}
+	return &asrCommon{asrSensorCore: agg, stream: stream}
 }
 
 // connect dials the single stream's ASR websocket.
@@ -308,11 +306,7 @@ func serializeASRText(text string) []byte {
 	frameID := uuid.New().String()
 
 	var buf []byte
-
-	// CDR encapsulation header (little-endian)
-	buf = append(buf, 0x00, 0x01, 0x00, 0x00)
-
-	// stamp.sec (int32 LE)
+	buf = append(buf, 0x00, 0x01, 0x00, 0x00) // CDR encapsulation header (little-endian)
 	buf = zenohsession.AppendInt32LE(buf, int32(now.Unix()))
 
 	// stamp.nanosec (uint32 LE)

--- a/plugins/inputs/asr_stream.go
+++ b/plugins/inputs/asr_stream.go
@@ -38,7 +38,7 @@ type transcriberStream struct {
 	name string
 	log  *zap.Logger
 
-	model        string
+	provider     string
 	apiVersion   string
 	language     string
 	languageCode string
@@ -48,9 +48,8 @@ type transcriberStream struct {
 	parseMessage asrMessageParser
 	wsClient     *ws.Client
 
-	onTranscript func(model, text string)
+	onTranscript func(provider, text string)
 
-	// mu guards the per-utterance speech timing used by the vendor parsers.
 	mu              sync.Mutex
 	speechStartTime time.Time
 	speechStarted   bool
@@ -60,11 +59,11 @@ type transcriberStream struct {
 
 // newTranscriberStream builds a stream from a vendor-resolved config, wiring its
 // websocket client to onWSMessage and its accepted transcripts to onTranscript.
-func newTranscriberStream(cfg asrCommonConfig, log *zap.Logger, onTranscript func(model, text string)) *transcriberStream {
+func newTranscriberStream(cfg asrCommonConfig, log *zap.Logger, onTranscript func(provider, text string)) *transcriberStream {
 	s := &transcriberStream{
 		name:         cfg.Name,
 		log:          log,
-		model:        cfg.Model,
+		provider:     cfg.Provider,
 		apiVersion:   cfg.APIVersion,
 		language:     cfg.Language,
 		languageCode: cfg.LanguageCode,
@@ -152,15 +151,15 @@ func (s *transcriberStream) onWSMessage(msgType int, data []byte) {
 	}
 
 	if s.onTranscript != nil {
-		s.onTranscript(s.model, transcript)
+		s.onTranscript(s.provider, transcript)
 	}
 }
 
 // observeASR records an ASR latency metric pair with this stream's labels.
 func (s *transcriberStream) observeASR(hist *prometheus.HistogramVec, gauge *prometheus.GaugeVec, d time.Duration) {
 	seconds := d.Seconds()
-	hist.WithLabelValues(s.model, s.language, s.apiVersion).Observe(seconds)
-	gauge.WithLabelValues(s.model, s.language, s.apiVersion).Set(seconds)
+	hist.WithLabelValues(s.provider, s.language, s.apiVersion).Observe(seconds)
+	gauge.WithLabelValues(s.provider, s.language, s.apiVersion).Set(seconds)
 }
 
 // statsLoop logs send statistics every 15 seconds until ctx is cancelled.

--- a/plugins/inputs/elevenlabs_asr.go
+++ b/plugins/inputs/elevenlabs_asr.go
@@ -22,8 +22,8 @@ func init() {
 	inputs.Register("ElevenLabsASRInput", NewElevenLabsASR)
 }
 
-// elevenlabsLanguageCodeMap maps friendly language names to the short codes
-// accepted by the ElevenLabs ASR service. "auto" enables language detection.
+// elevenlabsLanguageCodeMap maps friendly language names to ElevenLabs short codes;
+// "auto" enables language detection.
 var elevenlabsLanguageCodeMap = map[string]string{
 	"auto":       "auto",
 	"english":    "en",
@@ -64,8 +64,7 @@ type elevenlabsASRParams struct {
 	enableTTSInterrupt bool
 }
 
-// ElevenLabsASRSensor captures audio from a local microphone (via PortAudio) and
-// streams it to the ElevenLabs ASR websocket through the shared asrCommon.
+// ElevenLabsASRSensor streams local microphone audio to ElevenLabs ASR via the shared asrCommon.
 type ElevenLabsASRSensor struct {
 	*asrCommon
 
@@ -281,7 +280,7 @@ func resolveElevenLabsASRConfig(p elevenlabsASRParams) asrCommonConfig {
 
 	return asrCommonConfig{
 		Name:               p.name,
-		Model:              "elevenlabs",
+		Provider:           "elevenlabs",
 		APIVersion:         elevenlabsAPIVersion,
 		WSURL:              wsURL,
 		Rate:               p.rate,
@@ -292,10 +291,11 @@ func resolveElevenLabsASRConfig(p elevenlabsASRParams) asrCommonConfig {
 	}
 }
 
-// elevenlabsParseMessage implements the ElevenLabs ASR protocol (partial marks speech start, committed carries the transcript) and records its latency metric.
+// elevenlabsParseMessage handles the ElevenLabs ASR protocol (partial marks speech
+// start, committed carries the transcript) and records its latency metric.
 func elevenlabsParseMessage(s *transcriberStream, msg ASRMessage) string {
 	if msg.Type == "partial" {
-		// Record the start time only on the first partial of an utterance, else latency shrinks to time-since-last-partial.
+		// Stamp the start only on the first partial, else latency measures time-since-last-partial.
 		if !s.speechStarted {
 			s.speechStartTime = time.Now()
 			s.speechStarted = true

--- a/plugins/inputs/elevenlabs_asr_test.go
+++ b/plugins/inputs/elevenlabs_asr_test.go
@@ -19,7 +19,7 @@ func newTestStream(model, languageCode string, parser asrMessageParser, ch chan 
 		name:         model + "Test",
 		log:          zap.NewNop(),
 		rate:         16000,
-		model:        model,
+		provider:     model,
 		apiVersion:   elevenlabsAPIVersion,
 		language:     "english",
 		languageCode: languageCode,
@@ -37,10 +37,10 @@ func newTestElevenLabsStream(ch chan string) *transcriberStream {
 	return newTestStream("elevenlabs", "en", elevenlabsParseMessage, ch)
 }
 
-// newTestAggregator builds an asrAggregator with a no-op logger and no zenoh, for
+// newTestSensorCore builds an asrSensorCore with a no-op logger and no zenoh, for
 // testing the transcript buffer independent of any vendor stream.
-func newTestAggregator() *asrAggregator {
-	return &asrAggregator{
+func newTestSensorCore() *asrSensorCore {
+	return &asrSensorCore{
 		name:         "test",
 		log:          zap.NewNop(),
 		transcriptCh: make(chan string, 8),
@@ -225,21 +225,21 @@ func TestOnWSMessageIgnoresInvalidOrShort(t *testing.T) {
 	}
 }
 
-func TestAggregatorStoppedIgnores(t *testing.T) {
-	a := newTestAggregator()
+func TestSensorCoreStoppedIgnores(t *testing.T) {
+	a := newTestSensorCore()
 	a.stopped = true
 
 	a.pushTranscript("hello world")
 
 	select {
 	case <-a.transcriptCh:
-		t.Fatal("a stopped aggregator must drop transcripts")
+		t.Fatal("a stopped sensor core must drop transcripts")
 	default:
 	}
 }
 
 func TestRawToText(t *testing.T) {
-	a := newTestAggregator()
+	a := newTestSensorCore()
 	ctx := context.Background()
 
 	msg, err := a.RawToText(ctx, 123)
@@ -264,7 +264,7 @@ func TestRawToText(t *testing.T) {
 }
 
 func TestFormattedLatestBuffer(t *testing.T) {
-	a := newTestAggregator()
+	a := newTestSensorCore()
 
 	require.Equal(t, "", a.FormattedLatestBuffer())
 

--- a/plugins/inputs/google_asr.go
+++ b/plugins/inputs/google_asr.go
@@ -22,8 +22,7 @@ func init() {
 	inputs.Register("GoogleASRInput", NewGoogleASR)
 }
 
-// googleLanguageCodeMap maps friendly language names to the BCP-47 codes accepted
-// by the Google ASR service.
+// googleLanguageCodeMap maps friendly language names to Google's BCP-47 codes.
 var googleLanguageCodeMap = map[string]string{
 	"english":    "en-US",
 	"chinese":    "cmn-Hans-CN",
@@ -65,8 +64,7 @@ type googleASRParams struct {
 	enableTTSInterrupt   bool
 }
 
-// GoogleASRSensor captures audio from a local microphone (via PortAudio) and
-// streams it to the Google ASR websocket through the shared asrCommon.
+// GoogleASRSensor streams local microphone audio to Google ASR via the shared asrCommon.
 type GoogleASRSensor struct {
 	*asrCommon
 
@@ -299,7 +297,7 @@ func resolveGoogleASRConfig(p googleASRParams) asrCommonConfig {
 
 	return asrCommonConfig{
 		Name:               p.name,
-		Model:              "google",
+		Provider:           "google",
 		APIVersion:         apiVersion,
 		WSURL:              wsURL,
 		Rate:               p.rate,
@@ -311,7 +309,7 @@ func resolveGoogleASRConfig(p googleASRParams) asrCommonConfig {
 	}
 }
 
-// googleParseMessage implements the Google ASR protocol (speech_start/speech_end/end_of_utterance events plus asr_reply) and records its latency metrics.
+// googleParseMessage handles the Google ASR protocol and records latency metrics.
 func googleParseMessage(s *transcriberStream, msg ASRMessage) string {
 	switch msg.Type {
 	case "speech_start":

--- a/plugins/inputs/google_asr_test.go
+++ b/plugins/inputs/google_asr_test.go
@@ -15,7 +15,7 @@ func TestGoogleLanguageCodeMap(t *testing.T) {
 }
 
 func TestGoogleParseMessage(t *testing.T) {
-	s := &transcriberStream{log: zap.NewNop(), model: "google", language: "english", apiVersion: "v2"}
+	s := &transcriberStream{log: zap.NewNop(), provider: "google", language: "english", apiVersion: "v2"}
 
 	require.Empty(t, googleParseMessage(s, ASRMessage{Type: "speech_start"}))
 	require.True(t, s.speechStarted)

--- a/plugins/inputs/parallel_asr.go
+++ b/plugins/inputs/parallel_asr.go
@@ -32,7 +32,7 @@ const defaultParallelDedupWindow = 3 * time.Second
 
 // ParallelASRProviderConfig configures one ASR provider within a parallel sensor.
 type ParallelASRProviderConfig struct {
-	Model                string   `json:"model"`   // provider type: "riva" | "google" | "elevenlabs"
+	Provider             string   `json:"model"`   // provider type: "riva" | "google" | "elevenlabs"
 	APIKey               string   `json:"api_key"` // required for google/elevenlabs
 	APIVersion           string   `json:"api_version"`
 	BaseURL              string   `json:"base_url"` // override WS endpoint
@@ -58,7 +58,7 @@ type ParallelASRConfig struct {
 // ParallelASRSensor captures audio from source, fans the PCM out, and forwards the first
 // transcript to the cortex loop while suppressing the slower duplicates.
 type ParallelASRSensor struct {
-	*asrAggregator
+	*asrSensorCore
 
 	cfg     ParallelASRConfig
 	streams []*transcriberStream
@@ -68,10 +68,10 @@ type ParallelASRSensor struct {
 	audioChunk []int16
 
 	// first-wins dedup state
-	dedupWindow time.Duration
-	dmu         sync.Mutex
-	lastModel   string
-	lastTime    time.Time
+	dedupWindow  time.Duration
+	dmu          sync.Mutex
+	lastProvider string
+	lastTime     time.Time
 }
 
 // NewParallelASR constructs a ParallelASRSensor with the given configuration.
@@ -114,7 +114,7 @@ func NewParallelASR(configMap map[string]any) (inputs.Sensor, error) {
 	}
 
 	s := &ParallelASRSensor{
-		asrAggregator: newAggregator("ParallelASRInput", cfg.EnableTTSInterrupt),
+		asrSensorCore: newSensorCore("ParallelASRInput", cfg.EnableTTSInterrupt),
 		cfg:           cfg,
 		dedupWindow:   dedupWindow,
 	}
@@ -144,8 +144,8 @@ func NewParallelASR(configMap map[string]any) (inputs.Sensor, error) {
 // buildStreamConfig resolves one provider entry into a transcriberStream config,
 // reusing each vendor's existing config resolution (endpoints, language mapping).
 func (s *ParallelASRSensor) buildStreamConfig(p ParallelASRProviderConfig) (asrCommonConfig, error) {
-	model := strings.TrimSpace(strings.ToLower(p.Model))
-	name := fmt.Sprintf("ParallelASRInput[%s]", model)
+	provider := strings.TrimSpace(strings.ToLower(p.Provider))
+	name := fmt.Sprintf("ParallelASRInput[%s]", provider)
 
 	// Providers inherit the sensor-level api_key
 	apiKey := p.APIKey
@@ -153,7 +153,7 @@ func (s *ParallelASRSensor) buildStreamConfig(p ParallelASRProviderConfig) (asrC
 		apiKey = s.cfg.APIKey
 	}
 
-	switch model {
+	switch provider {
 	case "riva":
 		return resolveRivaASRConfig(rivaASRParams{
 			name:               name,
@@ -190,32 +190,32 @@ func (s *ParallelASRSensor) buildStreamConfig(p ParallelASRProviderConfig) (asrC
 			enableTTSInterrupt: s.cfg.EnableTTSInterrupt,
 		}), nil
 	default:
-		return asrCommonConfig{}, fmt.Errorf("unknown provider model %q (want riva, google, or elevenlabs)", p.Model)
+		return asrCommonConfig{}, fmt.Errorf("unknown provider %q (want riva, google, or elevenlabs)", p.Provider)
 	}
 }
 
 // deliver applies first-wins dedup: the first provider to transcribe an utterance
 // wins and is forwarded.
-func (s *ParallelASRSensor) deliver(model, text string) {
+func (s *ParallelASRSensor) deliver(provider, text string) {
 	s.dmu.Lock()
 	now := time.Now()
-	if model != s.lastModel && now.Sub(s.lastTime) < s.dedupWindow {
-		winner := s.lastModel
+	if provider != s.lastProvider && now.Sub(s.lastTime) < s.dedupWindow {
+		winner := s.lastProvider
 		s.dmu.Unlock()
-		metrics.ASRParallelTranscripts.WithLabelValues(model, "suppressed").Inc()
+		metrics.ASRParallelTranscripts.WithLabelValues(provider, "suppressed").Inc()
 		s.log.Info("ParallelASRInput: lost race, suppressed duplicate",
-			zap.String("loser", model),
+			zap.String("loser", provider),
 			zap.String("winner", winner),
 			zap.String("text", text),
 		)
 		return
 	}
-	s.lastModel = model
+	s.lastProvider = provider
 	s.lastTime = now
 	s.dmu.Unlock()
 
-	metrics.ASRParallelTranscripts.WithLabelValues(model, "won").Inc()
-	s.log.Info("ParallelASRInput: winner", zap.String("winner", model), zap.String("text", text))
+	metrics.ASRParallelTranscripts.WithLabelValues(provider, "won").Inc()
+	s.log.Info("ParallelASRInput: winner", zap.String("winner", provider), zap.String("text", text))
 	s.pushTranscript(text)
 }
 
@@ -266,7 +266,7 @@ func (s *ParallelASRSensor) connectStreams() {
 			defer wg.Done()
 			if err := st.connect(); err != nil {
 				s.log.Warn("ParallelASRInput: provider ws connect failed, will retry",
-					zap.String("model", st.model), zap.Error(err))
+					zap.String("provider", st.provider), zap.Error(err))
 			}
 		}(st)
 	}

--- a/plugins/inputs/parallel_asr_test.go
+++ b/plugins/inputs/parallel_asr_test.go
@@ -9,7 +9,7 @@ import (
 
 func newTestParallelSensor(window time.Duration) *ParallelASRSensor {
 	return &ParallelASRSensor{
-		asrAggregator: newTestAggregator(),
+		asrSensorCore: newTestSensorCore(),
 		dedupWindow:   window,
 	}
 }
@@ -54,26 +54,26 @@ func TestParallelDeliverFailover(t *testing.T) {
 	require.Equal(t, "failover transcript", got)
 
 	s.dmu.Lock()
-	require.Equal(t, "google", s.lastModel)
+	require.Equal(t, "google", s.lastProvider)
 	s.dmu.Unlock()
 }
 
 func TestParallelBuildStreamConfig(t *testing.T) {
 	s := &ParallelASRSensor{cfg: ParallelASRConfig{Rate: 16000}}
 
-	riva, err := s.buildStreamConfig(ParallelASRProviderConfig{Model: "riva", BaseURL: "ws://localhost:6790"})
+	riva, err := s.buildStreamConfig(ParallelASRProviderConfig{Provider: "riva", BaseURL: "ws://localhost:6790"})
 	require.NoError(t, err)
-	require.Equal(t, "riva", riva.Model)
+	require.Equal(t, "riva", riva.Provider)
 	require.Equal(t, "ws://localhost:6790", riva.WSURL)
 
-	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Model: "google"})
+	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Provider: "google"})
 	require.Error(t, err, "google requires an api_key")
 
-	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Model: "elevenlabs"})
+	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Provider: "elevenlabs"})
 	require.Error(t, err, "elevenlabs requires an api_key")
 
-	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Model: "whisper"})
-	require.Error(t, err, "unknown provider model must be rejected")
+	_, err = s.buildStreamConfig(ParallelASRProviderConfig{Provider: "whisper"})
+	require.Error(t, err, "unknown provider must be rejected")
 }
 
 func TestNewParallelASRValidation(t *testing.T) {

--- a/plugins/inputs/riva_asr.go
+++ b/plugins/inputs/riva_asr.go
@@ -19,8 +19,7 @@ func init() {
 	inputs.Register("RivaASRInput", NewRivaASR)
 }
 
-// rivaLanguageCodeMap maps friendly language names to the BCP-47 codes accepted
-// by the Riva ASR service.
+// rivaLanguageCodeMap maps friendly language names to Riva's BCP-47 codes.
 var rivaLanguageCodeMap = map[string]string{
 	"english":    "en-US",
 	"chinese":    "cmn-Hans-CN",
@@ -61,8 +60,7 @@ type rivaASRParams struct {
 	enableTTSInterrupt bool
 }
 
-// RivaASRSensor captures audio from a local microphone (via PortAudio) and
-// streams it to the Riva ASR websocket through the shared asrCommon.
+// RivaASRSensor streams local microphone audio to Riva ASR via the shared asrCommon.
 type RivaASRSensor struct {
 	*asrCommon
 
@@ -270,7 +268,7 @@ func resolveRivaASRConfig(p rivaASRParams) asrCommonConfig {
 
 	return asrCommonConfig{
 		Name:               p.name,
-		Model:              "riva",
+		Provider:           "riva",
 		APIVersion:         rivaAPIVersion,
 		WSURL:              wsURL,
 		Rate:               p.rate,


### PR DESCRIPTION
This pull request refactors the ASR (Automatic Speech Recognition) input plugin code to improve naming consistency, clarify documentation, and generalize the terminology used for ASR providers. The main focus is on renaming types and variables from "model" and "aggregator" to "provider" and "sensor core," making the codebase more descriptive and easier to extend to additional ASR vendors. It also updates comments for clarity and simplifies some function implementations.

### Naming and Type Refactoring

* Renamed the `asrAggregator` type and related functions to `asrSensorCore`, updating all method receivers and references accordingly for clarity and to better reflect their purpose. [[1]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL49-R69) [[2]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL87-R91) [[3]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL117-R117) [[4]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL143-R147) [[5]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL163-R161) [[6]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL178-R176) [[7]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL197-R199) [[8]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL231-R229) [[9]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL242-R240) [[10]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL254-R252) [[11]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL268-R270) [[12]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L40-R43) [[13]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L228-R242) [[14]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L267-R267)
* Changed the `model` field and related variables in `asrCommonConfig`, `transcriberStream`, and related functions to `provider`, reflecting that this value identifies the ASR service vendor (e.g., "google", "elevenlabs"). [[1]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL49-R69) [[2]](diffhunk://#diff-c71b04112f3ecc6c64146e24dd88417868683584245879e77cbd9be3f3c364d4L41-R41) [[3]](diffhunk://#diff-c71b04112f3ecc6c64146e24dd88417868683584245879e77cbd9be3f3c364d4L51-L53) [[4]](diffhunk://#diff-c71b04112f3ecc6c64146e24dd88417868683584245879e77cbd9be3f3c364d4L63-R66) [[5]](diffhunk://#diff-c71b04112f3ecc6c64146e24dd88417868683584245879e77cbd9be3f3c364d4L155-R162) [[6]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL268-R270) [[7]](diffhunk://#diff-b4a9a2ee6bd1e90b53065f6da9204cd98f7e52a257bcd895ed9c7f248b8eb8ffL284-R283) [[8]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L22-R22) [[9]](diffhunk://#diff-b6657751c957df53982c68094c8e3df4777692736e0fb43c16967b99c2989e4aL302-R300)

### Documentation Improvements

* Updated comments throughout the codebase to clarify the role of types and variables, simplify language, and ensure documentation matches the refactored code (e.g., describing "sensor core" instead of "aggregator", and "provider" instead of "model"). [[1]](diffhunk://#diff-10e54e89db36e458b655691fc5f72a473c759eae231b2afb0ae54b0380415f4dL22-R23) [[2]](diffhunk://#diff-b4a9a2ee6bd1e90b53065f6da9204cd98f7e52a257bcd895ed9c7f248b8eb8ffL25-R26) [[3]](diffhunk://#diff-b4a9a2ee6bd1e90b53065f6da9204cd98f7e52a257bcd895ed9c7f248b8eb8ffL67-R67) [[4]](diffhunk://#diff-b6657751c957df53982c68094c8e3df4777692736e0fb43c16967b99c2989e4aL25-R25) [[5]](diffhunk://#diff-b6657751c957df53982c68094c8e3df4777692736e0fb43c16967b99c2989e4aL68-R67) [[6]](diffhunk://#diff-b4a9a2ee6bd1e90b53065f6da9204cd98f7e52a257bcd895ed9c7f248b8eb8ffL295-R298) [[7]](diffhunk://#diff-b6657751c957df53982c68094c8e3df4777692736e0fb43c16967b99c2989e4aL314-R312)

### Test Updates

* Updated test helpers and test names to use the new `asrSensorCore` naming and the `provider` field, ensuring consistency with the main code changes. [[1]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L40-R43) [[2]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L228-R242) [[3]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L267-R267) [[4]](diffhunk://#diff-148a9f97bd5ce70bdca4d7317c1329caacbf9bbf863f07bb739885d4bb9d4217L22-R22)

### Minor Implementation Changes

* Simplified buffer initialization in `serializeASRText` and improved comment clarity.
* Minor rewording and clarification in protocol-specific message parsing functions. [[1]](diffhunk://#diff-b4a9a2ee6bd1e90b53065f6da9204cd98f7e52a257bcd895ed9c7f248b8eb8ffL295-R298) [[2]](diffhunk://#diff-b6657751c957df53982c68094c8e3df4777692736e0fb43c16967b99c2989e4aL314-R312)

These changes collectively improve the maintainability and clarity of the ASR input subsystem, making it easier to add support for new providers and reducing ambiguity in the codebase.