### PR TITLE
Add paths provider and Paths sensor

### DIFF
--- a/internal/providers/paths.go
+++ b/internal/providers/paths.go
@@ -1,0 +1,213 @@
+package providers
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/openmind/om1/internal/logger"
+	zenohsession "github.com/openmind/om1/internal/zenoh"
+)
+
+const pathsTopic = "om/paths"
+
+// PathsProvider subscribes to the om/paths topic and derives a natural-language
+// summary of the safe movement directions from the raw path indices.
+//
+// Path indices are classified into movement options as follows:
+//
+//	[0, 3)  -> turn left
+//	[3, 5]  -> move forwards
+//	(5, 9)  -> turn right
+//	9       -> move back (retreat)
+type PathsProvider struct {
+	log     *zap.Logger
+	session *zenohsession.Session
+	sub     *zenohsession.Subscriber
+
+	mu          sync.RWMutex
+	turnLeft    []uint32
+	turnRight   []uint32
+	advance     []uint32
+	retreat     bool
+	validPaths  []uint32
+	lidarString string
+}
+
+// NewPathsProvider opens a zenoh session and subscribes to the om/paths topic.
+func NewPathsProvider() *PathsProvider {
+	p := &PathsProvider{log: logger.Get()}
+
+	sess, err := zenohsession.Open()
+	if err != nil {
+		p.log.Warn("paths: zenoh unavailable, paths disabled", zap.Error(err))
+		return p
+	}
+	p.session = sess
+
+	sub, err := sess.DeclareSubscriber(pathsTopic, p.onPaths)
+	if err != nil {
+		sess.Close()
+		p.session = nil
+		p.log.Warn("paths: failed to declare subscriber", zap.Error(err))
+		return p
+	}
+	p.sub = sub
+
+	p.log.Info("paths: provider initialized", zap.String("topic", pathsTopic))
+	return p
+}
+
+// onPaths handles an incoming Paths message, recomputing the derived movement
+// options and the natural-language summary.
+func (p *PathsProvider) onPaths(data []byte) {
+	paths, err := deserializePaths(data)
+	if err != nil {
+		p.log.Error("paths: failed to deserialize message", zap.Error(err))
+		return
+	}
+
+	var turnLeft, turnRight, advance []uint32
+	retreat := false
+
+	for _, path := range paths {
+		switch {
+		case path < 3:
+			turnLeft = append(turnLeft, path)
+		case path <= 5:
+			advance = append(advance, path)
+		case path < 9:
+			turnRight = append(turnRight, path)
+		case path == 9:
+			retreat = true
+		}
+	}
+
+	p.mu.Lock()
+	p.turnLeft = turnLeft
+	p.turnRight = turnRight
+	p.advance = advance
+	p.retreat = retreat
+	p.validPaths = paths
+	p.lidarString = generateMovementString(paths, turnLeft, advance, turnRight, retreat)
+	p.mu.Unlock()
+}
+
+// generateMovementString builds the natural-language assessment of possible
+// movement directions from the derived movement options.
+func generateMovementString(validPaths, turnLeft, advance, turnRight []uint32, retreat bool) string {
+	if validPaths == nil {
+		return "You are surrounded by objects and cannot safely move in any direction. DO NOT MOVE."
+	}
+
+	var b strings.Builder
+	b.WriteString("The safe movement directions are: {")
+
+	if len(turnLeft) > 0 {
+		b.WriteString("'turn left', ")
+	}
+	if len(advance) > 0 {
+		b.WriteString("'move forwards', ")
+	}
+	if len(turnRight) > 0 {
+		b.WriteString("'turn right', ")
+	}
+	if retreat {
+		b.WriteString("'move back', ")
+	}
+
+	b.WriteString("'stand still'}. ")
+	return b.String()
+}
+
+// LidarString returns the latest natural-language assessment of possible paths,
+// or an empty string if no message has been received yet.
+func (p *PathsProvider) LidarString() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.lidarString
+}
+
+// ValidPaths returns the most recently received path indices.
+func (p *PathsProvider) ValidPaths() []uint32 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.validPaths
+}
+
+// MovementOptions returns the derived movement options based on the current
+// valid paths.
+func (p *PathsProvider) MovementOptions() map[string]any {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return map[string]any{
+		"turn_left":  p.turnLeft,
+		"advance":    p.advance,
+		"turn_right": p.turnRight,
+		"retreat":    p.retreat,
+	}
+}
+
+// Stop releases the zenoh subscriber and session.
+func (p *PathsProvider) Stop() {
+	if p.sub != nil {
+		p.sub.Drop()
+		p.sub = nil
+	}
+	if p.session != nil {
+		p.session.Close()
+		p.session = nil
+	}
+	p.log.Info("paths: provider stopped")
+}
+
+// deserializePaths extracts the path indices from a CDR-encoded Paths message.
+//
+// Wire layout (absolute offsets from start of buffer):
+//
+//	[0]  CDR encapsulation header: 4 bytes
+//	[4]  stamp.sec        int32  LE  (data offset 0)
+//	[8]  stamp.nanosec    uint32 LE  (data offset 4)
+//	[12] header.frame_id  CDR string (data offset 8) + padding to 4-byte
+//	[..] paths            sequence<uint32>: count uint32 + count*uint32
+//	[..] blocked_by_obstacle_idx, blocked_by_hazard_idx (ignored)
+func deserializePaths(data []byte) ([]uint32, error) {
+	if len(data) < 16 {
+		return nil, fmt.Errorf("paths: payload too short (%d bytes)", len(data))
+	}
+
+	pos := 4 // skip CDR header
+	pos += 4 // stamp.sec
+	pos += 4 // stamp.nanosec
+
+	// frame_id: length uint32 + bytes + padding to 4-byte data boundary
+	if pos+4 > len(data) {
+		return nil, fmt.Errorf("paths: truncated at frame_id length")
+	}
+	frameIDLen := int(binary.LittleEndian.Uint32(data[pos:]))
+	pos += 4 + frameIDLen
+	if dataOff := pos - 4; (4-dataOff%4)%4 > 0 {
+		pos += (4 - dataOff%4) % 4
+	}
+
+	// paths: sequence<uint32> — count uint32 followed by count uint32 values
+	if pos+4 > len(data) {
+		return nil, fmt.Errorf("paths: truncated at paths count")
+	}
+	count := int(binary.LittleEndian.Uint32(data[pos:]))
+	pos += 4
+	if pos+count*4 > len(data) {
+		return nil, fmt.Errorf("paths: truncated at paths data (count=%d)", count)
+	}
+
+	paths := make([]uint32, count)
+	for i := 0; i < count; i++ {
+		paths[i] = binary.LittleEndian.Uint32(data[pos:])
+		pos += 4
+	}
+
+	return paths, nil
+}

--- a/internal/providers/paths_test.go
+++ b/internal/providers/paths_test.go
@@ -1,0 +1,77 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	zenohsession "github.com/openmind/om1/internal/zenoh"
+)
+
+func buildPathsPayload(paths []uint32) []byte {
+	buf := make([]byte, 0, 64)
+	buf = append(buf, 0x00, 0x01, 0x00, 0x00)
+	buf = zenohsession.AppendInt32LE(buf, 0)
+	buf = zenohsession.AppendUint32LE(buf, 0)
+	buf = zenohsession.AppendCDRString(buf, "")
+
+	buf = zenohsession.AppendUint32LE(buf, uint32(len(paths)))
+	for _, p := range paths {
+		buf = zenohsession.AppendUint32LE(buf, p)
+	}
+
+	buf = zenohsession.AppendUint32LE(buf, 0)
+	buf = zenohsession.AppendUint32LE(buf, 0)
+	return buf
+}
+
+func TestDeserializePaths(t *testing.T) {
+	want := []uint32{0, 3, 4, 5, 9}
+	got, err := deserializePaths(buildPathsPayload(want))
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	empty, err := deserializePaths(buildPathsPayload(nil))
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	_, err = deserializePaths([]byte{0x00, 0x01})
+	require.Error(t, err)
+}
+
+func TestGenerateMovementString(t *testing.T) {
+	classify := func(paths []uint32) string {
+		var tl, tr, adv []uint32
+		retreat := false
+		for _, p := range paths {
+			switch {
+			case p < 3:
+				tl = append(tl, p)
+			case p <= 5:
+				adv = append(adv, p)
+			case p < 9:
+				tr = append(tr, p)
+			case p == 9:
+				retreat = true
+			}
+		}
+		return generateMovementString(paths, tl, adv, tr, retreat)
+	}
+
+	require.Equal(t,
+		"The safe movement directions are: {'turn left', 'move forwards', 'turn right', 'move back', 'stand still'}. ",
+		classify([]uint32{0, 4, 7, 9}),
+	)
+	require.Equal(t,
+		"The safe movement directions are: {'move forwards', 'stand still'}. ",
+		classify([]uint32{3, 4, 5}),
+	)
+	require.Equal(t,
+		"The safe movement directions are: {'stand still'}. ",
+		classify([]uint32{}),
+	)
+	require.Equal(t,
+		"You are surrounded by objects and cannot safely move in any direction. DO NOT MOVE.",
+		generateMovementString(nil, nil, nil, nil, false),
+	)
+}

--- a/plugins/inputs/paths.go
+++ b/plugins/inputs/paths.go
@@ -1,0 +1,141 @@
+package inputs
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/openmind/om1/internal/inputs"
+	"github.com/openmind/om1/internal/logger"
+	"github.com/openmind/om1/internal/providers"
+)
+
+func init() {
+	inputs.Register("Paths", NewPaths)
+}
+
+const (
+	pathsDescriptor  = "Information about objects and walls around you, to plan your movements and avoid bumping into things."
+	pathsPollPeriod  = 200 * time.Millisecond
+	pathsMaxMessages = 10
+)
+
+type PathsSensor struct {
+	log      *zap.Logger
+	provider *providers.PathsProvider
+
+	mu       sync.Mutex
+	messages []inputs.Message
+	stopped  bool
+}
+
+// NewPaths constructs a PathsSensor and starts its underlying PathsProvider.
+func NewPaths(_ map[string]any) (inputs.Sensor, error) {
+	log := logger.Get()
+	log.Info("Paths: initializing")
+
+	return &PathsSensor{
+		log:      log,
+		provider: providers.NewPathsProvider(),
+	}, nil
+}
+
+// Listen polls the paths provider at a fixed cadence and yields each non-empty
+// assessment on the returned channel until ctx is cancelled.
+func (s *PathsSensor) Listen(ctx context.Context) (<-chan any, error) {
+	out := make(chan any)
+	go func() {
+		defer close(out)
+		defer s.Stop()
+
+		ticker := time.NewTicker(pathsPollPeriod)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			raw, err := s.Poll(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				continue
+			}
+
+			select {
+			case out <- raw:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// Poll returns the latest path assessment from the provider.
+func (s *PathsSensor) Poll(_ context.Context) (any, error) {
+	return s.provider.LidarString(), nil
+}
+
+// RawToText converts a raw assessment line into a timestamped Message and
+// appends it to the bounded in-memory history.
+func (s *PathsSensor) RawToText(_ context.Context, raw any) (*inputs.Message, error) {
+	text, ok := raw.(string)
+	if !ok || text == "" {
+		return nil, nil
+	}
+
+	msg := inputs.NewMessage(text)
+
+	s.mu.Lock()
+	s.messages = append(s.messages, *msg)
+	if len(s.messages) > pathsMaxMessages {
+		s.messages = s.messages[len(s.messages)-pathsMaxMessages:]
+	}
+	s.mu.Unlock()
+
+	return msg, nil
+}
+
+// FormattedLatestBuffer returns the newest assessment as a prompt-ready block
+// and clears the history. It returns "" when empty.
+func (s *PathsSensor) FormattedLatestBuffer() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.messages) == 0 {
+		return ""
+	}
+
+	latest := s.messages[len(s.messages)-1]
+	result := fmt.Sprintf("\n%s: %q\n", pathsDescriptor, latest.Message)
+
+	ts := time.Unix(0, int64(latest.Timestamp*1e9))
+	providers.IO().AddInput(pathsDescriptor, latest.Message, ts)
+	s.messages = nil
+
+	return result
+}
+
+// Stop releases the underlying provider.
+func (s *PathsSensor) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	s.mu.Unlock()
+
+	s.log.Info("Paths: stopping sensor")
+	if s.provider != nil {
+		s.provider.Stop()
+	}
+}


### PR DESCRIPTION
Introduce a PathsProvider that subscribes to the om/paths topic via zenoh, deserializes CDR-encoded Paths messages, classifies path indices into movement options (turn left, move forwards, turn right, move back) and generates a natural-language assessment string. Expose methods to retrieve the latest lidar string, valid paths and movement options, and add graceful stop/cleanup. Add a PathsSensor plugin that registers as "Paths", polls the provider on a fixed cadence, converts raw assessments into timestamped messages, maintains a bounded history and formats the latest buffer for prompts. Unit tests cover payload deserialization and movement-string generation.