### PR TITLE
plugins/llm: add Requesty as an LLM provider

### DIFF
--- a/docs/api-reference/endpoints/llm.md
+++ b/docs/api-reference/endpoints/llm.md
@@ -28,6 +28,7 @@ OpenMind supports the following LLM providers:
 | X.AI | `xai` | Grok models from X.AI |
 | NEAR.AI | `nearai` | Qwen and other NEAR.AI hosted models |
 | OpenRouter | `openrouter` | Multi-provider access including Anthropic Claude, Meta Llama |
+| Requesty | `requesty` | Multi-provider access via Requesty's router (connects directly to `https://router.requesty.ai/v1`, not via the OpenMind proxy) |
 
 ## Supported Models
 
@@ -85,6 +86,18 @@ meta-llama/llama-3.1-70b-instruct
 meta-llama/llama-3.3-70b-instruct
 anthropic/claude-sonnet-4.5
 anthropic/claude-opus-4.1
+```
+
+### Requesty Models
+
+Requesty connects directly to `https://router.requesty.ai/v1` (not via the OpenMind proxy). Supply your own `REQUESTY_API_KEY`.
+
+```
+anthropic/claude-sonnet-4-5
+openai/gpt-4o-mini
+google/gemini-2.5-flash
+deepseek/deepseek-chat
+x-ai/grok-4-fast
 ```
 
 > **Note:** Model names are validated using prefix matching. For example, "gpt-4o" will match "gpt-4o", "gpt-4o-2024-08-06", etc.

--- a/docs/developing/0_introduction.md
+++ b/docs/developing/0_introduction.md
@@ -26,7 +26,7 @@ Whether you're just getting started with OM1 or looking to optimize an existing 
 | Easy to add new data inputs              | Seamlessly integrate new data without major changes to the existing architecture. |
 | Easy to support new hardware             | Via plugins for API endpoints and specific robot hardware.                      |
 | Supports Standard Middleware             | `ROS2`, `Zenoh`, and `CycloneDDS`                                               |
-| Preconfigured endpoints                  | Text-to-Speech, OpenAI's `gpt-4o`, DeepSeek, Gemini, Openrouter, Near AI, Ollama (local), and multiple VLMs. |
+| Preconfigured endpoints                  | Text-to-Speech, OpenAI's `gpt-4o`, DeepSeek, Gemini, Openrouter, Requesty, Near AI, Ollama (local), and multiple VLMs. |
 | Simulators                               | Gazebo, Isaac Sim (Coming Soon)
 
 To get started with OM1, head over to [Installation Guide](1_get-started.md).

--- a/docs/developing/5_llms.md
+++ b/docs/developing/5_llms.md
@@ -164,6 +164,24 @@ The system supports on-device inference using the Qwen3-30B local LLM. This enab
 make run CONFIG=ollama
 ```
 
+### Requesty
+
+[Requesty](https://requesty.ai) provides an OpenAI-compatible router for multiple model providers. OM1 supports Requesty through the `Requesty` plugin. Unlike the other providers, Requesty is **not** proxied through OpenMind — it connects directly to `https://router.requesty.ai/v1`. Supply your own `REQUESTY_API_KEY`.
+
+**Configuration:**
+```json5
+  "cortex_llm": {
+    "type": "Requesty",     // The class name of the LLM plugin you wish to use
+    "config": {
+      "model": "anthropic/claude-sonnet-4-5",   // Optional: defaults to anthropic/claude-sonnet-4-5
+      "base_url": "https://router.requesty.ai/v1", // Optional: Requesty connects directly (not via the OpenMind proxy)
+      "api_key": "<REQUESTY_API_KEY>",           // Required: your Requesty API key
+      "agent_name": "Iris",                      // Optional: Name of the agent
+      "history_length": 10                       // The number of input->action cycles to provide as historical context
+    }
+  }
+```
+
 ### Agent Architecture
 
 The system employs four primary agents that work together:
@@ -220,6 +238,11 @@ var NearAISupportedModels = []string{"qwen3-30b-a3b-instruct-2507", "qwen2.5-vl-
 
 ```go
 var OpenRouterSupportedModels = []string{"meta-llama/llama-3.1-70b-instruct", "meta-llama/llama-3.3-70b-instruct", "anthropic/claude-sonnet-4.5", "anthropic/claude-opus-4.1"}
+```
+
+```go
+// Requesty connects directly to https://router.requesty.ai/v1 (not via the OpenMind proxy)
+var RequestySupportedModels = []string{"anthropic/claude-sonnet-4-5", "openai/gpt-4o-mini", "google/gemini-2.5-flash", "deepseek/deepseek-chat", "x-ai/grok-4-fast"}
 ```
 
 ```go

--- a/docs/developing/5_llms.md
+++ b/docs/developing/5_llms.md
@@ -131,6 +131,24 @@ The system supports on-device inference using the Qwen3-30B local LLM. This enab
 make run CONFIG=conversation
 ```
 
+### Requesty
+
+[Requesty](https://requesty.ai) provides an OpenAI-compatible router for multiple model providers. OM1 supports Requesty through the `Requesty` plugin. Unlike the other providers, Requesty is **not** proxied through OpenMind. It connects directly to `https://router.requesty.ai/v1`, so supply your own `REQUESTY_API_KEY`.
+
+**Configuration:**
+```json5
+  "cortex_llm": {
+    "type": "Requesty",     // The class name of the LLM plugin you wish to use
+    "config": {
+      "model": "anthropic/claude-sonnet-4-5",   // Optional: defaults to anthropic/claude-sonnet-4-5
+      "base_url": "https://router.requesty.ai/v1", // Optional: Requesty connects directly (not via the OpenMind proxy)
+      "api_key": "<REQUESTY_API_KEY>",           // Required: your Requesty API key
+      "agent_name": "Iris",                      // Optional: Name of the agent
+      "history_length": 10                       // The number of input->action cycles to provide as historical context
+    }
+  }
+```
+
 ### Main API Endpoint
 
 ```go
@@ -166,6 +184,7 @@ The models each plugin accepts are defined in `plugins/llm/<provider>.go`. The c
 | `XAILLM` | `grok-2-latest`, `grok-3-beta`, `grok-4-latest`, `grok-4` |
 | `NearAILLM` | `qwen3-30b-a3b-instruct-2507`, `qwen2.5-vl-72b-instruct`, `qwen2.5-7b-instruct` |
 | `OpenRouter` | `anthropic/claude-sonnet-4.5`, `anthropic/claude-opus-4.5`, `anthropic/claude-haiku-4.5`, `moonshotai/kimi-k2.5`, `minimax/minimax-m2.1`, `z-ai/glm-4.7`, `x-ai/grok-4-fast`, `deepseek/deepseek-v3.2`, `meta-llama/llama-3.3-70b-instruct` |
+| `Requesty` | `anthropic/claude-sonnet-4-5`, `openai/gpt-4o-mini`, `google/gemini-2.5-flash`, `deepseek/deepseek-chat`, `x-ai/grok-4-fast` (connects directly to `https://router.requesty.ai/v1`, not via the OpenMind proxy) |
 | `OllamaLLM` | any model from [ollama.ai/library](https://ollama.ai/library) (default `llama3.2`) |
 | `QwenLLM` (local) | `RedHatAI/Qwen3-30B-A3B-quantized.w4a16` (default) |
 

--- a/plugins/llm/openai_compat_test.go
+++ b/plugins/llm/openai_compat_test.go
@@ -45,6 +45,7 @@ func TestProviderDefaults(t *testing.T) {
 		{"DeepSeekLLM", map[string]any{"api_key": "k"}, defaultDeepSeekModel, defaultDeepSeekBaseURL},
 		{"XAILLM", map[string]any{"api_key": "k"}, defaultXAIModel, defaultXAIBaseURL},
 		{"OpenRouter", map[string]any{"api_key": "k"}, defaultOpenRouterModel, defaultOpenRouterBaseURL},
+		{"Requesty", map[string]any{"api_key": "k"}, defaultRequestyModel, "https://router.requesty.ai/v1"},
 		{"NearAILLM", map[string]any{"api_key": "k"}, defaultNearAIModel, defaultNearAIBaseURL},
 		{"FunctionGemmaLLM", map[string]any{"api_key": "k"}, defaultFunctionGemmaModel, defaultFunctionGemmaBaseURL},
 	}

--- a/plugins/llm/requesty.go
+++ b/plugins/llm/requesty.go
@@ -1,0 +1,26 @@
+package llm
+
+import (
+	"github.com/openmind/om1/internal/llm"
+)
+
+func init() {
+	llm.Register("Requesty", NewRequesty)
+}
+
+type requestyModel = string
+
+const (
+	RequestyModelAnthropicSonnet45 requestyModel = "anthropic/claude-sonnet-4-5"
+	RequestyModelOpenAIGPT4oMini   requestyModel = "openai/gpt-4o-mini"
+	RequestyModelGeminiFlash25     requestyModel = "google/gemini-2.5-flash"
+	RequestyModelDeepSeekChat      requestyModel = "deepseek/deepseek-chat"
+	RequestyModelXAIGrok4Fast      requestyModel = "x-ai/grok-4-fast"
+
+	defaultRequestyModel   requestyModel = RequestyModelAnthropicSonnet45
+	defaultRequestyBaseURL string        = "https://router.requesty.ai/v1"
+)
+
+func NewRequesty(configMap map[string]any) (llm.LLM, error) {
+	return newOpenAICompat("Requesty", configMap, defaultRequestyModel, defaultRequestyBaseURL, "auto", true)
+}


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as a provider plugin, mirroring the existing OpenRouter plugin.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router, so it uses the shared `newOpenAICompat` path like the other providers. Note: Requesty connects directly, not through the OpenMind proxy the built-in providers default to.

Changes:
- `plugins/llm/requesty.go`: new `Requesty` plugin (registered via `llm.Register`), default base URL `https://router.requesty.ai/v1`, default model `anthropic/claude-sonnet-4-5`.
- `plugins/llm/openai_compat_test.go`: a Requesty row in the provider-defaults table.
- docs updated.

Verified: `plugins/llm` and `internal/llm` build+vet clean and `go test ./plugins/llm/` passes (incl. the new Requesty subtest).

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.