### PR TITLE
fix memory integration test

### DIFF
--- a/test/integration/config_runner_test.go
+++ b/test/integration/config_runner_test.go
@@ -76,16 +76,29 @@ func runCaseFile(t *testing.T, path string) {
 		}
 	}
 
-	if len(tc.Expected.ForbiddenCalls) > 0 {
-		waitFor = 0
+	var done func([]recordedCall) bool
+	if len(tc.Expected.ForbiddenCalls) == 0 && !tc.Expected.NoCalls {
+		done = func(calls []recordedCall) bool {
+			if len(calls) < waitFor {
+				return false
+			}
+			for _, want := range tc.Expected.ActionCalls {
+				if !matchesAny(want, calls) {
+					return false
+				}
+			}
+			return true
+		}
 	}
 	timeout := 3 * time.Second
 	if tc.TimeoutMs > 0 {
 		timeout = time.Duration(tc.TimeoutMs) * time.Millisecond
 	}
 
+	drainModeContext()
+
 	session, s := newSession()
-	calls := runRuntime(sysCfg, session, s, waitFor, timeout)
+	calls := runRuntime(sysCfg, session, s, done, timeout)
 
 	evaluate(t, tc, calls)
 }

--- a/test/integration/harness_test.go
+++ b/test/integration/harness_test.go
@@ -82,12 +82,6 @@ func (s *sink) snapshot() []recordedCall {
 	return out
 }
 
-func (s *sink) len() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.calls)
-}
-
 var (
 	sinksMu sync.Mutex
 	sinks   = map[string]*sink{}
@@ -124,10 +118,11 @@ type mockSensor struct {
 	publishContext map[string]any
 	voiceKey       string
 	dynamicVars    map[string]string
+	consumed       chan struct{}
 }
 
 func newMockSensor(cfg map[string]any) (inputs.Sensor, error) {
-	s := &mockSensor{triggers: true}
+	s := &mockSensor{triggers: true, consumed: make(chan struct{}, 1)}
 	if v, ok := cfg["triggers_tick"].(bool); ok {
 		s.triggers = v
 	}
@@ -181,11 +176,15 @@ func (s *mockSensor) Listen(ctx context.Context) (<-chan any, error) {
 			s.mu.Unlock()
 			select {
 			case ch <- m:
-				if i < len(s.messages)-1 {
-					time.Sleep(100 * time.Millisecond)
-				}
 			case <-ctx.Done():
 				return
+			}
+			if i < len(s.messages)-1 {
+				select {
+				case <-s.consumed:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 		<-ctx.Done()
@@ -205,6 +204,12 @@ func (s *mockSensor) FormattedLatestBuffer() string {
 	msg := s.currentMsg
 	s.currentMsg = ""
 	s.mu.Unlock()
+	if msg != "" {
+		select {
+		case s.consumed <- struct{}{}:
+		default:
+		}
+	}
 	if s.voiceKey != "" && msg != "" {
 		providers.IO().AddInput(s.voiceKey, msg, time.Now())
 		return msg
@@ -307,7 +312,7 @@ func (c *recordingConnector) Tick(ctx context.Context) {
 
 func (c *recordingConnector) Stop() {}
 
-func runRuntime(cfg *config.SystemConfig, session string, s *sink, waitForCalls int, timeout time.Duration) []recordedCall {
+func runRuntime(cfg *config.SystemConfig, session string, s *sink, done func([]recordedCall) bool, timeout time.Duration) []recordedCall {
 	injectActionMeta(cfg, session)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -326,7 +331,7 @@ func runRuntime(cfg *config.SystemConfig, session string, s *sink, waitForCalls 
 	poll := time.NewTicker(10 * time.Millisecond)
 	defer poll.Stop()
 
-	for waitForCalls <= 0 || s.len() < waitForCalls {
+	for done == nil || !done(s.snapshot()) {
 		select {
 		case <-deadline.C:
 			goto stop

--- a/test/integration/mcp_test.go
+++ b/test/integration/mcp_test.go
@@ -238,7 +238,7 @@ func TestMCPRuntimeEndToEnd(t *testing.T) {
 		Modes:            map[string]config.ModeConfig{"default": mode},
 	}
 
-	recorded := runRuntime(cfg, session, s, 1, 5*time.Second)
+	recorded := runRuntime(cfg, session, s, func(calls []recordedCall) bool { return len(calls) >= 1 }, 5*time.Second)
 
 	require.NotEmpty(t, recorded, "the runtime executed at least one OM1 action")
 	require.True(t, matchesAny(expectedCall{


### PR DESCRIPTION
mock sensor send the message in fixed time (100ms), only the latest one is keep. The memory recall test assume every message is a cortex tick, when CI machine is slow, the old message will be replaced.