### PR TITLE
feat: migrate smoke and gas detector input plugin to Go

### DIFF
--- a/config/smoke_gas_detector.json5
+++ b/config/smoke_gas_detector.json5
@@ -1,0 +1,26 @@
+{
+  version: "v1.1.0",
+  hertz: 0.5,
+  name: "smoke_gas_patrol",
+  api_key: "${OM_API_KEY:-openmind_free}",
+  system_prompt_base: "You are a safety monitoring agent for a warehouse patrol robot. Watch for smoke and gas hazards and alert immediately if detected.",
+  system_governance: "Here are the laws that govern your actions. Do not violate these laws.\nFirst Law: A robot cannot harm a human or allow a human to come to harm.\nSecond Law: A robot must obey orders from humans, unless those orders conflict with the First Law.\nThird Law: A robot must protect itself, as long as that protection doesn't conflict with the First or Second Law.\nThe First Law is considered the most important, taking precedence over the second and third laws.",
+  system_prompt_examples: "If a danger alert is reported, speak clearly and urgently to notify nearby people and recommend evacuation.",
+  cortex_llm: {
+    type: "GeminiLLM",
+    config: {
+      agent_name: "SafetyBot",
+      history_length: 10,
+    },
+  },
+  agent_inputs: [
+    {
+      type: "SmokeGasDetector",
+      config: {
+        mock_scenario: "normal",
+        cooldown: 5.0,
+      },
+    },
+  ],
+  agent_actions: [],
+}

--- a/plugins/inputs/smoke_gas_detector.go
+++ b/plugins/inputs/smoke_gas_detector.go
@@ -1,0 +1,239 @@
+package inputs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/openmind/om1/internal/inputs"
+	"github.com/openmind/om1/internal/logger"
+	"github.com/openmind/om1/internal/providers"
+)
+
+func init() {
+	inputs.Register("SmokeGasDetector", NewSmokeGasDetector)
+}
+
+const (
+	smokeGasDescriptor  = "Smoke and Gas Detector"
+	smokeGasIOKey       = "SmokeGasDetector"
+	smokeGasMaxMessages = 1
+
+	smokeWarningThresholdDefault = 300.0
+	smokeDangerThresholdDefault  = 600.0
+	gasWarningThresholdDefault   = 300.0
+	gasDangerThresholdDefault    = 600.0
+	cooldownDefaultSec           = 5.0
+	smokeGasPollIntervalSec      = 0.5
+)
+
+type SmokeGasDetectorConfig struct {
+	CooldownSec           float64 `json:"cooldown"`
+	SmokeWarningThreshold float64 `json:"smoke_warning_threshold"`
+	SmokeDangerThreshold  float64 `json:"smoke_danger_threshold"`
+	GasWarningThreshold   float64 `json:"gas_warning_threshold"`
+	GasDangerThreshold    float64 `json:"gas_danger_threshold"`
+	MockScenario          string  `json:"mock_scenario"`
+}
+
+type SmokeGasReading struct {
+	SmokePPM float64
+	GasPPM   float64
+}
+
+type mockSmokeConnector struct {
+	scenario string
+	rng      *rand.Rand
+}
+
+func newMockSmokeConnector(scenario string) *mockSmokeConnector {
+	return &mockSmokeConnector{
+		scenario: scenario,
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+func (m *mockSmokeConnector) Read() *SmokeGasReading {
+	var smoke, gas float64
+	switch m.scenario {
+	case "warning":
+		smoke = 350 + (m.rng.Float64()*40 - 20)
+		gas = 320 + (m.rng.Float64()*40 - 20)
+	case "danger":
+		smoke = 750 + (m.rng.Float64()*60 - 30)
+		gas = 700 + (m.rng.Float64()*60 - 30)
+	default:
+		smoke = 50 + (m.rng.Float64()*20 - 10)
+		gas = 40 + (m.rng.Float64()*20 - 10)
+	}
+	return &SmokeGasReading{SmokePPM: smoke, GasPPM: gas}
+}
+
+type SmokeGasDetectorSensor struct {
+	cfg       SmokeGasDetectorConfig
+	log       *zap.Logger
+	connector *mockSmokeConnector
+
+	mu            sync.Mutex
+	messages      []inputs.Message
+	lastAlertTime time.Time
+	stopped       bool
+}
+
+func NewSmokeGasDetector(configMap map[string]any) (inputs.Sensor, error) {
+	var cfg SmokeGasDetectorConfig
+	if b, err := json.Marshal(configMap); err == nil {
+		_ = json.Unmarshal(b, &cfg)
+	}
+
+	if cfg.CooldownSec <= 0 {
+		cfg.CooldownSec = cooldownDefaultSec
+	}
+	if cfg.SmokeWarningThreshold <= 0 {
+		cfg.SmokeWarningThreshold = smokeWarningThresholdDefault
+	}
+	if cfg.SmokeDangerThreshold <= 0 {
+		cfg.SmokeDangerThreshold = smokeDangerThresholdDefault
+	}
+	if cfg.GasWarningThreshold <= 0 {
+		cfg.GasWarningThreshold = gasWarningThresholdDefault
+	}
+	if cfg.GasDangerThreshold <= 0 {
+		cfg.GasDangerThreshold = gasDangerThresholdDefault
+	}
+	if cfg.MockScenario == "" {
+		cfg.MockScenario = "normal"
+	}
+
+	log := logger.Get().Named("SmokeGasDetector")
+	log.Info("initialized", zap.String("mock_scenario", cfg.MockScenario), zap.Float64("cooldown_sec", cfg.CooldownSec))
+
+	return &SmokeGasDetectorSensor{
+		cfg:       cfg,
+		log:       log,
+		connector: newMockSmokeConnector(cfg.MockScenario),
+	}, nil
+}
+
+func (s *SmokeGasDetectorSensor) classify(r *SmokeGasReading) string {
+	if r.SmokePPM >= s.cfg.SmokeDangerThreshold || r.GasPPM >= s.cfg.GasDangerThreshold {
+		return "danger"
+	}
+	if r.SmokePPM >= s.cfg.SmokeWarningThreshold || r.GasPPM >= s.cfg.GasWarningThreshold {
+		return "warning"
+	}
+	return "normal"
+}
+
+func (s *SmokeGasDetectorSensor) readingToText(r *SmokeGasReading) string {
+	level := s.classify(r)
+	now := time.Now()
+	cooldown := time.Duration(s.cfg.CooldownSec * float64(time.Second))
+
+	switch level {
+	case "danger":
+		if now.Sub(s.lastAlertTime) < cooldown {
+			return ""
+		}
+		s.lastAlertTime = now
+		return fmt.Sprintf(
+			"SMOKE ALERT: Critical smoke/gas level detected. Smoke: %.0f ppm, Gas: %.0f ppm. Immediate evacuation recommended. Possible fire or gas leak.",
+			r.SmokePPM, r.GasPPM,
+		)
+	case "warning":
+		if now.Sub(s.lastAlertTime) < cooldown {
+			return ""
+		}
+		s.lastAlertTime = now
+		return fmt.Sprintf(
+			"SMOKE WARNING: Elevated smoke/gas detected. Smoke: %.0f ppm, Gas: %.0f ppm. Possible fire risk. Inspect area immediately.",
+			r.SmokePPM, r.GasPPM,
+		)
+	default:
+		return fmt.Sprintf("Smoke/gas detector: Air quality normal. Smoke: %.0f ppm, Gas: %.0f ppm.", r.SmokePPM, r.GasPPM)
+	}
+}
+
+func (s *SmokeGasDetectorSensor) Listen(ctx context.Context) (<-chan any, error) {
+	out := make(chan any)
+	go func() {
+		defer close(out)
+		defer s.Stop()
+
+		ticker := time.NewTicker(time.Duration(smokeGasPollIntervalSec * float64(time.Second)))
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			text := s.readingToText(s.connector.Read())
+			if text == "" {
+				continue
+			}
+
+			msg := inputs.NewMessage(text)
+			s.mu.Lock()
+			s.messages = append(s.messages, *msg)
+			if len(s.messages) > smokeGasMaxMessages {
+				s.messages = s.messages[len(s.messages)-smokeGasMaxMessages:]
+			}
+			s.mu.Unlock()
+		}
+	}()
+	return out, nil
+}
+
+func (s *SmokeGasDetectorSensor) Poll(_ context.Context) (any, error) {
+	return s.readingToText(s.connector.Read()), nil
+}
+
+func (s *SmokeGasDetectorSensor) RawToText(_ context.Context, raw any) (*inputs.Message, error) {
+	text, ok := raw.(string)
+	if !ok || text == "" {
+		return nil, nil
+	}
+	msg := inputs.NewMessage(text)
+	s.mu.Lock()
+	s.messages = append(s.messages, *msg)
+	s.mu.Unlock()
+	return msg, nil
+}
+
+func (s *SmokeGasDetectorSensor) FormattedLatestBuffer() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.messages) == 0 {
+		return ""
+	}
+
+	latest := s.messages[len(s.messages)-1]
+	result := fmt.Sprintf("\nINPUT: %s\n// START\n%s\n// END\n", smokeGasDescriptor, latest.Message)
+
+	ts := time.Unix(0, int64(latest.Timestamp*1e9))
+	providers.IO().AddInput(smokeGasIOKey, latest.Message, ts)
+	s.messages = nil
+
+	return result
+}
+
+func (s *SmokeGasDetectorSensor) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	s.mu.Unlock()
+
+	s.log.Info("stopping sensor")
+}

--- a/plugins/inputs/smoke_gas_detector_test.go
+++ b/plugins/inputs/smoke_gas_detector_test.go
@@ -1,0 +1,108 @@
+package inputs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func newTestSmokeGasSensor(scenario string) *SmokeGasDetectorSensor {
+	return &SmokeGasDetectorSensor{
+		log: zap.NewNop(),
+		cfg: SmokeGasDetectorConfig{
+			CooldownSec:           5.0,
+			SmokeWarningThreshold: smokeWarningThresholdDefault,
+			SmokeDangerThreshold:  smokeDangerThresholdDefault,
+			GasWarningThreshold:   gasWarningThresholdDefault,
+			GasDangerThreshold:    gasDangerThresholdDefault,
+			MockScenario:          scenario,
+		},
+		connector: newMockSmokeConnector(scenario),
+	}
+}
+
+func TestSmokeGasClassify(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	require.Equal(t, "normal", s.classify(&SmokeGasReading{SmokePPM: 100, GasPPM: 100}))
+	require.Equal(t, "warning", s.classify(&SmokeGasReading{SmokePPM: 350, GasPPM: 100}))
+	require.Equal(t, "danger", s.classify(&SmokeGasReading{SmokePPM: 700, GasPPM: 100}))
+	require.Equal(t, "danger", s.classify(&SmokeGasReading{SmokePPM: 100, GasPPM: 700}))
+}
+
+func TestSmokeGasReadingToTextNormal(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	text := s.readingToText(&SmokeGasReading{SmokePPM: 50, GasPPM: 40})
+	require.Contains(t, text, "Air quality normal")
+}
+
+func TestSmokeGasReadingToTextDangerCooldown(t *testing.T) {
+	s := newTestSmokeGasSensor("danger")
+
+	first := s.readingToText(&SmokeGasReading{SmokePPM: 750, GasPPM: 700})
+	require.Contains(t, first, "SMOKE ALERT")
+
+	second := s.readingToText(&SmokeGasReading{SmokePPM: 750, GasPPM: 700})
+	require.Empty(t, second)
+}
+
+func TestSmokeGasPoll(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	raw, err := s.Poll(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, raw, "Air quality normal")
+}
+
+func TestSmokeGasRawToTextNonString(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	msg, err := s.RawToText(context.Background(), 42)
+	require.NoError(t, err)
+	require.Nil(t, msg)
+}
+
+func TestSmokeGasRawToTextEmptyString(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	msg, err := s.RawToText(context.Background(), "")
+	require.NoError(t, err)
+	require.Nil(t, msg)
+}
+
+func TestSmokeGasFormattedLatestBuffer(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	require.Equal(t, "", s.FormattedLatestBuffer())
+
+	_, err := s.RawToText(context.Background(), "Smoke/gas detector: Air quality normal. Smoke: 50 ppm, Gas: 40 ppm.")
+	require.NoError(t, err)
+
+	out := s.FormattedLatestBuffer()
+	require.Contains(t, out, smokeGasDescriptor)
+	require.Contains(t, out, "Air quality normal")
+
+	require.Equal(t, "", s.FormattedLatestBuffer())
+}
+
+func TestSmokeGasStopIsIdempotent(t *testing.T) {
+	s := newTestSmokeGasSensor("normal")
+
+	s.Stop()
+	require.True(t, s.stopped)
+	require.NotPanics(t, s.Stop)
+}
+
+func TestNewSmokeGasDetector(t *testing.T) {
+	s, err := NewSmokeGasDetector(map[string]any{
+		"mock_scenario": "warning",
+		"cooldown":      2.0,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	s.Stop()
+}


### PR DESCRIPTION
## Summary
Migrates the Smoke and Gas Detector input plugin from the deprecated Python runtime (#2481) to Go, per @Prachi1615's request.

## Scope
This PR includes the **mock connector only**. Real hardware backends (Arduino MQ serial, ENS160 I2C, SGP30 I2C) require new Go dependencies not currently in `go.mod`, which per CONTRIBUTING.md need discussion in an issue before adding. These will follow in a separate PR.

## What's included
- `SmokeGasDetector` input plugin (`plugins/inputs/smoke_gas_detector.go`)
- Classify logic (normal/warning/danger) and cooldown behavior ported 1:1 from the Python version
- Unit tests (`plugins/inputs/smoke_gas_detector_test.go`)
- Example config (`config/smoke_gas_detector.json5`)

## Testing
- `make build` ✅
- `make vet` ✅
- `make test` — all pass, no regressions ✅
- Manual run verified alert output and cooldown timing end-to-end