### PR TITLE
Enhance turn counting and add configurable max rounds for greetings

### DIFF
--- a/config/greeting_conversation.json5
+++ b/config/greeting_conversation.json5
@@ -144,6 +144,7 @@ You should prioritize safe, comfortable, and positive human interaction.",
           connector: "greeting_conversation_elevenlabs",
           config: {
             voice_id: "${VOICE_ID:-PoHUWWWMHFrA8z7Q88pu}",
+            max_rounds: 50,
           },
         },
         {

--- a/internal/providers/greeting_conversation_state.go
+++ b/internal/providers/greeting_conversation_state.go
@@ -211,15 +211,13 @@ func (c *ConfidenceCalculator) ShouldTransitionToFinished(r ConfidenceResult, ti
 	return false
 }
 
-// GreetingConversationStateMachineProvider manages greeting conversation state
-// transitions based on confidence scores.
 type GreetingConversationStateMachineProvider struct {
 	mu sync.Mutex
 
 	currentState          ConversationState
 	previousState         ConversationState
 	stateEntryTime        time.Time
-	conversationStartTime time.Time // zero value means "not started"
+	conversationStartTime time.Time
 	turnCount             int
 	maxTurnCount          int
 	lastUserUtterance     string
@@ -233,6 +231,8 @@ type GreetingConversationStateMachineProvider struct {
 	log *zap.Logger
 }
 
+const DefaultMaxTurnCount = 3
+
 var (
 	greetingOnce     sync.Once
 	greetingInstance *GreetingConversationStateMachineProvider
@@ -240,7 +240,7 @@ var (
 
 // Greeting returns the singleton GreetingConversationStateMachineProvider.
 func Greeting() *GreetingConversationStateMachineProvider {
-	greetingOnce.Do(func() { greetingInstance = NewGreetingConversationStateMachineProvider(3) })
+	greetingOnce.Do(func() { greetingInstance = NewGreetingConversationStateMachineProvider(DefaultMaxTurnCount) })
 	return greetingInstance
 }
 
@@ -550,6 +550,17 @@ func (g *GreetingConversationStateMachineProvider) MaxTurnCount() int {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	return g.maxTurnCount
+}
+
+// SetMaxTurnCount sets the maximum number of back-and-forth exchanges before
+// the conversation is forced to finish. A value less than 1 is ignored.
+func (g *GreetingConversationStateMachineProvider) SetMaxTurnCount(n int) {
+	if n < 1 {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.maxTurnCount = n
 }
 
 const finalTurnGuidance = "\nGreeting status: This is the final exchange of this greeting conversation. " +

--- a/internal/providers/greeting_conversation_state.go
+++ b/internal/providers/greeting_conversation_state.go
@@ -289,6 +289,11 @@ func (g *GreetingConversationStateMachineProvider) ProcessConversation(llmOutput
 	result := g.calc.CalculateCompletionConfidence(factors)
 	g.recordConfidence(result.Overall)
 
+	if voice != nil && g.io.TickCounter() == voice.Tick {
+		g.turnCount++
+		g.lastUserUtterance = voice.Input
+	}
+
 	newState := g.determineNextState(result)
 	g.previousState = g.currentState
 	if newState != g.currentState {
@@ -299,12 +304,6 @@ func (g *GreetingConversationStateMachineProvider) ProcessConversation(llmOutput
 			zap.String("to", string(g.currentState)),
 			zap.Float64("confidence", result.Overall),
 		)
-	}
-
-	// Count a turn when the latest voice input arrived during the current tick.
-	if voice != nil && g.io.TickCounter() == voice.Tick {
-		g.turnCount++
-		g.lastUserUtterance = voice.Input
 	}
 
 	command := g.generateCommand(result)
@@ -376,10 +375,14 @@ func (g *GreetingConversationStateMachineProvider) determineNextState(r Confiden
 	llmState := r.Factors.ConversationState
 	timeInState := time.Since(g.stateEntryTime).Seconds()
 
-	// Force finish if we've had too many turns to prevent infinite conversations
 	if g.turnCount >= g.maxTurnCount {
 		g.log.Info("greeting: maximum turn count reached - forcing finish",
 			zap.Int("max_turn_count", g.maxTurnCount))
+		return StateFinished
+	}
+
+	if llmState == StateFinished {
+		g.log.Info("greeting: LLM indicates finished")
 		return StateFinished
 	}
 

--- a/internal/providers/greeting_conversation_state_test.go
+++ b/internal/providers/greeting_conversation_state_test.go
@@ -109,6 +109,31 @@ func TestStateMachineLifecycle(t *testing.T) {
 	require.Equal(t, 0, g.TurnCount())
 }
 
+func TestDetermineNextStateForcesFinishAtMaxTurnCount(t *testing.T) {
+	g := NewGreetingConversationStateMachineProvider(3)
+	g.currentState = StateConversing
+
+	r := ConfidenceResult{Factors: ConfidenceFactors{ConversationState: StateConversing}}
+
+	g.turnCount = 2
+	require.NotEqual(t, StateFinished, g.determineNextState(r),
+		"turn below max keeps conversing")
+
+	g.turnCount = 3
+	require.Equal(t, StateFinished, g.determineNextState(r),
+		"reaching max turn count forces finish")
+}
+
+func TestDetermineNextStateHonorsLLMFinished(t *testing.T) {
+	g := NewGreetingConversationStateMachineProvider(3)
+	g.currentState = StateConcluding
+	g.turnCount = 1
+
+	r := ConfidenceResult{Factors: ConfidenceFactors{ConversationState: StateFinished}}
+	require.Equal(t, StateFinished, g.determineNextState(r),
+		"an explicit finished state from the LLM ends the conversation")
+}
+
 func TestConfidenceHistoryTrend(t *testing.T) {
 	g := NewGreetingConversationStateMachineProvider(3)
 	require.Equal(t, "insufficient_data", g.confidenceTrend())

--- a/plugins/actions/greeting_conversation/greeting_conversation_elevenlabs.go
+++ b/plugins/actions/greeting_conversation/greeting_conversation_elevenlabs.go
@@ -67,6 +67,7 @@ type Config struct {
 	ModelID          string `json:"model_id"`
 	OutputFormat     string `json:"output_format"`
 	Rate             int    `json:"rate"`
+	MaxRounds        int    `json:"max_rounds"`
 }
 
 // Connector implements the greeting conversation action using the ElevenLabs TTS provider.
@@ -117,6 +118,9 @@ func NewElevenLabsGreetingConversation(configMap map[string]any) (actions.Connec
 	}, log)
 
 	greeting := providers.Greeting()
+	if cfg.MaxRounds > 0 {
+		greeting.SetMaxTurnCount(cfg.MaxRounds)
+	}
 	greeting.StartConversation()
 
 	c := &Connector{


### PR DESCRIPTION
This pull request introduces improvements to the greeting conversation system, focusing on configurability and robustness. The main changes allow the maximum number of conversation rounds to be set via configuration, ensure the state machine respects both this limit and explicit LLM signals to finish, and add tests for these behaviors.

**Configurability and Limits**
* Added a `max_rounds` parameter to the greeting conversation configuration (`config/greeting_conversation.json5`, `plugins/actions/greeting_conversation/greeting_conversation_elevenlabs.go`) so the maximum number of conversation turns can be set per deployment. This is now wired through to the state machine (`SetMaxTurnCount`). [[1]](diffhunk://#diff-4171a7b0793ca558a7ea19369ff5ba8975a9374fcf721e19f76aa14951739730R147) [[2]](diffhunk://#diff-cff5e564c6a1cfee992c11dfa418923a029d51ab958e21b18e3079af54d0e45aR70) [[3]](diffhunk://#diff-cff5e564c6a1cfee992c11dfa418923a029d51ab958e21b18e3079af54d0e45aR121-R123)
* Introduced `DefaultMaxTurnCount` and used it as the default in the singleton provider.
* Added a setter method `SetMaxTurnCount` to allow dynamic adjustment of the maximum turn count.

**State Machine Logic and Robustness**
* Updated the state machine to force the conversation to finish when the maximum turn count is reached, and to immediately finish if the LLM indicates the conversation is done.
* Refactored and clarified turn counting logic in `ProcessConversation`. [[1]](diffhunk://#diff-4a931df7d06a1a6c5221389caa07fb4431aeedaa1433466db909c18519e56480R292-R296) [[2]](diffhunk://#diff-4a931df7d06a1a6c5221389caa07fb4431aeedaa1433466db909c18519e56480L304-L309)

**Testing**
* Added unit tests to verify that the state machine finishes at the maximum turn count and respects explicit finished signals from the LLM.