### PR TITLE
Annotate nearest face in ToText output

### DIFF
--- a/internal/providers/face_presence.go
+++ b/internal/providers/face_presence.go
@@ -208,8 +208,7 @@ func (s *PresenceSnapshot) ToText() string {
 	}
 
 	// faces is sorted by area desc, so the first kept entry is the largest
-	// face = closest to camera = most likely the active speaker. Identify it
-	// before formatting so the marker survives the named-before-anon bucketing.
+	// face = closest to camera = most likely the active speaker.
 	var closest *FaceEntry
 	for i := range faces {
 		if f := &faces[i]; f.Name != "unknown" && f.Name != "" {

--- a/internal/providers/face_presence.go
+++ b/internal/providers/face_presence.go
@@ -189,8 +189,10 @@ func (s *PresenceSnapshot) ToText() string {
 	})
 
 	// Bucket into named/anon; drop unknown (transient, no UUID).
-	var named, anons []FaceEntry
-	for _, f := range faces {
+	// Hold pointers into the sorted slice so identity survives bucketing.
+	var named, anons []*FaceEntry
+	for i := range faces {
+		f := &faces[i]
 		switch {
 		case strings.HasPrefix(f.Name, "anon_"):
 			anons = append(anons, f)
@@ -205,18 +207,39 @@ func (s *PresenceSnapshot) ToText() string {
 		return ""
 	}
 
+	// faces is sorted by area desc, so the first kept entry is the largest
+	// face = closest to camera = most likely the active speaker. Identify it
+	// before formatting so the marker survives the named-before-anon bucketing.
+	var closest *FaceEntry
+	for i := range faces {
+		if f := &faces[i]; f.Name != "unknown" && f.Name != "" {
+			closest = f
+			break
+		}
+	}
+
 	total := len(named) + len(anons)
 	descriptor := fmt.Sprintf("FacePresence: %d face", total)
 	if total != 1 {
 		descriptor += "s"
 	}
+	// Tell the model the list is ordered by proximity and what that implies.
+	descriptor += " (nearest first; nearest face is closest to the camera and most likely addressing the robot)"
 
 	var parts []string
 	for _, f := range named {
-		parts = append(parts, formatNamedEntry(f))
+		entry := formatNamedEntry(*f)
+		if f == closest {
+			entry += " [closest, likely speaking]"
+		}
+		parts = append(parts, entry)
 	}
 	for _, f := range anons {
-		parts = append(parts, formatAnonEntry(f))
+		entry := formatAnonEntry(*f)
+		if f == closest {
+			entry += " [closest, likely speaking]"
+		}
+		parts = append(parts, entry)
 	}
 
 	return fmt.Sprintf("%s — %s", descriptor, strings.Join(parts, ", "))

--- a/internal/providers/face_presence.go
+++ b/internal/providers/face_presence.go
@@ -188,53 +188,36 @@ func (s *PresenceSnapshot) ToText() string {
 		return faces[i].TrackID < faces[j].TrackID
 	})
 
-	// Bucket into named/anon; drop unknown (transient, no UUID).
-	// Hold pointers into the sorted slice so identity survives bucketing.
-	var named, anons []*FaceEntry
+	var kept []*FaceEntry
 	for i := range faces {
 		f := &faces[i]
-		switch {
-		case strings.HasPrefix(f.Name, "anon_"):
-			anons = append(anons, f)
-		case f.Name == "unknown" || f.Name == "":
-			// drop
-		default:
-			named = append(named, f)
+		if f.Name == "unknown" || f.Name == "" {
+			continue
 		}
+		kept = append(kept, f)
 	}
 
-	if len(named) == 0 && len(anons) == 0 {
+	if len(kept) == 0 {
 		return ""
 	}
 
-	// faces is sorted by area desc, so the first kept entry is the largest
-	// face = closest to camera = most likely the active speaker.
-	var closest *FaceEntry
-	for i := range faces {
-		if f := &faces[i]; f.Name != "unknown" && f.Name != "" {
-			closest = f
-			break
-		}
-	}
+	closest := kept[0]
 
-	total := len(named) + len(anons)
-	descriptor := fmt.Sprintf("FacePresence: %d face", total)
-	if total != 1 {
+	descriptor := fmt.Sprintf("FacePresence: %d face", len(kept))
+	if len(kept) != 1 {
 		descriptor += "s"
 	}
 	// Tell the model the list is ordered by proximity and what that implies.
 	descriptor += " (nearest first; nearest face is closest to the camera and most likely addressing the robot)"
 
 	var parts []string
-	for _, f := range named {
-		entry := formatNamedEntry(*f)
-		if f == closest {
-			entry += " [closest, likely speaking]"
+	for _, f := range kept {
+		var entry string
+		if strings.HasPrefix(f.Name, "anon_") {
+			entry = formatAnonEntry(*f)
+		} else {
+			entry = formatNamedEntry(*f)
 		}
-		parts = append(parts, entry)
-	}
-	for _, f := range anons {
-		entry := formatAnonEntry(*f)
 		if f == closest {
 			entry += " [closest, likely speaking]"
 		}

--- a/internal/providers/face_presence_test.go
+++ b/internal/providers/face_presence_test.go
@@ -6,10 +6,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func f64(v float64) *float64  { return &v }
+func strptr(v string) *string { return &v }
 
 func TestPresenceSnapshotToText_Empty(t *testing.T) {
 	snap := PresenceSnapshot{}
@@ -52,6 +56,55 @@ func TestPresenceSnapshotToText_ClosestIsAnon(t *testing.T) {
 	text := snap.ToText()
 	require.Contains(t, text, "anon_73d0a4 (newcomer) [closest, likely speaking]")
 	require.NotContains(t, text, "sean (recognized) [closest")
+	require.Less(t, strings.Index(text, "anon_73d0a4"), strings.Index(text, "sean"))
+}
+
+func TestPresenceSnapshotToText_ThreeFacesAnonClosest(t *testing.T) {
+	snap := PresenceSnapshot{
+		Faces: []FaceEntry{
+			{Name: "doyuan", UUID: "d1", Area: 1500},
+			{Name: "anon_78198", UUID: "a1", Area: 4000, LastSeenAgoSec: f64(600), LastSeenISO: strptr("2026-06-17T09:00:00Z")},
+			{Name: "anon_783098", UUID: "a2", Area: 500, LastSeenAgoSec: f64(600), LastSeenISO: strptr("2026-06-17T08:00:00Z")},
+		},
+	}
+	text := snap.ToText()
+
+	require.Contains(t, text, "FacePresence: 3 faces")
+	require.Contains(t, text, "nearest first")
+	require.Contains(t, text, "anon_78198 (met before, last seen 2026-06-17) [closest, likely speaking]")
+	iClosest := strings.Index(text, "anon_78198")
+	iMid := strings.Index(text, "doyuan")
+	iFar := strings.Index(text, "anon_783098")
+	require.Less(t, iClosest, iMid)
+	require.Less(t, iMid, iFar)
+
+	require.Equal(t, 1, strings.Count(text, "[closest, likely speaking]"))
+}
+
+func TestPresenceSnapshotToText_SingleClosestMarker(t *testing.T) {
+	snap := PresenceSnapshot{
+		Faces: []FaceEntry{
+			{Name: "sean", UUID: "abc", Area: 1000}, // TrackID 0
+			{Name: "kim", UUID: "def", Area: 2000},  // TrackID 0
+			{Name: "lee", UUID: "ghi", Area: 500},   // TrackID 0
+		},
+	}
+	text := snap.ToText()
+	require.Equal(t, 1, strings.Count(text, "[closest, likely speaking]"))
+	require.Contains(t, text, "kim (recognized) [closest, likely speaking]")
+}
+
+func TestPresenceSnapshotToText_EqualAreaSingleMarker(t *testing.T) {
+	snap := PresenceSnapshot{
+		Faces: []FaceEntry{
+			{Name: "sean", UUID: "abc", Area: 1000, TrackID: 2},
+			{Name: "kim", UUID: "def", Area: 1000, TrackID: 1},
+		},
+	}
+	text := snap.ToText()
+	require.Equal(t, 1, strings.Count(text, "[closest, likely speaking]"))
+	require.Less(t, strings.Index(text, "kim"), strings.Index(text, "sean"))
+	require.Contains(t, text, "kim (recognized) [closest, likely speaking]")
 }
 
 func TestPresenceSnapshotToText_UnknownDropped(t *testing.T) {

--- a/internal/providers/face_presence_test.go
+++ b/internal/providers/face_presence_test.go
@@ -22,7 +22,9 @@ func TestPresenceSnapshotToText_OneNamed(t *testing.T) {
 	}
 	text := snap.ToText()
 	require.Contains(t, text, "FacePresence: 1 face")
+	require.Contains(t, text, "nearest first")
 	require.Contains(t, text, "sean")
+	require.Contains(t, text, "sean (recognized) [closest, likely speaking]")
 }
 
 func TestPresenceSnapshotToText_NamedAndAnon(t *testing.T) {
@@ -36,6 +38,20 @@ func TestPresenceSnapshotToText_NamedAndAnon(t *testing.T) {
 	require.Contains(t, text, "2 faces")
 	require.Contains(t, text, "sean")
 	require.Contains(t, text, "anon_73d0a4")
+	require.Contains(t, text, "sean (recognized) [closest, likely speaking]")
+	require.NotContains(t, text, "anon_73d0a4 (newcomer) [closest")
+}
+
+func TestPresenceSnapshotToText_ClosestIsAnon(t *testing.T) {
+	snap := PresenceSnapshot{
+		Faces: []FaceEntry{
+			{Name: "sean", UUID: "abc", Area: 800},
+			{Name: "anon_73d0a4", UUID: "def", Area: 3000},
+		},
+	}
+	text := snap.ToText()
+	require.Contains(t, text, "anon_73d0a4 (newcomer) [closest, likely speaking]")
+	require.NotContains(t, text, "sean (recognized) [closest")
 }
 
 func TestPresenceSnapshotToText_UnknownDropped(t *testing.T) {


### PR DESCRIPTION
This pull request refines the face presence summary logic and expands its test coverage. The main improvements include consolidating the handling of named and anonymous faces, clarifying output ordering, and ensuring that the "closest" face is clearly marked in the output. The test suite is enhanced to cover new edge cases and verify the correctness of the output.

**Face presence summary improvements:**

* Refactored `ToText()` in `face_presence.go` to combine named and anonymous faces into a single ordered list, dropping only "unknown" faces, and clarified that the list is ordered by proximity with the nearest face marked as "closest, likely speaking".
* Ensured that only the first (closest) face receives the "[closest, likely speaking]" marker and that the output descriptor explains the ordering.

**Test suite enhancements:**

* Added new tests in `face_presence_test.go` for scenarios where the closest face is anonymous, when there are multiple faces with the same area, and to ensure only one "[closest, likely speaking]" marker is present.
* Updated existing tests to check for the presence of proximity ordering information and the correct annotation of the closest face.
* Added helper functions for test data setup and imported `strings` to support new test assertions.