### PR TITLE
Enhance config path handling and Makefile usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,12 @@ build: download-zenohc
 .PHONY: run
 run: build
 	@echo "Running $(BINARY_NAME) with config: $(CONFIG)"
-	$(BUILD_DIR)/$(BINARY_NAME) -config ./config/$(CONFIG).json5
+	$(BUILD_DIR)/$(BINARY_NAME) -config $(CONFIG)
 
 .PHONY: dev
 dev: download-zenohc
 	@echo "Running in dev mode with config: $(CONFIG)"
-	$(DYLD_VAR)=$(ZENOH_C_ABS_DIR)/lib $(GO) run $(CMD_DIR) -config ./config/$(CONFIG).json5 -log-level debug
+	$(DYLD_VAR)=$(ZENOH_C_ABS_DIR)/lib $(GO) run $(CMD_DIR) -config $(CONFIG) -log-level debug
 
 .PHONY: lint
 lint: download-zenohc

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -46,11 +46,14 @@ func Load(nameOrPath string) (*SystemConfig, error) {
 
 // resolvePath determines the actual file path of the configuration based on the provided name or path.
 func resolvePath(nameOrPath string) (string, error) {
-	if filepath.IsAbs(nameOrPath) {
-		return nameOrPath, nil
+	if nameOrPath == "" {
+		return "", fmt.Errorf("config name or path is empty")
 	}
 
-	if strings.HasSuffix(nameOrPath, ".json5") || strings.HasSuffix(nameOrPath, ".json") {
+	if filepath.IsAbs(nameOrPath) ||
+		strings.HasSuffix(nameOrPath, ".json5") ||
+		strings.HasSuffix(nameOrPath, ".json") ||
+		strings.ContainsRune(nameOrPath, os.PathSeparator) {
 		return nameOrPath, nil
 	}
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -66,9 +66,13 @@ func TestNormalizePreservesExistingModes(t *testing.T) {
 func TestResolvePath(t *testing.T) {
 	require.Equal(t, "/abs/path.json5", mustResolve(t, "/abs/path.json5"), "absolute paths pass through")
 	require.Equal(t, "rel/config.json", mustResolve(t, "rel/config.json"), "explicit .json suffix passes through")
+	require.Equal(t, "some/dir/agent", mustResolve(t, "some/dir/agent"), "relative paths with a separator pass through")
 
 	_, err := resolvePath("nonexistent-config-name")
 	require.Error(t, err, "bare names that resolve to no file error out")
+
+	_, err = resolvePath("")
+	require.Error(t, err, "empty config errors out")
 }
 
 func mustResolve(t *testing.T, in string) string {


### PR DESCRIPTION
This pull request updates how configuration file paths are handled and improves error checking in the config loader. The main changes focus on making the config loader more robust and flexible, and updating the `Makefile` to match the new config file handling.

**Configuration file path handling improvements:**

* The `resolvePath` function in `internal/config/loader.go` now returns an error if the config name or path is empty, and treats any string containing a path separator as a valid file path, not just those with `.json` or `.json5` extensions.

**Build process updates:**

* The `Makefile` `run` and `dev` targets now pass the config path directly (without prepending `./config/` or appending `.json5`), matching the new loader logic.

**Testing improvements:**

* The `TestResolvePath` test in `internal/config/loader_test.go` was updated to cover the new behaviors, including erroring on empty config, accepting paths with separators, and handling bare names that don't resolve.