### PR TITLE
add localtime volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - PULSE_COOKIE=/root/.config/pulse/cookie
       - ALSA_CARD=0
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ./config:/app/OM1/config
       - ${HOME}/shared_data/locations:/app/OM1/locations:rw
       - ${HOME}/shared_data/memory:/app/OM1/memory:rw


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file by mounting the host's local time configuration into the container to ensure time synchronization.

* Added a read-only volume mount for `/etc/localtime` to the service in `docker-compose.yml` to synchronize the container's time with the host system.