### PR TITLE
addback current time in fuser

### DIFF
--- a/internal/fuser/fuser.go
+++ b/internal/fuser/fuser.go
@@ -3,6 +3,7 @@ package fuser
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/openmind/om1/internal/actions"
 	"github.com/openmind/om1/internal/config"
@@ -42,6 +43,11 @@ func (f *Fuser) Fuse(ctx context.Context, sensorBuffers []string) (string, error
 		builder.WriteString(f.runtimeConfig.SystemGovernance)
 		builder.WriteString("\n\n")
 	}
+
+	// 1b. Current timestamp.
+	builder.WriteString("Current time is ")
+	builder.WriteString(time.Now().Format("January 2, 2006 15:04:05"))
+	builder.WriteString(".\n\n")
 
 	// 2. Sensory inputs.
 	hasObservations := false

--- a/internal/fuser/fuser.go
+++ b/internal/fuser/fuser.go
@@ -46,7 +46,7 @@ func (f *Fuser) Fuse(ctx context.Context, sensorBuffers []string) (string, error
 
 	// 1b. Current timestamp.
 	builder.WriteString("Current time is ")
-	builder.WriteString(time.Now().Format("January 2, 2006 15:04:05"))
+	builder.WriteString(time.Now().Format("Monday, January 2, 2006 at 3:04 PM"))
 	builder.WriteString(".\n\n")
 
 	// 2. Sensory inputs.

--- a/internal/fuser/fuser_test.go
+++ b/internal/fuser/fuser_test.go
@@ -33,6 +33,7 @@ func TestFuseBasic(t *testing.T) {
 	out, err := f.Fuse(context.Background(), nil)
 	require.NoError(t, err)
 	require.Contains(t, out, "You are a robot.")
+	require.Contains(t, out, "Current time is ")
 	require.Contains(t, out, "What will you do next?")
 	require.NotContains(t, out, "Current observations:")
 }


### PR DESCRIPTION
This pull request adds a new feature to the `Fuse` function in the `internal/fuser/fuser.go` file. The main change is the inclusion of the current timestamp in the fused output, which can help provide context for when the fusion was performed.

Enhancement to output:

* Added the current timestamp (formatted as "January 2, 2006 15:04:05") to the beginning of the fused output in the `Fuse` function. [[1]](diffhunk://#diff-eff40133df9250bd2e8baeeb11c9fa9f3490ea07a7c10cd15d0b1edba085889dR6) [[2]](diffhunk://#diff-eff40133df9250bd2e8baeeb11c9fa9f3490ea07a7c10cd15d0b1edba085889dR47-R51)