### PR TITLE
fix(ws): start read and write loops for non-reconnecting clients

### DIFF
--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -60,7 +60,13 @@ func New(cfg Config, log *zap.Logger, onMessage func(messageType int, data []byt
 // Connect dials the server and starts the send/read goroutines.
 func (c *Client) Connect() error {
 	if !c.cfg.Reconnect {
-		return c.dial()
+		if err := c.dial(); err != nil {
+			return err
+		}
+		c.wg.Add(2)
+		go c.sendLoop()
+		go c.readLoop()
+		return nil
 	}
 
 	for {

--- a/internal/ws/client_test.go
+++ b/internal/ws/client_test.go
@@ -68,6 +68,25 @@ func TestConnectSendReceive(t *testing.T) {
 	}
 }
 
+func TestConnectSendReceiveWithoutReconnect(t *testing.T) {
+	url := echoServer(t)
+
+	received := make(chan []byte, 1)
+	c := New(Config{URL: url, Reconnect: false}, zap.NewNop(), func(_ int, data []byte) {
+		received <- append([]byte(nil), data...)
+	})
+	require.NoError(t, c.Connect())
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Send([]byte("ping")))
+	select {
+	case got := <-received:
+		require.Equal(t, []byte("ping"), got, "the server echoes the message back to onMessage")
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive echoed message")
+	}
+}
+
 func TestConnectFailsForBadURL(t *testing.T) {
 	c := New(Config{URL: "ws://127.0.0.1:1"}, zap.NewNop(), nil)
 	require.Error(t, c.Connect(), "non-reconnecting client returns the dial error")


### PR DESCRIPTION
## Overview

Fix WebSocket clients configured with `Reconnect: false` so they can send and receive messages after a successful initial connection.


When `Reconnect` is disabled, `Client.Connect()` returns immediately after a successful dial without starting the send and read goroutines.

Consequently, `Send()` can enqueue data successfully, but no goroutine consumes the queue, and incoming messages are never delivered to `onMessage`.


Fixes https://github.com/OpenMind/OM1/issues/2665

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes
[Detail the changes you have made in this pull request. Include any new features, bug fixes, or improvements.]

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if applicable)
- [x] Local testing completed
- [ ] Tests added/updated (if applicable)

## Impact
[Explain the impact of your changes. Include any potential risks or side effects that reviewers should be aware of.]

- Start `sendLoop` and `readLoop` after every successful initial dial.
- Keep `Reconnect` responsible for retrying failed initial connections and
  reconnecting after subsequent connection errors.
- Add `TestConnectSendReceiveWithoutReconnect` as a regression test.



## Additional Information
[Include any additional information that may be relevant to reviewers. This could include links to related issues or pull requests, references to documentation, or other context that may help reviewers understand your changes.]
