### PR TITLE
move docs-sync PR branch out of docs/ namespace to avoid ref conflict

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
-          branch: docs/auto-sync-${{ steps.range.outputs.after }}
+          branch: docs-sync/auto-${{ steps.range.outputs.after }}
           add-paths: docs/**
           commit-message: "docs: sync with recent changes to main"
           title: "docs: sync with recent changes to main"


### PR DESCRIPTION
## Problem
Docs Sync fails to push: `docs/auto-sync-<sha> (directory file conflict)` — a `docs` branch already exists on the remote, so Git can't create refs under `docs/`.

## Fix
Rename the PR branch prefix `docs/auto-sync-<sha>` → `docs-sync/auto-<sha>` (clear on the remote).