### PR TITLE
Make greeting end-hook farewell messages configurable

### DIFF
--- a/internal/hooks/greeting_hook.go
+++ b/internal/hooks/greeting_hook.go
@@ -21,6 +21,12 @@ func init() {
 
 const defaultGreetingLLMType = "GeminiLLM"
 
+const (
+	defaultEndMessageMaxTurns = "Thank you for chatting with me today. I hope you enjoy the rest of your day."
+	defaultEndMessageActive   = "It was nice talking with you! If you have any more questions, come chat with me again!"
+	defaultEndMessageNoTurns  = "It was great meeting you! If you want to chat later, just come back and say hi!"
+)
+
 const defaultGreetingPrompt = "You are {robot_name}, a friendly robot greeting whoever is in front of you. " +
 	"The current time is {current_time}. " +
 	"Generate a single warm, natural spoken greeting of one or two short sentences. " +
@@ -205,7 +211,7 @@ func staticGreeting(snapshot providers.PresenceSnapshot, snapErr error, robotNam
 
 // greetingEndHook handles the end of a greeting conversation, announcing a
 // farewell whose wording depends on how far the conversation progressed.
-func (r *Runner) greetingEndHook(_ context.Context, cfg, _ map[string]any) error {
+func (r *Runner) greetingEndHook(_ context.Context, cfg, vars map[string]any) error {
 	provider, err := r.greetingTTSProvider(cfg)
 	if err != nil {
 		r.log.Error("greeting_end_hook: error", zap.Error(err))
@@ -213,15 +219,18 @@ func (r *Runner) greetingEndHook(_ context.Context, cfg, _ map[string]any) error
 	}
 
 	state := providers.Greeting()
+	var message string
 	switch {
 	case state.TurnCount() >= state.MaxTurnCount():
 		r.log.Info("greeting conversation ended due to maximum turn count")
-		provider.AddText("Thank you for chatting with me today. I hope you enjoy the rest of your day.")
+		message = stringValDefault(cfg, "end_message_max_turns", defaultEndMessageMaxTurns)
 	case state.TurnCount() > 0:
-		provider.AddText("It was nice talking with you! If you have any more questions, come chat with me again!")
+		message = stringValDefault(cfg, "end_message_active", defaultEndMessageActive)
 	default:
-		provider.AddText("It was great meeting you! If you want to chat later, just come back and say hi!")
+		message = stringValDefault(cfg, "end_message_no_turns", defaultEndMessageNoTurns)
 	}
+
+	provider.AddText(formatTemplate(message, vars))
 
 	return nil
 }

--- a/internal/hooks/greeting_hook.go
+++ b/internal/hooks/greeting_hook.go
@@ -229,9 +229,7 @@ func (r *Runner) greetingEndHook(_ context.Context, cfg, vars map[string]any) er
 	return nil
 }
 
-// endMessage selects the farewell message for the given conversation progress,
-// honoring the configurable handler_config keys and falling back to the
-// built-in defaults, then applies template variables such as {robot_name}.
+// endMessage selects the farewell message for the given conversation progress.
 func endMessage(cfg, vars map[string]any, turnCount, maxTurnCount int) string {
 	var message string
 	switch {

--- a/internal/hooks/greeting_hook.go
+++ b/internal/hooks/greeting_hook.go
@@ -219,20 +219,31 @@ func (r *Runner) greetingEndHook(_ context.Context, cfg, vars map[string]any) er
 	}
 
 	state := providers.Greeting()
+	turnCount, maxTurnCount := state.TurnCount(), state.MaxTurnCount()
+	if turnCount >= maxTurnCount {
+		r.log.Info("greeting conversation ended due to maximum turn count")
+	}
+
+	provider.AddText(endMessage(cfg, vars, turnCount, maxTurnCount))
+
+	return nil
+}
+
+// endMessage selects the farewell message for the given conversation progress,
+// honoring the configurable handler_config keys and falling back to the
+// built-in defaults, then applies template variables such as {robot_name}.
+func endMessage(cfg, vars map[string]any, turnCount, maxTurnCount int) string {
 	var message string
 	switch {
-	case state.TurnCount() >= state.MaxTurnCount():
-		r.log.Info("greeting conversation ended due to maximum turn count")
+	case turnCount >= maxTurnCount:
 		message = stringValDefault(cfg, "end_message_max_turns", defaultEndMessageMaxTurns)
-	case state.TurnCount() > 0:
+	case turnCount > 0:
 		message = stringValDefault(cfg, "end_message_active", defaultEndMessageActive)
 	default:
 		message = stringValDefault(cfg, "end_message_no_turns", defaultEndMessageNoTurns)
 	}
 
-	provider.AddText(formatTemplate(message, vars))
-
-	return nil
+	return formatTemplate(message, vars)
 }
 
 // greetingTTSProvider resolves the TTS provider for a greeting hook.

--- a/internal/hooks/greeting_hook_test.go
+++ b/internal/hooks/greeting_hook_test.go
@@ -1,0 +1,53 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndMessageDefaults(t *testing.T) {
+	cases := []struct {
+		name          string
+		turnCount     int
+		maxTurnCount  int
+		wantSubstring string
+	}{
+		{"max turns reached", 3, 3, defaultEndMessageMaxTurns},
+		{"beyond max turns", 5, 3, defaultEndMessageMaxTurns},
+		{"active conversation", 1, 3, defaultEndMessageActive},
+		{"no turns", 0, 3, defaultEndMessageNoTurns},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := endMessage(map[string]any{}, nil, tc.turnCount, tc.maxTurnCount)
+			require.Equal(t, tc.wantSubstring, got)
+		})
+	}
+}
+
+func TestEndMessageConfigOverrides(t *testing.T) {
+	cfg := map[string]any{
+		"end_message_max_turns": "bye after max",
+		"end_message_active":    "bye after chat",
+		"end_message_no_turns":  "bye no chat",
+	}
+
+	require.Equal(t, "bye after max", endMessage(cfg, nil, 3, 3))
+	require.Equal(t, "bye after chat", endMessage(cfg, nil, 1, 3))
+	require.Equal(t, "bye no chat", endMessage(cfg, nil, 0, 3))
+}
+
+func TestEndMessageBlankOverrideFallsBackToDefault(t *testing.T) {
+	// A present-but-empty config value should fall back to the default rather
+	// than announcing an empty farewell.
+	cfg := map[string]any{"end_message_active": "   "}
+	require.Equal(t, defaultEndMessageActive, endMessage(cfg, nil, 1, 3))
+}
+
+func TestEndMessageAppliesTemplateVars(t *testing.T) {
+	cfg := map[string]any{"end_message_no_turns": "Goodbye from {robot_name}!"}
+	got := endMessage(cfg, map[string]any{"robot_name": "Bits"}, 0, 3)
+	require.Equal(t, "Goodbye from Bits!", got)
+}


### PR DESCRIPTION
## What

Makes the three hardcoded farewell messages in `greetingEndHook` configurable via the hook's `handler_config`, instead of being baked into the Go source.

## Why

Deployments (e.g. the UME Tea boba-shop config) want to customize the robot's goodbye wording per install without editing and rebuilding OM1.

## Changes

- Extract the three farewells into `defaultEndMessage*` constants preserving the original wording.
- `greetingEndHook` now reads these keys from `handler_config`, falling back to the defaults when absent:
  - `end_message_max_turns` — conversation reached `MaxTurnCount`
  - `end_message_active` — customer engaged (turn count > 0)
  - `end_message_no_turns` — ended with no back-and-forth
- Messages are run through `formatTemplate`, so config can reference variables like `{robot_name}` (the hook now uses `vars` instead of discarding it).

Behavior is unchanged when the keys are not set.

## Testing

- `go build ./internal/hooks/`
- `go vet ./internal/hooks/`