### PR TITLE
improve memory reader and change riva rate to 16000

### DIFF
--- a/internal/memory/reader.go
+++ b/internal/memory/reader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -124,7 +125,7 @@ func (r *Reader) FormatContext(searchResults []MemoryEntry, maxChars int, userID
 		totalChars += len(doc.Text)
 	}
 
-	return strings.Join(parts, "\n\n")
+	return r.normalizeUserTags(strings.Join(parts, "\n\n"))
 }
 
 // readProfileVisitInfo reads profile.json and formats visit info.
@@ -218,4 +219,34 @@ func (r *Reader) ReadUserFacts(userID string) string {
 		lines = append(lines, fmt.Sprintf("- [%s] %s", cat, f.Fact))
 	}
 	return strings.Join(lines, "\n")
+}
+
+var longHexInTag = regexp.MustCompile(`\[User: ([0-9a-fA-F]{12,})\]`)
+
+func (r *Reader) normalizeUserTags(text string) string {
+	return longHexInTag.ReplaceAllStringFunc(text, func(match string) string {
+		sub := longHexInTag.FindStringSubmatch(match)
+		uuid := sub[1]
+		if name := r.profileName(uuid); name != "" {
+			return "[User: " + name + "]"
+		}
+		return "[User: anon_" + uuid[:6] + "]"
+	})
+}
+
+func (r *Reader) profileName(uuid string) string {
+	raw, err := os.ReadFile(filepath.Join(r.usersDir, uuid, "profile.json"))
+	if err != nil {
+		return ""
+	}
+	var p struct {
+		Names []string `json:"names"`
+	}
+	if json.Unmarshal(raw, &p) != nil {
+		return ""
+	}
+	if len(p.Names) > 0 {
+		return p.Names[0]
+	}
+	return ""
 }

--- a/plugins/inputs/asr/riva_asr.go
+++ b/plugins/inputs/asr/riva_asr.go
@@ -43,7 +43,7 @@ const rivaDefaultBaseURL = "ws://localhost:6790"
 // RivaASRConfig configures the local microphone-sourced Riva ASR sensor.
 type RivaASRConfig struct {
 	APIKey             string `json:"api_key"`
-	Rate               int    `json:"rate"`                 // sample rate Hz (default 48000)
+	Rate               int    `json:"rate"`                 // sample rate Hz (default 16000)
 	Chunk              int    `json:"chunk"`                // frames per buffer (default 12144)
 	BaseURL            string `json:"base_url"`             // override WS endpoint
 	MicDeviceIndex     int    `json:"microphone_device_id"` // -1 = default
@@ -76,7 +76,7 @@ func NewRivaASR(configMap map[string]any) (inputs.Sensor, error) {
 		_ = json.Unmarshal(b, &cfg)
 	}
 	if cfg.Rate == 0 {
-		cfg.Rate = 48000
+		cfg.Rate = 16000
 	}
 	if cfg.Chunk == 0 {
 		cfg.Chunk = 12144


### PR DESCRIPTION
This pull request introduces improvements to user tag normalization in memory context formatting and updates the default sample rate for the Riva ASR plugin. The key changes are grouped below:

**User tag normalization and display improvements:**

* Added a `normalizeUserTags` method to `Reader` that replaces `[User: <hex>]` tags in memory context with either the user's display name (if available) or an anonymized short ID, improving readability of user references. This includes a new helper `profileName` to look up display names from user profiles (`internal/memory/reader.go`). [[1]](diffhunk://#diff-13ebae980f06fdac473091631e5d5c97c7173a134463638e5f9741dd9933ceeeR9) [[2]](diffhunk://#diff-13ebae980f06fdac473091631e5d5c97c7173a134463638e5f9741dd9933ceeeL127-R128) [[3]](diffhunk://#diff-13ebae980f06fdac473091631e5d5c97c7173a134463638e5f9741dd9933ceeeR223-R252)

**Riva ASR configuration changes:**

* Changed the default sample rate for Riva ASR from 48000 Hz to 16000 Hz to better match common ASR model requirements (`plugins/inputs/asr/riva_asr.go`). [[1]](diffhunk://#diff-1a9bf16f0d0e3c9e6dd30d9964b8d8019edda0dd1ca7fc8730d657d7bc21f08bL46-R46) [[2]](diffhunk://#diff-1a9bf16f0d0e3c9e6dd30d9964b8d8019edda0dd1ca7fc8730d657d7bc21f08bL79-R79)