### PR TITLE
Add talking_Xs actions and update speaking guidelines

### DIFF
--- a/config/greeting_conversation.json5
+++ b/config/greeting_conversation.json5
@@ -85,6 +85,22 @@ Behavior Guidelines:\n\
 - Avoid excessive or repetitive motions.\n\
 - Never perform unsafe, aggressive, or inappropriate actions.\n\
 \n\
+Speaking Action Selection:\n\
+- When generating a spoken response, estimate how long it will take to speak naturally.\n\
+- Select exactly one talking action that best matches the expected speaking duration.\n\
+- Use talking_2s for responses up to 2 seconds.\n\
+- Use talking_4s for responses between 2 and 4 seconds.\n\
+- Use talking_6s for responses between 4 and 6 seconds.\n\
+- Use talking_8s for responses between 6 and 8 seconds.\n\
+- Use talking_10s for responses between 8 and 10 seconds.\n\
+- Use talking_12s for responses between 10 and 12 seconds.\n\
+- Use talking_14s for responses between 12 and 14 seconds.\n\
+- Use talking_16s for responses between 14 and 16 seconds.\n\
+- Use talking_18s for responses between 16 and 18 seconds.\n\
+- Use talking_20s for responses longer than 18 seconds.\n\
+- If a response primarily requires a special gesture (such as SHAKE_HAND, FACE_WAVE, SALUTE, HEART, SHRUG, HANDS_UP, COME_CLOSER, or PUSH), use that gesture instead of a talking action.\n\
+- Otherwise, prefer the appropriate talking_xs action while speaking rather than STAND_STILL.\n\
+\n\
 You should prioritize safe, comfortable, and positive human interaction.",
       hertz: 0.001,
       agent_inputs: [
@@ -211,6 +227,22 @@ Behavior Guidelines:\n\
 - When idle, listening, or explaining, prefer STAND_STILL.\n\
 - Avoid excessive or repetitive motions.\n\
 - Never perform unsafe, aggressive, or inappropriate actions.\n\
+\n\
+Speaking Action Selection:\n\
+- When generating a spoken response, estimate how long it will take to speak naturally.\n\
+- Select exactly one talking action that best matches the expected speaking duration.\n\
+- Use talking_2s for responses up to 2 seconds.\n\
+- Use talking_4s for responses between 2 and 4 seconds.\n\
+- Use talking_6s for responses between 4 and 6 seconds.\n\
+- Use talking_8s for responses between 6 and 8 seconds.\n\
+- Use talking_10s for responses between 8 and 10 seconds.\n\
+- Use talking_12s for responses between 10 and 12 seconds.\n\
+- Use talking_14s for responses between 12 and 14 seconds.\n\
+- Use talking_16s for responses between 14 and 16 seconds.\n\
+- Use talking_18s for responses between 16 and 18 seconds.\n\
+- Use talking_20s for responses longer than 18 seconds.\n\
+- If a response primarily requires a special gesture (such as SHAKE_HAND, FACE_WAVE, SALUTE, HEART, SHRUG, HANDS_UP, COME_CLOSER, or PUSH), use that gesture instead of a talking action.\n\
+- Otherwise, prefer the appropriate talking_xs action while speaking rather than STAND_STILL.\n\
 \n\
 You should prioritize safe, comfortable, and positive human interaction.",
       hertz: 0.001,

--- a/config/unitree_g1_conversation.json5
+++ b/config/unitree_g1_conversation.json5
@@ -29,7 +29,7 @@
     conversation: {
       display_name: "Greeting Conversation Mode",
       description: "Robot engages in greeting conversations with users upon approach.",
-system_prompt_base: "You are Unitree G1, a polite humanoid robot designed for friendly human interaction and conversation.\
+      system_prompt_base: "You are Unitree G1, a polite humanoid robot designed for friendly human interaction and conversation.\
 \n\
 Your responsibilities:\n\
 - Speak clearly, politely, and naturally.\n\
@@ -42,7 +42,7 @@ Identity:\n\
 - You are Unitree G1, a humanoid robot.\n\
 - Your name is ${ROBOT_NAME:-Iris}.\n\
 \n\
-You are allowed to perform the following physical actions when appropriate during interaction: idle, shake_hand, face_wave, hands_up, stand_still, show_hand, rotate_hand, heart, push, salute, shrug, speak_action_extended, speak_action, come_closer, flexible.\n\
+You are allowed to perform the following physical actions when appropriate during interaction: idle, shake_hand, face_wave, hands_up, stand_still, show_hand, rotate_hands, heart, push, salute, shrug, come_closer, flexible, talking_2s, talking_4s, talking_6s, talking_8s, talking_10s, talking_12s, talking_14s, talking_16s, talking_18s, talking_20s.\n\
 \n\
 Behavior Guidelines:\n\
 - Use gestures naturally to improve interaction.\n\
@@ -52,16 +52,31 @@ Behavior Guidelines:\n\
 - When you are uncertain or do not know something, you may use SHRUG.\n\
 - When celebrating, showing excitement, or sharing good news, you may use HANDS_UP.\n\
 - SHOW_HAND is a simple friendly gesture to show your hand.\n\
-- ROTATE_HAND is a playful hand motion used to add fun and personality.\n\
+- ROTATE_HANDS is a playful hand motion used to add fun and personality.\n\
 - FLEXIBLE is a playful expressive movement that can make interactions more lively.\n\
 - When inviting someone to approach, you may use COME_CLOSER.\n\
 - PUSH should only be used when demonstrating or discussing a pushing action.\n\
-- For speaking with coordinated body language, you may use SPEAK_ACTION or SPEAK_ACTION_EXTENDED.\n\
-- When idle, listening, or explaining, prefer STAND_STILL.\n\
+- When idle or listening, prefer STAND_STILL.\n\
 - Avoid excessive or repetitive motions.\n\
 - Never perform unsafe, aggressive, or inappropriate actions.\n\
 \n\
-You should prioritize safe, comfortable, and positive human interaction.",
+Speaking Action Selection:\n\
+- When generating a spoken response, estimate how long it will take to speak naturally.\n\
+- Select exactly one talking action that best matches the expected speaking duration.\n\
+- Use talking_2s for responses up to 2 seconds.\n\
+- Use talking_4s for responses between 2 and 4 seconds.\n\
+- Use talking_6s for responses between 4 and 6 seconds.\n\
+- Use talking_8s for responses between 6 and 8 seconds.\n\
+- Use talking_10s for responses between 8 and 10 seconds.\n\
+- Use talking_12s for responses between 10 and 12 seconds.\n\
+- Use talking_14s for responses between 12 and 14 seconds.\n\
+- Use talking_16s for responses between 14 and 16 seconds.\n\
+- Use talking_18s for responses between 16 and 18 seconds.\n\
+- Use talking_20s for responses longer than 18 seconds.\n\
+- If a response primarily requires a special gesture (such as SHAKE_HAND, FACE_WAVE, SALUTE, HEART, SHRUG, HANDS_UP, COME_CLOSER, or PUSH), use that gesture instead of a talking action.\n\
+- Otherwise, prefer the appropriate talking_xs action while speaking rather than STAND_STILL.\n\
+\n\
+You should prioritize safe, comfortable, and positive human interaction."
       hertz: 0.001,
       agent_inputs: [
         {

--- a/plugins/actions/unitree/g1/arm/zenoh.go
+++ b/plugins/actions/unitree/g1/arm/zenoh.go
@@ -34,8 +34,16 @@ func (ArmAction) EnumValues() []string {
 		"rotate_hands",
 		"salute",
 		"shrug",
-		"speack_action_extended",
-		"speak_action",
+		"talking_2s",
+		"talking_4s",
+		"talking_6s",
+		"talking_8s",
+		"talking_10s",
+		"talking_12s",
+		"talking_14s",
+		"talking_16s",
+		"talking_18s",
+		"talking_20s",
 	}
 }
 


### PR DESCRIPTION
This pull request updates the behavior guidelines and action definitions for the Unitree G1 robot to introduce a new, duration-based set of talking actions for more natural and expressive speech coordination. It also removes the old generic speaking actions and clarifies gesture usage. The changes affect both configuration files and the action enumeration in the code.

**Key changes:**

### Speaking Action Overhaul

* Added a new set of talking actions (`talking_2s`, `talking_4s`, ..., `talking_20s`) that correspond to different speaking durations, and updated the guidelines to select the appropriate action based on the expected length of the spoken response. [[1]](diffhunk://#diff-4171a7b0793ca558a7ea19369ff5ba8975a9374fcf721e19f76aa14951739730R88-R103) [[2]](diffhunk://#diff-4171a7b0793ca558a7ea19369ff5ba8975a9374fcf721e19f76aa14951739730R231-R246) [[3]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L45-R45) [[4]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L55-R79) [[5]](diffhunk://#diff-2fbc17054c39974244ef1412dba7f919103d0052c608193ea2bc76e305ea58ffL37-R46)
* Removed the old generic speaking actions (`speak_action`, `speak_action_extended`) from both the configuration and the code, ensuring only the new duration-based actions are available. [[1]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L45-R45) [[2]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L55-R79) [[3]](diffhunk://#diff-2fbc17054c39974244ef1412dba7f919103d0052c608193ea2bc76e305ea58ffL37-R46)

### Gesture and Action Clarifications

* Updated gesture names for consistency (e.g., `rotate_hand` to `rotate_hands`) and clarified when to use gestures versus talking actions in the guidelines. [[1]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L45-R45) [[2]](diffhunk://#diff-d6705c6dbf1f4c5b9630e6e3709a34a98c2947b272bf624bce4585f0bcd76237L55-R79)
* Refined instructions to prefer the appropriate talking action while speaking, and clarified that `STAND_STILL` should be used only when idle or listening.

These changes make the robot's behavior more expressive and context-appropriate during conversations.