### PR TITLE
feat: reimplement AirQualityInput plugin in Go (aqicn, pms5003, bme680)

### DIFF
--- a/config/air_quality_example.json5
+++ b/config/air_quality_example.json5
@@ -1,0 +1,60 @@
+// Example agent_inputs entries for the AirQuality sensor plugin.
+// Copy the relevant block into your own config's `agent_inputs` array.
+// Only one `connector` per AirQuality entry; add multiple entries if you
+// want to combine sources (e.g. aqicn for outdoor + bme680 for indoor).
+//
+// NOTE: `version` below is only present so this file can be validated
+// standalone during development. When copying entries into your own
+// config, use your config's own `version`, not this one.
+{
+  version: "v1.1.0",
+  agent_inputs: [
+    // --- aqicn: AQICN cloud API, no hardware needed ---------------------
+    {
+      type: "AirQuality",
+      config: {
+        connector: "aqicn",
+        connector_config: {
+          api_key: "${AQICN_API_KEY}",
+          latitude: -6.9667,
+          longitude: 110.4167,
+        },
+        poll_interval: 300.0,
+        aqi_warning_threshold: 100,
+        aqi_danger_threshold: 150,
+      },
+    },
+
+    // --- pms5003: PMS5003/PMS7003 particulate sensor via Serial/UART ---
+    {
+      type: "AirQuality",
+      config: {
+        connector: "pms5003",
+        connector_config: {
+          port: "/dev/ttyUSB0",
+          location: "Outdoor",
+        },
+        poll_interval: 60.0,
+        aqi_warning_threshold: 100,
+        aqi_danger_threshold: 150,
+      },
+    },
+
+    // --- bme680: BME680 environmental sensor via I2C --------------------
+    {
+      type: "AirQuality",
+      config: {
+        connector: "bme680",
+        connector_config: {
+          i2c_bus: "/dev/i2c-1",
+          i2c_address: 118, // 0x76
+          location: "Indoor",
+          gas_baseline: 50000.0,
+        },
+        poll_interval: 60.0,
+        aqi_warning_threshold: 100,
+        aqi_danger_threshold: 150,
+      },
+    },
+  ],
+}

--- a/docs/air_quality/config_example.json5
+++ b/docs/air_quality/config_example.json5
@@ -2,12 +2,7 @@
 // Copy the relevant block into your own config's `agent_inputs` array.
 // Only one `connector` per AirQuality entry; add multiple entries if you
 // want to combine sources (e.g. aqicn for outdoor + bme680 for indoor).
-//
-// NOTE: `version` below is only present so this file can be validated
-// standalone during development. When copying entries into your own
-// config, use your config's own `version`, not this one.
 {
-  version: "v1.1.0",
   agent_inputs: [
     // --- aqicn: AQICN cloud API, no hardware needed ---------------------
     {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yalue/onnxruntime_go v1.31.0
+	go.bug.st/serial v1.8.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.37.0
 )
 
@@ -41,7 +43,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/yalue/onnxruntime_go v1.31.0 h1:1ln4YW1SFOFfGJZXe3jNOb2JUSt+l2pEneZfV
 github.com/yalue/onnxruntime_go v1.31.0/go.mod h1:b4X26A8pekNb1ACJ58wAXgNKeUCGEAQ9dmACut9Sm/4=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+go.bug.st/serial v1.8.0 h1:ZtnmN8aYXtPlTghwSvDWPHKBHL9TM6oFDa+KpSn4SQE=
+go.bug.st/serial v1.8.0/go.mod h1:d0MmS16Qt9b1m06yoYRNUXhRRTJV5Qg2S5EKqQtnayQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
@@ -82,8 +84,8 @@ golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJ
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
-golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
-golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=

--- a/plugins/inputs/air_quality.go
+++ b/plugins/inputs/air_quality.go
@@ -194,14 +194,15 @@ func (s *AirQualitySensor) pollOnce(ctx context.Context) (*connector.AirQualityD
 		return nil, nil
 	}
 
-	data, err := s.conn.Read(ctx)
-	if err != nil {
-		return nil, err
-	}
+	data, readErr := s.conn.Read(ctx)
+
 	if derr := s.conn.Disconnect(ctx); derr != nil {
 		s.log.Warn("disconnect error", zap.Error(derr))
 	}
 
+	if readErr != nil {
+		return nil, readErr
+	}
 	return data, nil
 }
 
@@ -237,9 +238,10 @@ func (s *AirQualitySensor) rawToMessage(raw *connector.AirQualityData) *inputs.M
 
 	var parts []string
 
+	var aqiLabel, aqiDescription string
 	if raw.AQI != nil {
-		label, _ := connector.GetAQILevel(*raw.AQI)
-		parts = append(parts, fmt.Sprintf("Air Quality in %s: %s (AQI: %d)", raw.Location, label, *raw.AQI))
+		aqiLabel, aqiDescription = connector.GetAQILevel(*raw.AQI)
+		parts = append(parts, fmt.Sprintf("Air Quality in %s: %s (AQI: %d)", raw.Location, aqiLabel, *raw.AQI))
 	} else {
 		parts = append(parts, fmt.Sprintf("Air Quality in %s", raw.Location))
 	}
@@ -279,11 +281,10 @@ func (s *AirQualitySensor) rawToMessage(raw *connector.AirQualityData) *inputs.M
 	}
 
 	if raw.AQI != nil {
-		label, description := connector.GetAQILevel(*raw.AQI)
 		if *raw.AQI >= s.cfg.AQIDangerThreshold {
-			parts = append(parts, fmt.Sprintf("DANGER: Air quality is %s — %s", label, description))
+			parts = append(parts, fmt.Sprintf("DANGER: Air quality is %s — %s", aqiLabel, aqiDescription))
 		} else if *raw.AQI >= s.cfg.AQIWarningThreshold {
-			parts = append(parts, fmt.Sprintf("WARNING: Air quality is %s — %s", label, description))
+			parts = append(parts, fmt.Sprintf("WARNING: Air quality is %s — %s", aqiLabel, aqiDescription))
 		}
 	}
 

--- a/plugins/inputs/air_quality.go
+++ b/plugins/inputs/air_quality.go
@@ -1,0 +1,325 @@
+package inputs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/openmind/om1/internal/inputs"
+	"github.com/openmind/om1/internal/logger"
+	"github.com/openmind/om1/internal/providers"
+	"github.com/openmind/om1/internal/util"
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector"
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector/aqicn"
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector/bme680"
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector/pms5003"
+)
+
+func init() {
+	inputs.Register("AirQuality", NewAirQuality)
+}
+
+const (
+	airQualityDescriptor  = "Air Quality"
+	airQualityIOKey       = "AirQuality"
+	airQualityMaxMessages = 10
+
+	airQualityDefaultConnector           = "aqicn"
+	airQualityDefaultPollIntervalSec     = 300.0
+	airQualityDefaultAQIWarningThreshold = 100
+	airQualityDefaultAQIDangerThreshold  = 150
+)
+
+// AirQualityConfig mirrors the Python AirQualityConfig(SensorConfig).
+// ConnectorConfig is passed through as-is (json.RawMessage) to whichever
+// connector is selected, mirroring Python's `connector_config: dict`.
+type AirQualityConfig struct {
+	Connector           string          `json:"connector"`
+	ConnectorConfig     json.RawMessage `json:"connector_config"`
+	PollIntervalSec     float64         `json:"poll_interval"`
+	AQIWarningThreshold int             `json:"aqi_warning_threshold"`
+	AQIDangerThreshold  int             `json:"aqi_danger_threshold"`
+}
+
+type AirQualitySensor struct {
+	cfg    AirQualityConfig
+	log    *zap.Logger
+	conn   connector.AirQualityConnector
+	period time.Duration
+
+	mu           sync.Mutex
+	messages     []inputs.Message
+	stopped      bool
+	lastPollTime time.Time
+}
+
+// NewAirQuality builds an AirQualitySensor from the given config map,
+// mirroring Python's AirQualityInput.__init__ (connector selection + defaults).
+func NewAirQuality(configMap map[string]any) (inputs.Sensor, error) {
+	var cfg AirQualityConfig
+	if b, err := json.Marshal(configMap); err == nil {
+		_ = json.Unmarshal(b, &cfg)
+	}
+	if cfg.Connector == "" {
+		cfg.Connector = airQualityDefaultConnector
+	}
+	if cfg.PollIntervalSec <= 0 {
+		cfg.PollIntervalSec = airQualityDefaultPollIntervalSec
+	}
+	if cfg.AQIWarningThreshold == 0 {
+		cfg.AQIWarningThreshold = airQualityDefaultAQIWarningThreshold
+	}
+	if cfg.AQIDangerThreshold == 0 {
+		cfg.AQIDangerThreshold = airQualityDefaultAQIDangerThreshold
+	}
+
+	log := logger.Get().Named("AirQuality")
+
+	var conn connector.AirQualityConnector
+	switch cfg.Connector {
+	case "aqicn":
+		var c aqicn.Config
+		if len(cfg.ConnectorConfig) > 0 {
+			_ = json.Unmarshal(cfg.ConnectorConfig, &c)
+		}
+		conn = aqicn.New(c, nil)
+	case "pms5003":
+		var c pms5003.Config
+		if len(cfg.ConnectorConfig) > 0 {
+			_ = json.Unmarshal(cfg.ConnectorConfig, &c)
+		}
+		conn = pms5003.New(c, nil)
+	case "bme680":
+		var c bme680.Config
+		if len(cfg.ConnectorConfig) > 0 {
+			_ = json.Unmarshal(cfg.ConnectorConfig, &c)
+		}
+		conn = bme680.New(c, nil)
+	default:
+		return nil, fmt.Errorf(
+			"AirQualityInput: unknown connector '%s'. Available: [aqicn pms5003 bme680]",
+			cfg.Connector,
+		)
+	}
+
+	log.Info("initializing",
+		zap.String("connector", cfg.Connector),
+		zap.Float64("poll_interval", cfg.PollIntervalSec),
+		zap.Int("aqi_warning_threshold", cfg.AQIWarningThreshold),
+		zap.Int("aqi_danger_threshold", cfg.AQIDangerThreshold),
+	)
+
+	return &AirQualitySensor{
+		cfg:    cfg,
+		log:    log,
+		conn:   conn,
+		period: time.Duration(cfg.PollIntervalSec * float64(time.Second)),
+	}, nil
+}
+
+// Listen polls the connector on a ticker and pushes formatted messages.
+// Mirrors Python's `_poll()` loop being driven by the outer runtime, adapted
+// to the OM1 Go Listen/channel pattern used by FacePresenceSensor.
+func (s *AirQualitySensor) Listen(ctx context.Context) (<-chan any, error) {
+	out := make(chan any)
+	go func() {
+		defer close(out)
+		defer s.Stop()
+
+		ticker := time.NewTicker(s.period)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			data, err := s.pollOnce(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				s.log.Warn("poll failed", zap.Error(err))
+				util.Sleep(ctx, 2*time.Second)
+				continue
+			}
+			if data == nil {
+				continue
+			}
+
+			msg := s.rawToMessage(data)
+			if msg == nil {
+				continue
+			}
+
+			s.mu.Lock()
+			s.messages = append(s.messages, *msg)
+			if len(s.messages) > airQualityMaxMessages {
+				s.messages = s.messages[len(s.messages)-airQualityMaxMessages:]
+			}
+			s.mu.Unlock()
+
+			providers.IO().AddInput(airQualityIOKey, msg.Message, time.Now())
+		}
+	}()
+	return out, nil
+}
+
+// Poll performs one connect->read->disconnect cycle and returns the raw data.
+// Mirrors Python's `_poll()`.
+func (s *AirQualitySensor) Poll(ctx context.Context) (any, error) {
+	return s.pollOnce(ctx)
+}
+
+// pollOnce mirrors Python's `_poll()`: connect, read, disconnect.
+func (s *AirQualitySensor) pollOnce(ctx context.Context) (*connector.AirQualityData, error) {
+	now := time.Now()
+	if now.Sub(s.lastPollTime).Seconds() < s.cfg.PollIntervalSec {
+		return nil, nil
+	}
+	s.lastPollTime = now
+
+	ok, err := s.conn.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+
+	data, err := s.conn.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if derr := s.conn.Disconnect(ctx); derr != nil {
+		s.log.Warn("disconnect error", zap.Error(derr))
+	}
+
+	return data, nil
+}
+
+// RawToText implements inputs.Sensor. Converts raw AirQualityData into a
+// Message and appends it to the buffer. Mirrors Python's `raw_to_text`.
+func (s *AirQualitySensor) RawToText(_ context.Context, raw any) (*inputs.Message, error) {
+	data, ok := raw.(*connector.AirQualityData)
+	if !ok || data == nil {
+		return nil, nil
+	}
+
+	msg := s.rawToMessage(data)
+	if msg == nil {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	s.messages = append(s.messages, *msg)
+	if len(s.messages) > airQualityMaxMessages {
+		s.messages = s.messages[len(s.messages)-airQualityMaxMessages:]
+	}
+	s.mu.Unlock()
+
+	return msg, nil
+}
+
+// rawToMessage converts AirQualityData into a human-readable message for the LLM.
+// Mirrors Python's `_raw_to_text(raw_input)`.
+func (s *AirQualitySensor) rawToMessage(raw *connector.AirQualityData) *inputs.Message {
+	if raw == nil {
+		return nil
+	}
+
+	var parts []string
+
+	if raw.AQI != nil {
+		label, _ := connector.GetAQILevel(*raw.AQI)
+		parts = append(parts, fmt.Sprintf("Air Quality in %s: %s (AQI: %d)", raw.Location, label, *raw.AQI))
+	} else {
+		parts = append(parts, fmt.Sprintf("Air Quality in %s", raw.Location))
+	}
+
+	var pollutants []string
+	if raw.PM25 != nil {
+		pollutants = append(pollutants, fmt.Sprintf("PM2.5: %v µg/m³", *raw.PM25))
+	}
+	if raw.PM10 != nil {
+		pollutants = append(pollutants, fmt.Sprintf("PM10: %v µg/m³", *raw.PM10))
+	}
+	if raw.CO != nil {
+		pollutants = append(pollutants, fmt.Sprintf("CO: %v ppm", *raw.CO))
+	}
+	if raw.NO2 != nil {
+		pollutants = append(pollutants, fmt.Sprintf("NO2: %v µg/m³", *raw.NO2))
+	}
+	if raw.SO2 != nil {
+		pollutants = append(pollutants, fmt.Sprintf("SO2: %v µg/m³", *raw.SO2))
+	}
+	if raw.O3 != nil {
+		pollutants = append(pollutants, fmt.Sprintf("O3: %v µg/m³", *raw.O3))
+	}
+	if len(pollutants) > 0 {
+		parts = append(parts, strings.Join(pollutants, ", "))
+	}
+
+	var envData []string
+	if raw.Temperature != nil {
+		envData = append(envData, fmt.Sprintf("Temperature: %v°C", *raw.Temperature))
+	}
+	if raw.Humidity != nil {
+		envData = append(envData, fmt.Sprintf("Humidity: %v%%", *raw.Humidity))
+	}
+	if len(envData) > 0 {
+		parts = append(parts, strings.Join(envData, ", "))
+	}
+
+	if raw.AQI != nil {
+		label, description := connector.GetAQILevel(*raw.AQI)
+		if *raw.AQI >= s.cfg.AQIDangerThreshold {
+			parts = append(parts, fmt.Sprintf("DANGER: Air quality is %s — %s", label, description))
+		} else if *raw.AQI >= s.cfg.AQIWarningThreshold {
+			parts = append(parts, fmt.Sprintf("WARNING: Air quality is %s — %s", label, description))
+		}
+	}
+
+	text := strings.Join(parts, ". ") + "."
+	return inputs.NewMessage(text)
+}
+
+// FormattedLatestBuffer returns the latest formatted air quality message,
+// wrapped in the INPUT/START/END block, mirroring Python's
+// `formatted_latest_buffer()`.
+func (s *AirQualitySensor) FormattedLatestBuffer() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.messages) == 0 {
+		return ""
+	}
+
+	latest := s.messages[len(s.messages)-1]
+	result := fmt.Sprintf("\nINPUT: %s\n// START\n%s\n// END\n", airQualityDescriptor, latest.Message)
+
+	ts := time.Unix(0, int64(latest.Timestamp*1e9))
+	providers.IO().AddInput(airQualityIOKey, latest.Message, ts)
+	s.messages = nil
+
+	return result
+}
+
+func (s *AirQualitySensor) Stop() {
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	s.mu.Unlock()
+
+	s.log.Info("stopping sensor")
+}

--- a/plugins/inputs/air_quality/connector/aqicn/aqicn.go
+++ b/plugins/inputs/air_quality/connector/aqicn/aqicn.go
@@ -16,6 +16,10 @@ type Config struct {
 	APIKey    string  // config["api_key"]
 	Latitude  float64 // config["latitude"], default -6.2088
 	Longitude float64 // config["longitude"], default 106.8456
+
+	// BaseURL overrides the AQICN API base URL. Empty means the real API
+	// (https://api.waqi.info). Exists so tests can point at httptest.Server.
+	BaseURL string
 }
 
 // Connector implements connector.AirQualityConnector for the AQICN cloud API.
@@ -31,6 +35,9 @@ func New(cfg Config, logger *log.Logger) *Connector {
 	if cfg.Latitude == 0 && cfg.Longitude == 0 {
 		cfg.Latitude = -6.2088
 		cfg.Longitude = 106.8456
+	}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "https://api.waqi.info"
 	}
 	if logger == nil {
 		logger = log.Default()
@@ -68,7 +75,9 @@ type iaqiEntry struct {
 type aqicnPayload struct {
 	Status string `json:"status"`
 	Data   struct {
-		AQI  json.Number `json:"aqi"`
+		// AQI is raw because AQICN sends either a number or the literal
+		// string "-" when no AQI is available for the location.
+		AQI  json.RawMessage `json:"aqi"`
 		City struct {
 			Name string `json:"name"`
 		} `json:"city"`
@@ -92,7 +101,7 @@ func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error)
 		return nil, nil
 	}
 
-	url := fmt.Sprintf("https://api.waqi.info/feed/geo:%v;%v/?token=%s", c.cfg.Latitude, c.cfg.Longitude, c.cfg.APIKey)
+	url := fmt.Sprintf("%s/feed/geo:%v;%v/?token=%s", c.cfg.BaseURL, c.cfg.Latitude, c.cfg.Longitude, c.cfg.APIKey)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -131,9 +140,13 @@ func (c *Connector) parse(payload aqicnPayload) *connector.AirQualityData {
 	data := connector.NewAirQualityData()
 
 	// aqi_raw = data.get("aqi", "-"); aqi = int(aqi_raw) if aqi_raw not in ("-", None) else None
-	if aqiFloat, err := payload.Data.AQI.Float64(); err == nil {
-		aqi := int(aqiFloat)
-		data.AQI = &aqi
+	// AQI may be a JSON number or the literal string "-" (meaning unavailable).
+	var aqiNum json.Number
+	if err := json.Unmarshal(payload.Data.AQI, &aqiNum); err == nil {
+		if aqiFloat, err := aqiNum.Float64(); err == nil {
+			aqi := int(aqiFloat)
+			data.AQI = &aqi
+		}
 	}
 
 	get := func(e *iaqiEntry) *float64 {

--- a/plugins/inputs/air_quality/connector/aqicn/aqicn.go
+++ b/plugins/inputs/air_quality/connector/aqicn/aqicn.go
@@ -1,0 +1,163 @@
+package aqicn
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector"
+)
+
+// Config mirrors the `config: dict` passed into Python's AqicnConnector.__init__.
+type Config struct {
+	APIKey    string  // config["api_key"]
+	Latitude  float64 // config["latitude"], default -6.2088
+	Longitude float64 // config["longitude"], default 106.8456
+}
+
+// Connector implements connector.AirQualityConnector for the AQICN cloud API.
+// Mirrors Python's AqicnConnector.
+type Connector struct {
+	cfg        Config
+	httpClient *http.Client
+	logger     *log.Logger
+}
+
+// New creates a new AQICN connector, applying the same defaults as the Python version.
+func New(cfg Config, logger *log.Logger) *Connector {
+	if cfg.Latitude == 0 && cfg.Longitude == 0 {
+		cfg.Latitude = -6.2088
+		cfg.Longitude = 106.8456
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Connector{
+		cfg:        cfg,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		logger:     logger,
+	}
+}
+
+func (c *Connector) Name() string {
+	return "aqicn"
+}
+
+// Connect validates the API key and confirms the connector is ready.
+// Mirrors Python's `connect()`.
+func (c *Connector) Connect(ctx context.Context) (bool, error) {
+	if c.cfg.APIKey == "" {
+		c.logger.Println("AqicnConnector: no API key provided")
+		return false, nil
+	}
+	return true, nil
+}
+
+// Disconnect is a no-op: stateless HTTP connector requires no teardown.
+func (c *Connector) Disconnect(ctx context.Context) error {
+	return nil
+}
+
+type iaqiEntry struct {
+	V *float64 `json:"v"`
+}
+
+type aqicnPayload struct {
+	Status string `json:"status"`
+	Data   struct {
+		AQI  json.Number `json:"aqi"`
+		City struct {
+			Name string `json:"name"`
+		} `json:"city"`
+		IAQI struct {
+			PM25 *iaqiEntry `json:"pm25"`
+			PM10 *iaqiEntry `json:"pm10"`
+			CO   *iaqiEntry `json:"co"`
+			NO2  *iaqiEntry `json:"no2"`
+			SO2  *iaqiEntry `json:"so2"`
+			O3   *iaqiEntry `json:"o3"`
+			T    *iaqiEntry `json:"t"`
+			H    *iaqiEntry `json:"h"`
+		} `json:"iaqi"`
+	} `json:"data"`
+}
+
+// Read fetches air quality data from the AQICN API.
+// Returns (nil, nil) on any handled failure, mirroring Python's `return None`.
+func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error) {
+	if c.cfg.APIKey == "" {
+		return nil, nil
+	}
+
+	url := fmt.Sprintf("https://api.waqi.info/feed/geo:%v;%v/?token=%s", c.cfg.Latitude, c.cfg.Longitude, c.cfg.APIKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		c.logger.Printf("AqicnConnector: unexpected error: %v", err)
+		return nil, nil
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.logger.Printf("AqicnConnector: network error: %v", err)
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Printf("AqicnConnector: HTTP %d", resp.StatusCode)
+		return nil, nil
+	}
+
+	var payload aqicnPayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		c.logger.Printf("AqicnConnector: unexpected error: %v", err)
+		return nil, nil
+	}
+
+	if payload.Status != "ok" {
+		c.logger.Printf("AqicnConnector: API error, status=%q", payload.Status)
+		return nil, nil
+	}
+
+	return c.parse(payload), nil
+}
+
+// parse mirrors Python's `_parse(payload)`.
+func (c *Connector) parse(payload aqicnPayload) *connector.AirQualityData {
+	data := connector.NewAirQualityData()
+
+	// aqi_raw = data.get("aqi", "-"); aqi = int(aqi_raw) if aqi_raw not in ("-", None) else None
+	if aqiFloat, err := payload.Data.AQI.Float64(); err == nil {
+		aqi := int(aqiFloat)
+		data.AQI = &aqi
+	}
+
+	get := func(e *iaqiEntry) *float64 {
+		if e == nil {
+			return nil
+		}
+		return e.V
+	}
+
+	data.PM25 = get(payload.Data.IAQI.PM25)
+	data.PM10 = get(payload.Data.IAQI.PM10)
+	data.CO = get(payload.Data.IAQI.CO)
+	data.NO2 = get(payload.Data.IAQI.NO2)
+	data.SO2 = get(payload.Data.IAQI.SO2)
+	data.O3 = get(payload.Data.IAQI.O3)
+	data.Temperature = get(payload.Data.IAQI.T)
+	data.Humidity = get(payload.Data.IAQI.H)
+
+	if payload.Data.City.Name != "" {
+		data.Location = payload.Data.City.Name
+	} else {
+		data.Location = "Unknown"
+	}
+	data.Source = "aqicn"
+
+	return data
+}

--- a/plugins/inputs/air_quality/connector/aqicn/aqicn_test.go
+++ b/plugins/inputs/air_quality/connector/aqicn/aqicn_test.go
@@ -1,0 +1,129 @@
+package aqicn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnect_NoAPIKey(t *testing.T) {
+	c := New(Config{}, nil)
+	ok, err := c.Connect(context.Background())
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestConnect_WithAPIKey(t *testing.T) {
+	c := New(Config{APIKey: "token"}, nil)
+	ok, err := c.Connect(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestRead_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"status": "ok",
+			"data": {
+				"aqi": 99,
+				"city": {"name": "Semarang, Indonesia"},
+				"iaqi": {
+					"pm25": {"v": 99},
+					"t": {"v": 32.9},
+					"h": {"v": 53.1}
+				}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{APIKey: "token", BaseURL: server.URL}, nil)
+	data, err := c.Read(context.Background())
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, 99, *data.AQI)
+	require.Equal(t, 99.0, *data.PM25)
+	require.Equal(t, 32.9, *data.Temperature)
+	require.Equal(t, 53.1, *data.Humidity)
+	require.Equal(t, "Semarang, Indonesia", data.Location)
+	require.Equal(t, "aqicn", data.Source)
+}
+
+func TestRead_NoAPIKey(t *testing.T) {
+	c := New(Config{}, nil)
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := New(Config{APIKey: "token", BaseURL: server.URL}, nil)
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_APIStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status": "error", "data": "Invalid key"}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{APIKey: "token", BaseURL: server.URL}, nil)
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_MalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	c := New(Config{APIKey: "token", BaseURL: server.URL}, nil)
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_MissingPollutants(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status": "ok", "data": {"aqi": "-", "city": {}, "iaqi": {}}}`))
+	}))
+	defer server.Close()
+
+	c := New(Config{APIKey: "token", BaseURL: server.URL}, nil)
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Nil(t, data.AQI)
+	require.Nil(t, data.PM25)
+	require.Equal(t, "Unknown", data.Location)
+}
+
+func TestDisconnect_NoOp(t *testing.T) {
+	c := New(Config{}, nil)
+	err := c.Disconnect(context.Background())
+	require.NoError(t, err)
+}
+
+func TestName(t *testing.T) {
+	c := New(Config{}, nil)
+	require.Equal(t, "aqicn", c.Name())
+}
+
+func TestNew_DefaultLocation(t *testing.T) {
+	c := New(Config{}, nil)
+	require.Equal(t, -6.2088, c.cfg.Latitude)
+	require.Equal(t, 106.8456, c.cfg.Longitude)
+}

--- a/plugins/inputs/air_quality/connector/base.go
+++ b/plugins/inputs/air_quality/connector/base.go
@@ -1,0 +1,71 @@
+package connector
+
+import (
+	"context"
+	"math"
+)
+
+// AirQualityData is the standardized data structure returned by all connectors.
+// Mirrors the Python dataclass AirQualityData in connector/base.py.
+type AirQualityData struct {
+	AQI         *int
+	PM25        *float64
+	PM10        *float64
+	CO          *float64
+	NO2         *float64
+	SO2         *float64
+	O3          *float64
+	Temperature *float64
+	Humidity    *float64
+	Location    string
+	Source      string
+}
+
+// NewAirQualityData returns a data struct with Python-equivalent defaults
+// (location="Unknown", source="Unknown").
+func NewAirQualityData() *AirQualityData {
+	return &AirQualityData{
+		Location: "Unknown",
+		Source:   "Unknown",
+	}
+}
+
+type aqiLevel struct {
+	threshold   float64
+	label       string
+	description string
+}
+
+// AQILevels mirrors the Python AQI_LEVELS constant (US EPA AQI scale).
+var AQILevels = []aqiLevel{
+	{50, "GOOD", "Air quality is satisfactory."},
+	{100, "MODERATE", "Acceptable; some pollutants may concern sensitive groups."},
+	{150, "UNHEALTHY FOR SENSITIVE GROUPS", "Sensitive groups may experience health effects."},
+	{200, "UNHEALTHY", "Everyone may begin to experience health effects."},
+	{300, "VERY UNHEALTHY", "Health alert: everyone may experience serious effects."},
+	{math.Inf(1), "HAZARDOUS", "Health warning: emergency conditions for entire population."},
+}
+
+// GetAQILevel mirrors Python's get_aqi_level(aqi) -> (label, description).
+func GetAQILevel(aqi int) (label string, description string) {
+	for _, lvl := range AQILevels {
+		if float64(aqi) <= lvl.threshold {
+			return lvl.label, lvl.description
+		}
+	}
+	last := AQILevels[len(AQILevels)-1]
+	return last.label, last.description
+}
+
+// AirQualityConnector is the interface every connector must implement.
+// Mirrors the Python ABC AirQualityConnector.
+//
+// Connect returns (bool, error): bool mirrors Python's True/False success signal
+// (e.g. missing API key, sensor not found), error is for unexpected failures.
+// Callers should treat `!ok` the same as Python treating `connected == False`.
+type AirQualityConnector interface {
+	Connect(ctx context.Context) (ok bool, err error)
+	Read(ctx context.Context) (*AirQualityData, error)
+	Disconnect(ctx context.Context) error
+	Name() string
+}

--- a/plugins/inputs/air_quality/connector/base_test.go
+++ b/plugins/inputs/air_quality/connector/base_test.go
@@ -1,0 +1,62 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAQILevel_Good(t *testing.T) {
+	label, desc := GetAQILevel(25)
+	require.Equal(t, "GOOD", label)
+	require.Contains(t, desc, "satisfactory")
+}
+
+func TestGetAQILevel_Moderate(t *testing.T) {
+	label, _ := GetAQILevel(75)
+	require.Equal(t, "MODERATE", label)
+}
+
+func TestGetAQILevel_UnhealthySensitive(t *testing.T) {
+	label, _ := GetAQILevel(120)
+	require.Equal(t, "UNHEALTHY FOR SENSITIVE GROUPS", label)
+}
+
+func TestGetAQILevel_Unhealthy(t *testing.T) {
+	label, _ := GetAQILevel(180)
+	require.Equal(t, "UNHEALTHY", label)
+}
+
+func TestGetAQILevel_VeryUnhealthy(t *testing.T) {
+	label, _ := GetAQILevel(250)
+	require.Equal(t, "VERY UNHEALTHY", label)
+}
+
+func TestGetAQILevel_Hazardous(t *testing.T) {
+	label, _ := GetAQILevel(400)
+	require.Equal(t, "HAZARDOUS", label)
+}
+
+func TestGetAQILevel_Boundaries(t *testing.T) {
+	// Exact threshold values must fall in the lower (inclusive) tier,
+	// mirroring Python's `if aqi <= threshold`.
+	label, _ := GetAQILevel(50)
+	require.Equal(t, "GOOD", label)
+
+	label, _ = GetAQILevel(51)
+	require.Equal(t, "MODERATE", label)
+
+	label, _ = GetAQILevel(150)
+	require.Equal(t, "UNHEALTHY FOR SENSITIVE GROUPS", label)
+
+	label, _ = GetAQILevel(151)
+	require.Equal(t, "UNHEALTHY", label)
+}
+
+func TestNewAirQualityData_Defaults(t *testing.T) {
+	d := NewAirQualityData()
+	require.Equal(t, "Unknown", d.Location)
+	require.Equal(t, "Unknown", d.Source)
+	require.Nil(t, d.AQI)
+	require.Nil(t, d.PM25)
+}

--- a/plugins/inputs/air_quality/connector/bme680/bme680.go
+++ b/plugins/inputs/air_quality/connector/bme680/bme680.go
@@ -15,23 +15,23 @@ import (
 
 // Register addresses per Bosch BME680 datasheet.
 const (
-	regChipID       = 0xD0
-	regReset        = 0xE0
-	regCtrlHum      = 0x72
-	regCtrlMeas     = 0x74
-	regConfig       = 0x75
-	regCtrlGas1     = 0x71
-	regGasWait0     = 0x64
-	regResHeat0     = 0x5A
-	regMeasStatus0  = 0x1D
-	regFieldStart   = 0x1F // press_msb..gas_r_lsb block starts here
-	regCalibStart1  = 0x89 // calibration block 1 (0x89-0xA1)
-	regCalibStart2  = 0xE1 // calibration block 2 (0xE1-0xEF)
-	regHeatRange    = 0x02
-	regHeatVal      = 0x00
-	regRangeSwErr   = 0x04
-	chipIDExpected  = 0x61
-	i2cSlaveIoctl   = 0x0703 // unix.I2C_SLAVE
+	regChipID      = 0xD0
+	regReset       = 0xE0
+	regCtrlHum     = 0x72
+	regCtrlMeas    = 0x74
+	regConfig      = 0x75
+	regCtrlGas1    = 0x71
+	regGasWait0    = 0x64
+	regResHeat0    = 0x5A
+	regMeasStatus0 = 0x1D
+	regFieldStart  = 0x1F // press_msb..gas_r_lsb block starts here
+	regCalibStart1 = 0x89 // calibration block 1 (0x89-0xA1)
+	regCalibStart2 = 0xE1 // calibration block 2 (0xE1-0xEF)
+	regHeatRange   = 0x02
+	regHeatVal     = 0x00
+	regRangeSwErr  = 0x04
+	chipIDExpected = 0x61
+	i2cSlaveIoctl  = 0x0703 // unix.I2C_SLAVE
 )
 
 // Config mirrors the `config: dict` passed into Python's BME680Connector.__init__.
@@ -42,12 +42,51 @@ type Config struct {
 	GasBaseline float64 // config["gas_baseline"], default 50000.0
 }
 
+// i2cBus is the minimal set of register operations the connector needs.
+// Extracted as an interface so tests can supply a fake bus without touching
+// real hardware; realI2CBus is the only production implementation.
+type i2cBus interface {
+	writeReg(reg, value byte) error
+	readReg(reg byte) (byte, error)
+	readBlock(reg byte, length int) ([]byte, error)
+}
+
+// realI2CBus implements i2cBus over a real Linux i2c-dev file descriptor.
+type realI2CBus struct {
+	file *os.File
+}
+
+func (b *realI2CBus) writeReg(reg, value byte) error {
+	_, err := b.file.Write([]byte{reg, value})
+	return err
+}
+
+func (b *realI2CBus) readBlock(reg byte, length int) ([]byte, error) {
+	if _, err := b.file.Write([]byte{reg}); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, length)
+	if _, err := b.file.Read(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (b *realI2CBus) readReg(reg byte) (byte, error) {
+	buf, err := b.readBlock(reg, 1)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
 // Connector implements connector.AirQualityConnector for the BME680 sensor over I2C.
 // Talks to the sensor directly via Linux i2c-dev, following the Bosch BME680
 // datasheet register map and compensation formulas (no third-party driver).
 type Connector struct {
 	cfg    Config
-	file   *os.File
+	file   *os.File // real fd, only set/used outside tests; kept for Close()
+	bus    i2cBus
 	calib  calibration
 	logger *log.Logger
 }
@@ -90,54 +129,67 @@ func (c *Connector) Connect(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	id, err := readReg(f, regChipID)
-	if err != nil || id != chipIDExpected {
-		f.Close()
-		c.logger.Printf("BME680Connector: unexpected chip id 0x%X (err=%v)", id, err)
-		return false, nil
-	}
-
 	c.file = f
+	bus := &realI2CBus{file: f}
 
-	calib, err := readCalibration(f)
-	if err != nil {
-		c.file.Close()
+	if ok, err := c.connectWithBus(bus); !ok || err != nil {
+		f.Close()
 		c.file = nil
-		c.logger.Printf("BME680Connector: failed to read calibration: %v", err)
-		return false, nil
-	}
-	c.calib = calib
-
-	// Oversampling: humidity x2, pressure x4, temperature x8 (matches Python defaults).
-	if err := writeReg(f, regCtrlHum, 0x02); err != nil {
-		return false, nil
-	}
-	ctrlMeas := byte(0x05<<5) | byte(0x03<<2) // temp OS_8X (101), press OS_4X (011), mode=sleep
-	if err := writeReg(f, regCtrlMeas, ctrlMeas); err != nil {
-		return false, nil
-	}
-	// IIR filter size 3 -> filter coeff index 2 (per datasheet table), bits [4:2] of regConfig.
-	if err := writeReg(f, regConfig, 0x02<<2); err != nil {
-		return false, nil
-	}
-
-	// Gas heater: target 320°C for 150ms, profile 0 (matches Python defaults).
-	heaterRes := c.calcHeaterResistance(320, 25) // assume 25°C ambient if unknown
-	if err := writeReg(f, regResHeat0, heaterRes); err != nil {
-		return false, nil
-	}
-	if err := writeReg(f, regGasWait0, calcGasWait(150)); err != nil {
-		return false, nil
-	}
-	if err := writeReg(f, regCtrlGas1, 0x10); err != nil { // run_gas=1, nb_conv=0 (profile 0)
-		return false, nil
+		return ok, err
 	}
 
 	c.logger.Printf("BME680Connector: connected at I2C address 0x%X", c.cfg.I2CAddress)
 	return true, nil
 }
 
+// connectWithBus performs chip-ID verification, calibration read, and sensor
+// configuration against any i2cBus. Extracted from Connect so it can be
+// exercised with a fake bus in tests, without touching real hardware.
+func (c *Connector) connectWithBus(bus i2cBus) (bool, error) {
+	id, err := bus.readReg(regChipID)
+	if err != nil || id != chipIDExpected {
+		c.logger.Printf("BME680Connector: unexpected chip id 0x%X (err=%v)", id, err)
+		return false, nil
+	}
+
+	calib, err := readCalibration(bus)
+	if err != nil {
+		c.logger.Printf("BME680Connector: failed to read calibration: %v", err)
+		return false, nil
+	}
+	c.calib = calib
+	c.bus = bus
+
+	// Oversampling: humidity x2, pressure x4, temperature x8 (matches Python defaults).
+	if err := bus.writeReg(regCtrlHum, 0x02); err != nil {
+		return false, nil
+	}
+	ctrlMeas := byte(0x05<<5) | byte(0x03<<2) // temp OS_8X (101), press OS_4X (011), mode=sleep
+	if err := bus.writeReg(regCtrlMeas, ctrlMeas); err != nil {
+		return false, nil
+	}
+	// IIR filter size 3 -> filter coeff index 2 (per datasheet table), bits [4:2] of regConfig.
+	if err := bus.writeReg(regConfig, 0x02<<2); err != nil {
+		return false, nil
+	}
+
+	// Gas heater: target 320°C for 150ms, profile 0 (matches Python defaults).
+	heaterRes := c.calib.calcHeaterResistance(320, 25) // assume 25°C ambient if unknown
+	if err := bus.writeReg(regResHeat0, heaterRes); err != nil {
+		return false, nil
+	}
+	if err := bus.writeReg(regGasWait0, calcGasWait(150)); err != nil {
+		return false, nil
+	}
+	if err := bus.writeReg(regCtrlGas1, 0x10); err != nil { // run_gas=1, nb_conv=0 (profile 0)
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (c *Connector) Disconnect(ctx context.Context) error {
+	c.bus = nil
 	if c.file != nil {
 		err := c.file.Close()
 		c.file = nil
@@ -150,7 +202,7 @@ func (c *Connector) Disconnect(ctx context.Context) error {
 // Read triggers one forced-mode measurement and parses the result.
 // Runs in a goroutine, mirroring Python's `run_in_executor`.
 func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error) {
-	if c.file == nil {
+	if c.bus == nil {
 		c.logger.Println("BME680Connector: not connected")
 		return nil, nil
 	}
@@ -183,18 +235,18 @@ func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error)
 // Mirrors Python's `_read_sensor()`.
 func (c *Connector) readSensor() (*connector.AirQualityData, error) {
 	// Trigger forced mode: keep OS settings, set mode=01 (forced).
-	ctrlMeas, err := readReg(c.file, regCtrlMeas)
+	ctrlMeas, err := c.bus.readReg(regCtrlMeas)
 	if err != nil {
 		return nil, err
 	}
-	if err := writeReg(c.file, regCtrlMeas, (ctrlMeas&0xFC)|0x01); err != nil {
+	if err := c.bus.writeReg(regCtrlMeas, (ctrlMeas&0xFC)|0x01); err != nil {
 		return nil, err
 	}
 
 	// Poll new_data_0 bit in meas_status_0 (bit 7), timeout ~2s.
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		status, err := readReg(c.file, regMeasStatus0)
+		status, err := c.bus.readReg(regMeasStatus0)
 		if err != nil {
 			return nil, err
 		}
@@ -208,11 +260,11 @@ func (c *Connector) readSensor() (*connector.AirQualityData, error) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	field, err := readBlock(c.file, regFieldStart, 8) // press(3)+temp(3)+hum(2)
+	field, err := c.bus.readBlock(regFieldStart, 8) // press(3)+temp(3)+hum(2)
 	if err != nil {
 		return nil, err
 	}
-	gasField, err := readBlock(c.file, 0x2A, 2) // gas_r_msb, gas_r_lsb (contains ADC + range)
+	gasField, err := c.bus.readBlock(0x2A, 2) // gas_r_msb, gas_r_lsb (contains ADC + range)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +310,7 @@ func (c *Connector) readSensor() (*connector.AirQualityData, error) {
 	return data, nil
 }
 
-// --- Low-level I2C helpers -------------------------------------------------
+// --- Low-level I2C helpers (real hardware only, not unit-testable) --------
 
 func ioctlSetSlave(f *os.File, addr uint16) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), i2cSlaveIoctl, uintptr(addr))
@@ -266,28 +318,4 @@ func ioctlSetSlave(f *os.File, addr uint16) error {
 		return fmt.Errorf("ioctl I2C_SLAVE: %w", errno)
 	}
 	return nil
-}
-
-func writeReg(f *os.File, reg, value byte) error {
-	_, err := f.Write([]byte{reg, value})
-	return err
-}
-
-func readReg(f *os.File, reg byte) (byte, error) {
-	buf, err := readBlock(f, reg, 1)
-	if err != nil {
-		return 0, err
-	}
-	return buf[0], nil
-}
-
-func readBlock(f *os.File, reg byte, length int) ([]byte, error) {
-	if _, err := f.Write([]byte{reg}); err != nil {
-		return nil, err
-	}
-	buf := make([]byte, length)
-	if _, err := f.Read(buf); err != nil {
-		return nil, err
-	}
-	return buf, nil
 }

--- a/plugins/inputs/air_quality/connector/bme680/bme680.go
+++ b/plugins/inputs/air_quality/connector/bme680/bme680.go
@@ -1,0 +1,293 @@
+package bme680
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector"
+)
+
+// Register addresses per Bosch BME680 datasheet.
+const (
+	regChipID       = 0xD0
+	regReset        = 0xE0
+	regCtrlHum      = 0x72
+	regCtrlMeas     = 0x74
+	regConfig       = 0x75
+	regCtrlGas1     = 0x71
+	regGasWait0     = 0x64
+	regResHeat0     = 0x5A
+	regMeasStatus0  = 0x1D
+	regFieldStart   = 0x1F // press_msb..gas_r_lsb block starts here
+	regCalibStart1  = 0x89 // calibration block 1 (0x89-0xA1)
+	regCalibStart2  = 0xE1 // calibration block 2 (0xE1-0xEF)
+	regHeatRange    = 0x02
+	regHeatVal      = 0x00
+	regRangeSwErr   = 0x04
+	chipIDExpected  = 0x61
+	i2cSlaveIoctl   = 0x0703 // unix.I2C_SLAVE
+)
+
+// Config mirrors the `config: dict` passed into Python's BME680Connector.__init__.
+type Config struct {
+	I2CBus      string  // e.g. "/dev/i2c-1"
+	I2CAddress  uint16  // config["i2c_address"], default 0x76
+	Location    string  // config["location"], default "Robot"
+	GasBaseline float64 // config["gas_baseline"], default 50000.0
+}
+
+// Connector implements connector.AirQualityConnector for the BME680 sensor over I2C.
+// Talks to the sensor directly via Linux i2c-dev, following the Bosch BME680
+// datasheet register map and compensation formulas (no third-party driver).
+type Connector struct {
+	cfg    Config
+	file   *os.File
+	calib  calibration
+	logger *log.Logger
+}
+
+func New(cfg Config, logger *log.Logger) *Connector {
+	if cfg.I2CBus == "" {
+		cfg.I2CBus = "/dev/i2c-1"
+	}
+	if cfg.I2CAddress == 0 {
+		cfg.I2CAddress = 0x76
+	}
+	if cfg.Location == "" {
+		cfg.Location = "Robot"
+	}
+	if cfg.GasBaseline == 0 {
+		cfg.GasBaseline = 50000.0
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Connector{cfg: cfg, logger: logger}
+}
+
+func (c *Connector) Name() string {
+	return "bme680"
+}
+
+// Connect opens the I2C bus, verifies chip ID, reads calibration data, and
+// configures oversampling + gas heater, mirroring Python's `connect()`.
+func (c *Connector) Connect(ctx context.Context) (bool, error) {
+	f, err := os.OpenFile(c.cfg.I2CBus, os.O_RDWR, 0)
+	if err != nil {
+		c.logger.Printf("BME680Connector: failed to connect: %v", err)
+		return false, nil
+	}
+
+	if err := ioctlSetSlave(f, c.cfg.I2CAddress); err != nil {
+		f.Close()
+		c.logger.Printf("BME680Connector: failed to connect: %v", err)
+		return false, nil
+	}
+
+	id, err := readReg(f, regChipID)
+	if err != nil || id != chipIDExpected {
+		f.Close()
+		c.logger.Printf("BME680Connector: unexpected chip id 0x%X (err=%v)", id, err)
+		return false, nil
+	}
+
+	c.file = f
+
+	calib, err := readCalibration(f)
+	if err != nil {
+		c.file.Close()
+		c.file = nil
+		c.logger.Printf("BME680Connector: failed to read calibration: %v", err)
+		return false, nil
+	}
+	c.calib = calib
+
+	// Oversampling: humidity x2, pressure x4, temperature x8 (matches Python defaults).
+	if err := writeReg(f, regCtrlHum, 0x02); err != nil {
+		return false, nil
+	}
+	ctrlMeas := byte(0x05<<5) | byte(0x03<<2) // temp OS_8X (101), press OS_4X (011), mode=sleep
+	if err := writeReg(f, regCtrlMeas, ctrlMeas); err != nil {
+		return false, nil
+	}
+	// IIR filter size 3 -> filter coeff index 2 (per datasheet table), bits [4:2] of regConfig.
+	if err := writeReg(f, regConfig, 0x02<<2); err != nil {
+		return false, nil
+	}
+
+	// Gas heater: target 320°C for 150ms, profile 0 (matches Python defaults).
+	heaterRes := c.calcHeaterResistance(320, 25) // assume 25°C ambient if unknown
+	if err := writeReg(f, regResHeat0, heaterRes); err != nil {
+		return false, nil
+	}
+	if err := writeReg(f, regGasWait0, calcGasWait(150)); err != nil {
+		return false, nil
+	}
+	if err := writeReg(f, regCtrlGas1, 0x10); err != nil { // run_gas=1, nb_conv=0 (profile 0)
+		return false, nil
+	}
+
+	c.logger.Printf("BME680Connector: connected at I2C address 0x%X", c.cfg.I2CAddress)
+	return true, nil
+}
+
+func (c *Connector) Disconnect(ctx context.Context) error {
+	if c.file != nil {
+		err := c.file.Close()
+		c.file = nil
+		c.logger.Println("BME680Connector: disconnected")
+		return err
+	}
+	return nil
+}
+
+// Read triggers one forced-mode measurement and parses the result.
+// Runs in a goroutine, mirroring Python's `run_in_executor`.
+func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error) {
+	if c.file == nil {
+		c.logger.Println("BME680Connector: not connected")
+		return nil, nil
+	}
+
+	type result struct {
+		data *connector.AirQualityData
+		err  error
+	}
+	resCh := make(chan result, 1)
+
+	go func() {
+		data, err := c.readSensor()
+		if err != nil {
+			c.logger.Printf("BME680Connector: read error: %v", err)
+			resCh <- result{nil, nil}
+			return
+		}
+		resCh <- result{data, nil}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-resCh:
+		return res.data, res.err
+	}
+}
+
+// readSensor triggers forced mode, polls for new data, and compensates raw values.
+// Mirrors Python's `_read_sensor()`.
+func (c *Connector) readSensor() (*connector.AirQualityData, error) {
+	// Trigger forced mode: keep OS settings, set mode=01 (forced).
+	ctrlMeas, err := readReg(c.file, regCtrlMeas)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeReg(c.file, regCtrlMeas, (ctrlMeas&0xFC)|0x01); err != nil {
+		return nil, err
+	}
+
+	// Poll new_data_0 bit in meas_status_0 (bit 7), timeout ~2s.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		status, err := readReg(c.file, regMeasStatus0)
+		if err != nil {
+			return nil, err
+		}
+		if status&0x80 != 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			c.logger.Println("BME680Connector: sensor data not ready")
+			return nil, nil
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	field, err := readBlock(c.file, regFieldStart, 8) // press(3)+temp(3)+hum(2)
+	if err != nil {
+		return nil, err
+	}
+	gasField, err := readBlock(c.file, 0x2A, 2) // gas_r_msb, gas_r_lsb (contains ADC + range)
+	if err != nil {
+		return nil, err
+	}
+
+	tempADC := int32(field[3])<<12 | int32(field[4])<<4 | int32(field[5])>>4
+	humADC := int32(field[6])<<8 | int32(field[7])
+
+	tFine, tempC := c.calib.compensateTemp(tempADC)
+	humidity := c.calib.compensateHumidity(humADC, tFine)
+
+	gasADC := uint16(gasField[0])<<2 | uint16(gasField[1])>>6
+	gasRange := gasField[1] & 0x0F
+	heatStable := gasField[1]&0x10 != 0
+
+	temp := math.Round(tempC*10) / 10
+	hum := math.Round(humidity*10) / 10
+
+	data := connector.NewAirQualityData()
+	data.Temperature = &temp
+	data.Humidity = &hum
+	data.Location = c.cfg.Location
+	data.Source = "bme680"
+
+	// IAQ score 0-500 from gas resistance. Mirrors Python:
+	// ratio = gas_resistance / gas_baseline
+	// aqi = max(0, min(500, round(25 / max(ratio, 0.01))))
+	if heatStable {
+		gasResistance := c.calib.compensateGas(gasADC, gasRange)
+		ratio := gasResistance / c.cfg.GasBaseline
+		if ratio < 0.01 {
+			ratio = 0.01
+		}
+		aqi := int(math.Round(25 / ratio))
+		if aqi > 500 {
+			aqi = 500
+		}
+		if aqi < 0 {
+			aqi = 0
+		}
+		data.AQI = &aqi
+	}
+
+	return data, nil
+}
+
+// --- Low-level I2C helpers -------------------------------------------------
+
+func ioctlSetSlave(f *os.File, addr uint16) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.Fd(), i2cSlaveIoctl, uintptr(addr))
+	if errno != 0 {
+		return fmt.Errorf("ioctl I2C_SLAVE: %w", errno)
+	}
+	return nil
+}
+
+func writeReg(f *os.File, reg, value byte) error {
+	_, err := f.Write([]byte{reg, value})
+	return err
+}
+
+func readReg(f *os.File, reg byte) (byte, error) {
+	buf, err := readBlock(f, reg, 1)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+func readBlock(f *os.File, reg byte, length int) ([]byte, error) {
+	if _, err := f.Write([]byte{reg}); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, length)
+	if _, err := f.Read(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/plugins/inputs/air_quality/connector/bme680/bme680.go
+++ b/plugins/inputs/air_quality/connector/bme680/bme680.go
@@ -16,7 +16,6 @@ import (
 // Register addresses per Bosch BME680 datasheet.
 const (
 	regChipID      = 0xD0
-	regReset       = 0xE0
 	regCtrlHum     = 0x72
 	regCtrlMeas    = 0x74
 	regConfig      = 0x75

--- a/plugins/inputs/air_quality/connector/bme680/bme680_test.go
+++ b/plugins/inputs/air_quality/connector/bme680/bme680_test.go
@@ -1,0 +1,225 @@
+package bme680
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeI2CBus implements i2cBus entirely in memory for testing, without
+// touching real hardware.
+type fakeI2CBus struct {
+	regs     map[byte]byte   // single-register read/write state
+	blocks   map[byte][]byte // starting register -> bytes returned by readBlock
+	writes   map[byte]byte   // records every writeReg call
+	writeErr error
+	readErr  error
+}
+
+func newFakeBus() *fakeI2CBus {
+	return &fakeI2CBus{
+		regs:   make(map[byte]byte),
+		blocks: make(map[byte][]byte),
+		writes: make(map[byte]byte),
+	}
+}
+
+func (b *fakeI2CBus) writeReg(reg, value byte) error {
+	if b.writeErr != nil {
+		return b.writeErr
+	}
+	b.writes[reg] = value
+	b.regs[reg] = value
+	return nil
+}
+
+func (b *fakeI2CBus) readReg(reg byte) (byte, error) {
+	if b.readErr != nil {
+		return 0, b.readErr
+	}
+	return b.regs[reg], nil
+}
+
+func (b *fakeI2CBus) readBlock(reg byte, length int) ([]byte, error) {
+	if b.readErr != nil {
+		return nil, b.readErr
+	}
+	if data, ok := b.blocks[reg]; ok {
+		out := make([]byte, length)
+		copy(out, data)
+		return out, nil
+	}
+	return make([]byte, length), nil
+}
+
+// validCalibratedBus returns a fake bus pre-loaded with a valid chip ID,
+// zeroed (but present) calibration blocks, an immediately-ready measurement
+// status, and plausible raw field/gas data.
+func validCalibratedBus() *fakeI2CBus {
+	b := newFakeBus()
+	b.regs[regChipID] = chipIDExpected
+	b.blocks[regCalibStart1] = make([]byte, 25)
+	b.blocks[regCalibStart2] = make([]byte, 16)
+	b.regs[regHeatRange] = 0x00
+	b.regs[regHeatVal] = 0x00
+	b.regs[regRangeSwErr] = 0x00
+	b.regs[regMeasStatus0] = 0x80 // new_data bit set: data ready immediately
+	// field block: press(3) + temp(3) + hum(2), arbitrary plausible raw values
+	b.blocks[regFieldStart] = []byte{0, 0, 0, 0x80, 0x00, 0x00, 0x60, 0x00}
+	// gas field: gas_r_msb, gas_r_lsb -> heat_stable bit (0x10) set, range=0
+	b.blocks[0x2A] = []byte{0x20, 0x10}
+	return b
+}
+
+func newTestConnector() *Connector {
+	return New(Config{Location: "TestLab", GasBaseline: 50000}, log.Default())
+}
+
+func TestConnectWithBus_Success(t *testing.T) {
+	c := newTestConnector()
+	bus := validCalibratedBus()
+
+	ok, err := c.connectWithBus(bus)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, c.bus)
+
+	// Oversampling/config/heater registers must have been written.
+	require.Contains(t, bus.writes, byte(regCtrlHum))
+	require.Contains(t, bus.writes, byte(regCtrlMeas))
+	require.Contains(t, bus.writes, byte(regConfig))
+	require.Contains(t, bus.writes, byte(regResHeat0))
+	require.Contains(t, bus.writes, byte(regGasWait0))
+	require.Contains(t, bus.writes, byte(regCtrlGas1))
+}
+
+func TestConnectWithBus_BadChipID(t *testing.T) {
+	c := newTestConnector()
+	bus := newFakeBus()
+	bus.regs[regChipID] = 0x00 // wrong chip id
+
+	ok, err := c.connectWithBus(bus)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, c.bus)
+}
+
+func TestConnectWithBus_ReadError(t *testing.T) {
+	c := newTestConnector()
+	bus := newFakeBus()
+	bus.readErr = context.DeadlineExceeded
+
+	ok, err := c.connectWithBus(bus)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestRead_NotConnected(t *testing.T) {
+	c := newTestConnector()
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_FullCycle(t *testing.T) {
+	c := newTestConnector()
+	bus := validCalibratedBus()
+
+	ok, err := c.connectWithBus(bus)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.NotNil(t, data.Temperature)
+	require.NotNil(t, data.Humidity)
+	require.Equal(t, "TestLab", data.Location)
+	require.Equal(t, "bme680", data.Source)
+	// heat_stable bit was set in the fake gas field, so AQI must be populated.
+	require.NotNil(t, data.AQI)
+	require.GreaterOrEqual(t, *data.AQI, 0)
+	require.LessOrEqual(t, *data.AQI, 500)
+}
+
+func TestRead_GasNotStable_NoAQI(t *testing.T) {
+	c := newTestConnector()
+	bus := validCalibratedBus()
+	bus.blocks[0x2A] = []byte{0x20, 0x00} // heat_stable bit (0x10) cleared
+
+	ok, err := c.connectWithBus(bus)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Nil(t, data.AQI)
+}
+
+func TestDisconnect_NilFile(t *testing.T) {
+	c := newTestConnector()
+	c.bus = validCalibratedBus()
+
+	err := c.Disconnect(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, c.bus)
+}
+
+func TestName(t *testing.T) {
+	c := newTestConnector()
+	require.Equal(t, "bme680", c.Name())
+}
+
+func TestNew_Defaults(t *testing.T) {
+	c := New(Config{}, log.Default())
+	require.Equal(t, "/dev/i2c-1", c.cfg.I2CBus)
+	require.Equal(t, uint16(0x76), c.cfg.I2CAddress)
+	require.Equal(t, "Robot", c.cfg.Location)
+	require.Equal(t, 50000.0, c.cfg.GasBaseline)
+}
+
+// --- Calibration formula sanity tests --------------------------------------
+// These don't validate against real hardware (that requires physical
+// calibration and a reference sensor), only that the formulas are
+// deterministic, stay in-range, and respond monotonically as documented in
+// the Bosch datasheet.
+
+func TestCompensateTemp_Deterministic(t *testing.T) {
+	var c calibration
+	c.parT1, c.parT2, c.parT3 = 26000, 26500, 3
+
+	_, temp1 := c.compensateTemp(500000)
+	_, temp2 := c.compensateTemp(500000)
+	require.Equal(t, temp1, temp2, "same input must give same output")
+}
+
+func TestCompensateHumidity_ClampedRange(t *testing.T) {
+	var c calibration
+	c.parH1, c.parH2 = 600, 400
+	c.parH3, c.parH4, c.parH5, c.parH6, c.parH7 = 0, 20, 5, 60, 30
+
+	hum := c.compensateHumidity(30000, 25000)
+	require.GreaterOrEqual(t, hum, 0.0)
+	require.LessOrEqual(t, hum, 100.0)
+}
+
+func TestCalcGasWait_Encoding(t *testing.T) {
+	// 150ms should fit in the first multiplier tier (factor=0) since 150 <= 0x3F*4-ish range;
+	// just assert it round-trips to a value <= 0xFF and is deterministic.
+	v1 := calcGasWait(150)
+	v2 := calcGasWait(150)
+	require.Equal(t, v1, v2)
+}
+
+func TestCalcHeaterResistance_Deterministic(t *testing.T) {
+	var c calibration
+	c.parG1, c.parG2, c.parG3 = 50, 100, 10
+	c.resHeatRange, c.resHeatVal = 1, 2
+
+	v1 := c.calcHeaterResistance(320, 25)
+	v2 := c.calcHeaterResistance(320, 25)
+	require.Equal(t, v1, v2)
+}

--- a/plugins/inputs/air_quality/connector/bme680/calibration.go
+++ b/plugins/inputs/air_quality/connector/bme680/calibration.go
@@ -139,10 +139,6 @@ func (c calibration) calcHeaterResistance(targetTempC, ambientTempC float64) byt
 	return byte(resHeatX)
 }
 
-func (c *Connector) calcHeaterResistance(targetTempC, ambientTempC float64) byte {
-	return c.calib.calcHeaterResistance(targetTempC, ambientTempC)
-}
-
 // calcGasWait converts milliseconds into the gas_wait_x register encoding
 // (multiplier factor + 4x multiplier bits), per datasheet section 5.3.3.
 func calcGasWait(ms int) byte {

--- a/plugins/inputs/air_quality/connector/bme680/calibration.go
+++ b/plugins/inputs/air_quality/connector/bme680/calibration.go
@@ -2,7 +2,6 @@ package bme680
 
 import (
 	"math"
-	"os"
 )
 
 // calibration holds the factory calibration coefficients read from the sensor's
@@ -28,14 +27,14 @@ type calibration struct {
 }
 
 // readCalibration reads and parses both calibration blocks from the sensor.
-func readCalibration(f *os.File) (calibration, error) {
+func readCalibration(bus i2cBus) (calibration, error) {
 	var c calibration
 
-	b1, err := readBlock(f, regCalibStart1, 25) // 0x89-0xA1
+	b1, err := bus.readBlock(regCalibStart1, 25) // 0x89-0xA1
 	if err != nil {
 		return c, err
 	}
-	b2, err := readBlock(f, regCalibStart2, 16) // 0xE1-0xF0
+	b2, err := bus.readBlock(regCalibStart2, 16) // 0xE1-0xF0
 	if err != nil {
 		return c, err
 	}
@@ -60,19 +59,19 @@ func readCalibration(f *os.File) (calibration, error) {
 	c.parG1 = int8(b1[22])
 	c.parG3 = int8(b1[23])
 
-	rh, err := readReg(f, regHeatRange)
+	rh, err := bus.readReg(regHeatRange)
 	if err != nil {
 		return c, err
 	}
 	c.resHeatRange = (rh >> 4) & 0x03
 
-	hv, err := readReg(f, regHeatVal)
+	hv, err := bus.readReg(regHeatVal)
 	if err != nil {
 		return c, err
 	}
 	c.resHeatVal = int8(hv)
 
-	se, err := readReg(f, regRangeSwErr)
+	se, err := bus.readReg(regRangeSwErr)
 	if err != nil {
 		return c, err
 	}

--- a/plugins/inputs/air_quality/connector/bme680/calibration.go
+++ b/plugins/inputs/air_quality/connector/bme680/calibration.go
@@ -1,0 +1,157 @@
+package bme680
+
+import (
+	"math"
+	"os"
+)
+
+// calibration holds the factory calibration coefficients read from the sensor's
+// NVM registers, per the Bosch BME680 datasheet (section 3.4 "Trimming
+// coefficients").
+type calibration struct {
+	// Temperature
+	parT1 uint16
+	parT2 int16
+	parT3 int8
+
+	// Humidity
+	parH1, parH2 uint16
+	parH3, parH4, parH5, parH6, parH7 int8
+
+	// Gas
+	parG1 int8
+	parG2 int16
+	parG3 int8
+	resHeatRange byte
+	resHeatVal   int8
+	rangeSwErr   int8
+}
+
+// readCalibration reads and parses both calibration blocks from the sensor.
+func readCalibration(f *os.File) (calibration, error) {
+	var c calibration
+
+	b1, err := readBlock(f, regCalibStart1, 25) // 0x89-0xA1
+	if err != nil {
+		return c, err
+	}
+	b2, err := readBlock(f, regCalibStart2, 16) // 0xE1-0xF0
+	if err != nil {
+		return c, err
+	}
+
+	u16 := func(lsb, msb byte) uint16 { return uint16(msb)<<8 | uint16(lsb) }
+	s16 := func(lsb, msb byte) int16 { return int16(u16(lsb, msb)) }
+
+	// Offsets below follow the Bosch datasheet register map for calibration data.
+	c.parT2 = s16(b1[1], b1[2])
+	c.parT3 = int8(b1[3])
+	c.parT1 = u16(b2[8], b2[9])
+
+	c.parH2 = u16(b2[1], b2[0]) >> 4 // note: reversed byte order per datasheet
+	c.parH1 = u16(b2[2], b2[1]) & 0x0FFF
+	c.parH3 = int8(b2[3])
+	c.parH4 = int8(b2[4])
+	c.parH5 = int8(b2[5])
+	c.parH6 = int8(b2[6])
+	c.parH7 = int8(b2[7])
+
+	c.parG2 = s16(b1[20], b1[21])
+	c.parG1 = int8(b1[22])
+	c.parG3 = int8(b1[23])
+
+	rh, err := readReg(f, regHeatRange)
+	if err != nil {
+		return c, err
+	}
+	c.resHeatRange = (rh >> 4) & 0x03
+
+	hv, err := readReg(f, regHeatVal)
+	if err != nil {
+		return c, err
+	}
+	c.resHeatVal = int8(hv)
+
+	se, err := readReg(f, regRangeSwErr)
+	if err != nil {
+		return c, err
+	}
+	c.rangeSwErr = int8(se>>4) & 0x0F
+
+	return c, nil
+}
+
+// compensateTemp implements the datasheet's temperature compensation formula.
+// Returns (t_fine, temperature in °C) — t_fine is needed by humidity compensation.
+func (c calibration) compensateTemp(adcT int32) (int32, float64) {
+	var1 := (float64(adcT)/16384.0 - float64(c.parT1)/1024.0) * float64(c.parT2)
+	var2 := math.Pow(float64(adcT)/131072.0-float64(c.parT1)/8192.0, 2) * float64(c.parT3) * 16.0
+	tFine := int32(var1 + var2)
+	tempC := (var1 + var2) / 5120.0
+	return tFine, tempC
+}
+
+// compensateHumidity implements the datasheet's humidity compensation formula.
+func (c calibration) compensateHumidity(adcH int32, tFine int32) float64 {
+	tempComp := float64(tFine) / 5120.0
+
+	var1 := float64(adcH) - (float64(c.parH1)*16.0 + (float64(c.parH3)/2.0)*tempComp)
+	var2 := var1 * (float64(c.parH2) / 262144.0 * (1.0 + (float64(c.parH4)/16384.0)*tempComp + (float64(c.parH5)/1048576.0)*tempComp*tempComp))
+	var3 := float64(c.parH6) / 16384.0
+	var4 := float64(c.parH7) / 2097152.0
+	humidity := var2 + (var3+var4*tempComp)*var2*var2
+
+	if humidity > 100 {
+		humidity = 100
+	}
+	if humidity < 0 {
+		humidity = 0
+	}
+	return humidity
+}
+
+// compensateGas implements the datasheet's gas resistance compensation formula.
+func (c calibration) compensateGas(adcGas uint16, gasRange byte) float64 {
+	lookupK1 := [16]float64{
+		1, 1, 1, 1, 1, 0.99, 1, 0.992,
+		1, 1, 0.998, 0.995, 1, 0.99, 1, 1,
+	}
+	lookupK2 := [16]float64{
+		8000000, 4000000, 2000000, 1000000, 499500.4995, 248262.1648, 125000, 63000.03938,
+		31281.28128, 15625, 7812.5, 3906.25, 1953.125, 976.5625, 488.28125, 244.140625,
+	}
+
+	varGasSwitching := lookupK1[gasRange]*1340.0 + 5.0
+	var1 := varGasSwitching * (1340.0 + 5.0*float64(c.rangeSwErr)) / 100.0
+	var2 := var1 * (float64(adcGas)*1.0 - 512.0 + var1)
+	gasResistance := lookupK2[gasRange] * var1 / var2
+	return gasResistance
+}
+
+// calcHeaterResistance calculates the res_heat_x register value for a target
+// heater plate temperature (°C), given ambient temperature (°C), per datasheet.
+func (c calibration) calcHeaterResistance(targetTempC, ambientTempC float64) byte {
+	var1 := float64(c.parG1)/16.0 + 49.0
+	var2 := (float64(c.parG2)/32768.0)*0.0005 + 0.00235
+	var3 := float64(c.parG3) / 1024.0
+	var4 := var1 * (1.0 + var2*targetTempC)
+	var5 := var4 + var3*ambientTempC
+	resHeatX := 3.4*(var5*(4.0/(4.0+float64(c.resHeatRange)))*(1.0/(1.0+float64(c.resHeatVal)*0.002))-25.0)
+	return byte(resHeatX)
+}
+
+func (c *Connector) calcHeaterResistance(targetTempC, ambientTempC float64) byte {
+	return c.calib.calcHeaterResistance(targetTempC, ambientTempC)
+}
+
+// calcGasWait converts milliseconds into the gas_wait_x register encoding
+// (multiplier factor + 4x multiplier bits), per datasheet section 5.3.3.
+func calcGasWait(ms int) byte {
+	var factor byte
+	durVal := ms
+	for durVal > 0x3F {
+		durVal /= 4
+		factor++
+	}
+	return byte(durVal) | (factor << 6)
+}

--- a/plugins/inputs/air_quality/connector/pms5003/pms5003.go
+++ b/plugins/inputs/air_quality/connector/pms5003/pms5003.go
@@ -1,0 +1,220 @@
+package pms5003
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"go.bug.st/serial"
+
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector"
+)
+
+const (
+	baudRate    = 9600
+	frameLength = 32
+)
+
+var frameStart = [2]byte{0x42, 0x4D}
+
+// Config mirrors the `config: dict` passed into Python's PMS5003Connector.__init__.
+type Config struct {
+	Port     string // config["port"], default "/dev/ttyUSB0"
+	Location string // config["location"], default "Robot"
+}
+
+// Connector implements connector.AirQualityConnector for the PMS5003/PMS7003 sensor.
+// Mirrors Python's PMS5003Connector.
+type Connector struct {
+	cfg    Config
+	port   serial.Port
+	logger *log.Logger
+}
+
+// New creates a new PMS5003 connector, applying the same defaults as the Python version.
+func New(cfg Config, logger *log.Logger) *Connector {
+	if cfg.Port == "" {
+		cfg.Port = "/dev/ttyUSB0"
+	}
+	if cfg.Location == "" {
+		cfg.Location = "Robot"
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Connector{cfg: cfg, logger: logger}
+}
+
+func (c *Connector) Name() string {
+	return "pms5003"
+}
+
+// Connect opens the serial port. Mirrors Python's `connect()`.
+func (c *Connector) Connect(ctx context.Context) (bool, error) {
+	mode := &serial.Mode{
+		BaudRate: baudRate,
+		DataBits: 8,
+		Parity:   serial.NoParity,
+		StopBits: serial.OneStopBit,
+	}
+
+	port, err := serial.Open(c.cfg.Port, mode)
+	if err != nil {
+		c.logger.Printf("PMS5003Connector: failed to connect: %v", err)
+		return false, nil
+	}
+	port.SetReadTimeout(2 * time.Second)
+
+	c.port = port
+	c.logger.Printf("PMS5003Connector: connected on %s", c.cfg.Port)
+	return true, nil
+}
+
+// Disconnect closes the serial port if open. Mirrors Python's `disconnect()`.
+func (c *Connector) Disconnect(ctx context.Context) error {
+	if c.port != nil {
+		if err := c.port.Close(); err != nil {
+			return err
+		}
+		c.logger.Println("PMS5003Connector: disconnected")
+	}
+	return nil
+}
+
+// Read reads one frame from the sensor. Runs in a goroutine, mirroring Python's
+// `loop.run_in_executor` usage to avoid blocking the caller.
+func (c *Connector) Read(ctx context.Context) (*connector.AirQualityData, error) {
+	if c.port == nil {
+		c.logger.Println("PMS5003Connector: not connected")
+		return nil, nil
+	}
+
+	type result struct {
+		data *connector.AirQualityData
+		err  error
+	}
+	resCh := make(chan result, 1)
+
+	go func() {
+		frame, err := c.readFrame()
+		if err != nil {
+			c.logger.Printf("PMS5003Connector: read error: %v", err)
+			resCh <- result{nil, nil}
+			return
+		}
+		if frame == nil {
+			resCh <- result{nil, nil}
+			return
+		}
+		resCh <- result{c.parse(frame), nil}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-resCh:
+		return res.data, res.err
+	}
+}
+
+// readFrame reads and validates one 32-byte frame (blocking).
+// Mirrors Python's `_read_frame()`.
+func (c *Connector) readFrame() ([]byte, error) {
+	one := make([]byte, 1)
+
+	// Sync to frame start bytes 0x42 0x4D
+	for {
+		n, err := c.port.Read(one)
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			return nil, nil // timeout, mirrors Python's "if not byte: return None"
+		}
+		if one[0] == frameStart[0] {
+			n2, err := c.port.Read(one)
+			if err != nil {
+				return nil, err
+			}
+			if n2 > 0 && one[0] == frameStart[1] {
+				break
+			}
+		}
+	}
+
+	rest := make([]byte, frameLength-2)
+	total := 0
+	for total < len(rest) {
+		n, err := c.port.Read(rest[total:])
+		if err != nil {
+			return nil, err
+		}
+		if n == 0 {
+			break
+		}
+		total += n
+	}
+	if total != len(rest) {
+		return nil, nil // incomplete frame, mirrors Python's length check -> None
+	}
+
+	frame := append([]byte{frameStart[0], frameStart[1]}, rest...)
+
+	// Validate checksum: sum of bytes 0..29 == bytes 30..31 (big-endian)
+	var checksum uint32
+	for _, b := range frame[:30] {
+		checksum += uint32(b)
+	}
+	checksum &= 0xFFFF
+	expected := uint32(frame[30])<<8 | uint32(frame[31])
+	if checksum != expected {
+		c.logger.Println("PMS5003Connector: checksum mismatch")
+		return nil, nil
+	}
+
+	return frame, nil
+}
+
+// parse parses a validated 32-byte frame. Mirrors Python's `_parse(frame)`.
+// Frame layout (big-endian): [6:8] PM2.5 standard, [8:10] PM10 standard.
+func (c *Connector) parse(frame []byte) *connector.AirQualityData {
+	word := func(offset int) int {
+		return int(frame[offset])<<8 | int(frame[offset+1])
+	}
+
+	pm25 := float64(word(6))
+	pm10 := float64(word(8))
+	aqi := pm25ToAQI(pm25)
+
+	data := connector.NewAirQualityData()
+	data.AQI = &aqi
+	data.PM25 = &pm25
+	data.PM10 = &pm10
+	data.Location = c.cfg.Location
+	data.Source = "pms5003"
+	return data
+}
+
+// pm25ToAQI mirrors Python's `_pm25_to_aqi(pm25)`: US EPA breakpoint formula.
+func pm25ToAQI(pm25 float64) int {
+	type bp struct{ cLow, cHigh, aqiLow, aqiHigh float64 }
+	breakpoints := []bp{
+		{0.0, 12.0, 0, 50},
+		{12.1, 35.4, 51, 100},
+		{35.5, 55.4, 101, 150},
+		{55.5, 150.4, 151, 200},
+		{150.5, 250.4, 201, 300},
+		{250.5, 350.4, 301, 400},
+		{350.5, 500.4, 401, 500},
+	}
+	for _, b := range breakpoints {
+		if pm25 >= b.cLow && pm25 <= b.cHigh {
+			aqi := ((b.aqiHigh-b.aqiLow)/(b.cHigh-b.cLow))*(pm25-b.cLow) + b.aqiLow
+			return int(aqi + 0.5) // round half up, mirrors Python's round()
+		}
+	}
+	return 500
+}
+
+var _ = fmt.Sprintf // keep fmt imported if unused elsewhere later

--- a/plugins/inputs/air_quality/connector/pms5003/pms5003.go
+++ b/plugins/inputs/air_quality/connector/pms5003/pms5003.go
@@ -2,7 +2,6 @@ package pms5003
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -217,4 +216,3 @@ func pm25ToAQI(pm25 float64) int {
 	return 500
 }
 
-var _ = fmt.Sprintf // keep fmt imported if unused elsewhere later

--- a/plugins/inputs/air_quality/connector/pms5003/pms5003_test.go
+++ b/plugins/inputs/air_quality/connector/pms5003/pms5003_test.go
@@ -1,0 +1,165 @@
+package pms5003
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.bug.st/serial"
+)
+
+// mockPort implements serial.Port over an in-memory byte buffer, so tests
+// don't need real hardware.
+type mockPort struct {
+	buf       *bytes.Reader
+	closeErr  error
+	closed    bool
+	readErr   error
+	readCalls int
+}
+
+func newMockPort(data []byte) *mockPort {
+	return &mockPort{buf: bytes.NewReader(data)}
+}
+
+func (m *mockPort) SetMode(mode *serial.Mode) error { return nil }
+
+func (m *mockPort) Read(p []byte) (int, error) {
+	m.readCalls++
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	n, err := m.buf.Read(p)
+	if err != nil { // io.EOF at end of buffer -> mimic timeout (0 bytes, no error)
+		return 0, nil
+	}
+	return n, nil
+}
+
+func (m *mockPort) Write(p []byte) (int, error)                          { return len(p), nil }
+func (m *mockPort) Drain() error                                         { return nil }
+func (m *mockPort) ResetInputBuffer() error                              { return nil }
+func (m *mockPort) ResetOutputBuffer() error                             { return nil }
+func (m *mockPort) SetDTR(dtr bool) error                                { return nil }
+func (m *mockPort) SetRTS(rts bool) error                                { return nil }
+func (m *mockPort) GetModemStatusBits() (*serial.ModemStatusBits, error) { return &serial.ModemStatusBits{}, nil }
+func (m *mockPort) SetReadTimeout(t time.Duration) error                 { return nil }
+func (m *mockPort) Break(d time.Duration) error                          { return nil }
+func (m *mockPort) Close() error {
+	m.closed = true
+	return m.closeErr
+}
+
+// buildValidFrame constructs a valid 32-byte PMS5003 frame for the given
+// PM2.5 and PM10 values (offsets [6:8] and [8:10]), with a correct checksum.
+func buildValidFrame(pm25, pm10 int) []byte {
+	frame := make([]byte, 32)
+	frame[0] = 0x42
+	frame[1] = 0x4D
+	frame[6] = byte(pm25 >> 8)
+	frame[7] = byte(pm25)
+	frame[8] = byte(pm10 >> 8)
+	frame[9] = byte(pm10)
+
+	var checksum uint32
+	for _, b := range frame[:30] {
+		checksum += uint32(b)
+	}
+	checksum &= 0xFFFF
+	frame[30] = byte(checksum >> 8)
+	frame[31] = byte(checksum)
+	return frame
+}
+
+func newTestConnector(port *mockPort) *Connector {
+	c := New(Config{Location: "TestLab"}, log.Default())
+	c.port = port
+	return c
+}
+
+func TestRead_ValidFrame(t *testing.T) {
+	frame := buildValidFrame(35, 50)
+	c := newTestConnector(newMockPort(frame))
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, 35.0, *data.PM25)
+	require.Equal(t, 50.0, *data.PM10)
+	require.Equal(t, "TestLab", data.Location)
+	require.Equal(t, "pms5003", data.Source)
+	require.NotNil(t, data.AQI)
+}
+
+func TestRead_NotConnected(t *testing.T) {
+	c := New(Config{}, log.Default())
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_BadChecksum(t *testing.T) {
+	frame := buildValidFrame(35, 50)
+	frame[31] ^= 0xFF // corrupt checksum
+	c := newTestConnector(newMockPort(frame))
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_NoHeaderFound(t *testing.T) {
+	// 64+ junk bytes, no 0x42 0x4D anywhere -> readFrame loop exits via timeout (0 bytes).
+	junk := bytes.Repeat([]byte{0xFF}, 70)
+	c := newTestConnector(newMockPort(junk))
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestRead_IncompleteFrame(t *testing.T) {
+	frame := buildValidFrame(35, 50)
+	truncated := frame[:20] // header ok, but frame cut short
+	c := newTestConnector(newMockPort(truncated))
+
+	data, err := c.Read(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestDisconnect_ClosesPort(t *testing.T) {
+	port := newMockPort(nil)
+	c := newTestConnector(port)
+
+	err := c.Disconnect(context.Background())
+	require.NoError(t, err)
+	require.True(t, port.closed)
+}
+
+func TestDisconnect_NilPort(t *testing.T) {
+	c := New(Config{}, log.Default())
+	err := c.Disconnect(context.Background())
+	require.NoError(t, err)
+}
+
+func TestName(t *testing.T) {
+	c := New(Config{}, log.Default())
+	require.Equal(t, "pms5003", c.Name())
+}
+
+func TestNew_Defaults(t *testing.T) {
+	c := New(Config{}, log.Default())
+	require.Equal(t, "/dev/ttyUSB0", c.cfg.Port)
+	require.Equal(t, "Robot", c.cfg.Location)
+}
+
+func TestPM25ToAQI_Breakpoints(t *testing.T) {
+	require.Equal(t, 0, pm25ToAQI(0))
+	require.Equal(t, 50, pm25ToAQI(12.0))
+	require.InDelta(t, 100, pm25ToAQI(35.4), 1)
+	require.Equal(t, 500, pm25ToAQI(1000)) // above scale, capped
+}

--- a/plugins/inputs/air_quality_test.go
+++ b/plugins/inputs/air_quality_test.go
@@ -1,0 +1,259 @@
+package inputs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/openmind/om1/plugins/inputs/air_quality/connector"
+)
+
+// mockAQConnector is a test double implementing connector.AirQualityConnector.
+type mockAQConnector struct {
+	connectOK   bool
+	connectErr  error
+	readData    *connector.AirQualityData
+	readErr     error
+	disconnectErr error
+	connectCalls int
+	readCalls    int
+	disconnectCalls int
+}
+
+func (m *mockAQConnector) Connect(ctx context.Context) (bool, error) {
+	m.connectCalls++
+	return m.connectOK, m.connectErr
+}
+
+func (m *mockAQConnector) Read(ctx context.Context) (*connector.AirQualityData, error) {
+	m.readCalls++
+	return m.readData, m.readErr
+}
+
+func (m *mockAQConnector) Disconnect(ctx context.Context) error {
+	m.disconnectCalls++
+	return m.disconnectErr
+}
+
+func (m *mockAQConnector) Name() string {
+	return "mock"
+}
+
+func intPtr(i int) *int             { return &i }
+func f64Ptr(f float64) *float64     { return &f }
+
+func newTestAirQualitySensor(conn connector.AirQualityConnector) *AirQualitySensor {
+	return &AirQualitySensor{
+		log:  zap.NewNop(),
+		conn: conn,
+		cfg: AirQualityConfig{
+			Connector:           "mock",
+			PollIntervalSec:     airQualityDefaultPollIntervalSec,
+			AQIWarningThreshold: airQualityDefaultAQIWarningThreshold,
+			AQIDangerThreshold:  airQualityDefaultAQIDangerThreshold,
+		},
+	}
+}
+
+func TestAirQualityPollOnce_Success(t *testing.T) {
+	aqi := 42
+	pm25 := 12.5
+	mock := &mockAQConnector{
+		connectOK: true,
+		readData: &connector.AirQualityData{
+			AQI:      &aqi,
+			PM25:     &pm25,
+			Location: "Semarang, Indonesia",
+			Source:   "mock",
+		},
+	}
+	s := newTestAirQualitySensor(mock)
+
+	data, err := s.pollOnce(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	require.Equal(t, 42, *data.AQI)
+	require.Equal(t, 1, mock.connectCalls)
+	require.Equal(t, 1, mock.readCalls)
+	require.Equal(t, 1, mock.disconnectCalls)
+}
+
+func TestAirQualityPollOnce_ConnectFailed(t *testing.T) {
+	mock := &mockAQConnector{connectOK: false}
+	s := newTestAirQualitySensor(mock)
+
+	data, err := s.pollOnce(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.Equal(t, 1, mock.connectCalls)
+	require.Equal(t, 0, mock.readCalls) // must not read if connect failed
+}
+
+func TestAirQualityPollOnce_TooSoon(t *testing.T) {
+	mock := &mockAQConnector{connectOK: true}
+	s := newTestAirQualitySensor(mock)
+	s.lastPollTime = time.Now()
+
+	data, err := s.pollOnce(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.Equal(t, 0, mock.connectCalls) // must not even connect
+}
+
+func TestAirQualityRawToText_NilData(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	msg, err := s.RawToText(context.Background(), nil)
+	require.NoError(t, err)
+	require.Nil(t, msg)
+}
+
+func TestAirQualityRawToText_WrongType(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	msg, err := s.RawToText(context.Background(), "not air quality data")
+	require.NoError(t, err)
+	require.Nil(t, msg)
+}
+
+func TestAirQualityRawToText_FullData(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	data := &connector.AirQualityData{
+		AQI:         intPtr(99),
+		PM25:        f64Ptr(99),
+		Temperature: f64Ptr(32.9),
+		Humidity:    f64Ptr(53.1),
+		Location:    "Semarang, Indonesia",
+		Source:      "aqicn",
+	}
+
+	msg, err := s.RawToText(context.Background(), data)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.Contains(t, msg.Message, "Air Quality in Semarang, Indonesia: MODERATE (AQI: 99)")
+	require.Contains(t, msg.Message, "PM2.5: 99")
+	require.Contains(t, msg.Message, "Temperature: 32.9°C")
+	require.Contains(t, msg.Message, "Humidity: 53.1%")
+	require.NotZero(t, msg.Timestamp)
+}
+
+func TestAirQualityRawToText_WarningThreshold(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	data := &connector.AirQualityData{AQI: intPtr(120), Location: "Jakarta"}
+
+	msg, err := s.RawToText(context.Background(), data)
+	require.NoError(t, err)
+	require.Contains(t, msg.Message, "WARNING: Air quality is")
+	require.NotContains(t, msg.Message, "DANGER")
+}
+
+func TestAirQualityRawToText_DangerThreshold(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	data := &connector.AirQualityData{AQI: intPtr(200), Location: "Jakarta"}
+
+	msg, err := s.RawToText(context.Background(), data)
+	require.NoError(t, err)
+	require.Contains(t, msg.Message, "DANGER: Air quality is")
+}
+
+func TestAirQualityRawToText_NoAQI(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	data := &connector.AirQualityData{
+		Temperature: f64Ptr(25.0),
+		Location:    "Robot",
+	}
+
+	msg, err := s.RawToText(context.Background(), data)
+	require.NoError(t, err)
+	require.Contains(t, msg.Message, "Air Quality in Robot")
+	require.NotContains(t, msg.Message, "AQI:")
+}
+
+func TestAirQualityFormattedLatestBuffer(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	require.Equal(t, "", s.FormattedLatestBuffer())
+
+	data := &connector.AirQualityData{AQI: intPtr(50), Location: "Robot"}
+	_, err := s.RawToText(context.Background(), data)
+	require.NoError(t, err)
+
+	out := s.FormattedLatestBuffer()
+	require.Contains(t, out, "INPUT: "+airQualityDescriptor)
+	require.Contains(t, out, "// START")
+	require.Contains(t, out, "// END")
+	require.Contains(t, out, "Robot")
+
+	require.Equal(t, "", s.FormattedLatestBuffer())
+}
+
+func TestAirQualityFormattedLatestBufferReturnsNewest(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+
+	_, err := s.RawToText(context.Background(), &connector.AirQualityData{AQI: intPtr(10), Location: "Old"})
+	require.NoError(t, err)
+	_, err = s.RawToText(context.Background(), &connector.AirQualityData{AQI: intPtr(20), Location: "New"})
+	require.NoError(t, err)
+
+	out := s.FormattedLatestBuffer()
+	require.Contains(t, out, "New")
+	require.NotContains(t, out, "Old")
+}
+
+func TestAirQualityBoundedHistory(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	for i := 0; i < airQualityMaxMessages+5; i++ {
+		_, err := s.RawToText(context.Background(), &connector.AirQualityData{AQI: intPtr(10), Location: "Robot"})
+		require.NoError(t, err)
+	}
+	s.mu.Lock()
+	n := len(s.messages)
+	s.mu.Unlock()
+	require.LessOrEqual(t, n, airQualityMaxMessages)
+}
+
+func TestAirQualityStopIsIdempotent(t *testing.T) {
+	s := newTestAirQualitySensor(&mockAQConnector{})
+	s.Stop()
+	require.True(t, s.stopped)
+	require.NotPanics(t, s.Stop)
+}
+
+func TestNewAirQuality_DefaultsToAqicn(t *testing.T) {
+	s, err := NewAirQuality(map[string]any{})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	s.Stop()
+}
+
+func TestNewAirQuality_UnknownConnector(t *testing.T) {
+	s, err := NewAirQuality(map[string]any{"connector": "nonexistent"})
+	require.Error(t, err)
+	require.Nil(t, s)
+}
+
+func TestNewAirQuality_Pms5003(t *testing.T) {
+	s, err := NewAirQuality(map[string]any{
+		"connector": "pms5003",
+		"connector_config": map[string]any{
+			"port":     "/dev/ttyUSB0",
+			"location": "Outdoor",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	s.Stop()
+}
+
+func TestNewAirQuality_Bme680(t *testing.T) {
+	s, err := NewAirQuality(map[string]any{
+		"connector": "bme680",
+		"connector_config": map[string]any{
+			"i2c_address": 0x76,
+			"location":    "Indoor",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	s.Stop()
+}


### PR DESCRIPTION
## Overview
Reimplements the AirQualityInput plugin from #2437 (Python) for the Go runtime, since the project has since migrated to Go. Adds an `AirQuality` sensor plugin with 3 swappable connectors (aqicn, pms5003, bme680) — change sensors via config only.

## Changes
- `plugins/inputs/air_quality.go` — sensor plugin, registered as `AirQuality`
- `plugins/inputs/air_quality/connector/` — `aqicn` (cloud API), `pms5003` (Serial), `bme680` (I2C)
- `docs/air_quality/config_example.json5` — example config for all 3 connectors
- 58 unit tests across the plugin and connectors

**BME680 note:** implemented directly from the Bosch datasheet register map instead of using a third-party driver, since the only Go library with gas-resistance support is AGPL-licensed (incompatible with this project's MIT license).

## Impact
Purely additive, no changes to existing plugins. `go build`, `go vet`, and `go test` all pass across the whole repo.

** BME680 formulas are untested on real hardware** — I don't have a physical sensor to validate against. The I2C logic is unit-tested with a mock bus, but someone with the hardware should verify readings before relying on it in production.

## Additional Information
Test coverage: 49–90% depending on package. Also fixed a real bug found during testing — the aqicn connector crashed decoding the API response when AQI was returned as `"-"` instead of a number.