### PR TITLE
Add use_tracer flag to configuration schemas

### DIFF
--- a/config/schema/multi_mode_schema.json
+++ b/config/schema/multi_mode_schema.json
@@ -23,6 +23,7 @@
         },
         "api_key": {"type": "string", "description": "API key for the OM1 system."},
         "use_sim": {"type": "boolean", "description": "Whether to use the cloud simulation environment instead of a real robot."},
+        "use_tracer": {"type": "boolean", "description": "Whether to enable the tracer for debugging monitoring."},
         "unitree_ethernet": {"type": "string", "description": "Network interface name for the Unitree connection."},
         "system_governance": {"type": "string", "description": "Governance model determining system behavior rules."},
         "knowledge_base": {

--- a/config/schema/single_mode_schema.json
+++ b/config/schema/single_mode_schema.json
@@ -24,6 +24,7 @@
         "api_key": {"type": "string"},
         "URID": {"type": "string"},
         "use_sim": {"type": "boolean"},
+        "use_tracer": {"type": "boolean"},
         "unitree_ethernet": {"type": "string"},
         "system_prompt_base": {"type": "string"},
         "system_governance": {"type": "string"},


### PR DESCRIPTION
Add a new boolean property `use_tracer` to both multi_mode_schema.json and single_mode_schema.json. This flag enables the tracer for debugging/monitoring purposes in multi- and single-mode configurations.