### PR TITLE
fix(ws): start send/read loops when Reconnect is disabled

### DIFF
--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -58,11 +58,9 @@ func New(cfg Config, log *zap.Logger, onMessage func(messageType int, data []byt
 }
 
 // Connect dials the server and starts the send/read goroutines.
+// Reconnect controls whether a failed dial is retried, not whether the
+// send/read loops run: both are started after any successful dial.
 func (c *Client) Connect() error {
-	if !c.cfg.Reconnect {
-		return c.dial()
-	}
-
 	for {
 		err := c.dial()
 		if err == nil {
@@ -70,6 +68,10 @@ func (c *Client) Connect() error {
 			go c.sendLoop()
 			go c.readLoop()
 			return nil
+		}
+
+		if !c.cfg.Reconnect {
+			return err
 		}
 
 		c.log.Warn("ws: initial connect failed, retrying", zap.Error(err))

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -58,8 +58,6 @@ func New(cfg Config, log *zap.Logger, onMessage func(messageType int, data []byt
 }
 
 // Connect dials the server and starts the send/read goroutines.
-// Reconnect controls whether a failed dial is retried, not whether the
-// send/read loops run: both are started after any successful dial.
 func (c *Client) Connect() error {
 	for {
 		err := c.dial()

--- a/internal/ws/client_test.go
+++ b/internal/ws/client_test.go
@@ -97,9 +97,8 @@ func TestConnectSendReceiveWithoutReconnect(t *testing.T) {
 	require.NoError(t, c.Send([]byte("ping")))
 	select {
 	case got := <-received:
-		require.Equal(t, []byte("ping"), got,
-			"a non-reconnecting client still sends and receives after a successful dial")
+		require.Equal(t, []byte("ping"), got, "the server echoes the message back to onMessage")
 	case <-time.After(2 * time.Second):
-		t.Fatal("did not receive echoed message: send/read loops were never started")
+		t.Fatal("did not receive echoed message")
 	}
 }

--- a/internal/ws/client_test.go
+++ b/internal/ws/client_test.go
@@ -83,3 +83,23 @@ func TestCloseIsIdempotentBeforeConnect(t *testing.T) {
 	c := New(Config{URL: "ws://x"}, zap.NewNop(), nil)
 	require.NotPanics(t, c.Close, "Close is safe even if Connect was never called")
 }
+
+func TestConnectSendReceiveWithoutReconnect(t *testing.T) {
+	url := echoServer(t)
+
+	received := make(chan []byte, 1)
+	c := New(Config{URL: url, Reconnect: false}, zap.NewNop(), func(_ int, data []byte) {
+		received <- append([]byte(nil), data...)
+	})
+	require.NoError(t, c.Connect())
+	t.Cleanup(c.Close)
+
+	require.NoError(t, c.Send([]byte("ping")))
+	select {
+	case got := <-received:
+		require.Equal(t, []byte("ping"), got,
+			"a non-reconnecting client still sends and receives after a successful dial")
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not receive echoed message: send/read loops were never started")
+	}
+}


### PR DESCRIPTION
## Problem

`Client.Connect()` returned immediately after `dial()` when `Reconnect` was disabled:

```go
if !c.cfg.Reconnect {
    return c.dial()
}
```

`sendLoop` and `readLoop` were only started in the `Reconnect: true` branch, so a client
created with `Reconnect: false` connects but actually won't work:

- `Connect()` returns `nil`, so the caller believes the client is ready
- `Send()` returns `nil` + it only enqueues into `sendCh`
- no goroutine consumes `sendCh`, so nothing is ever written to the socket
- no read loop runs, so `onMessage` is never invoked

There isn't any error at any layer, so a caller has no way to detect that its messages are being ignored.

This also contradicts the documented behaviour of `Connect()`, which literally says it "starts the send/read goroutines".

Fixes #2665.

## Root cause

`Reconnect` was mixed up with two unrelated concerns: whether a failed dial is retried,
and whether the send/read loops run at all.

## Fix

Restructure `Connect()` so the loops start after any successful dial, and `Reconnect` handles only retry-on-failure. The dial error is still returned unchanged when reconnect is disabled, so no existing caller can see different error behaviour.

## Verification

The existing suite only uses `Reconnect: true`, which is prob why this was not caught. I added a test covering the `Reconnect: false` path for future development also.

Measured against unpatched `main` versus this branch, sending 200 messages over a local
echo server with `Reconnect: false`:

| | `main` | this branch |
|---|---|---|
| messages delivered | **0 / 200** | **200 / 200** |

Verified (all against a local `httptest` WebSocket server):

- **No goroutine leak or deadlock** — 20 connect/send/close cycles in both reconnect modes,
  goroutine count returns to baseline, `Close()` always returns
- **Server-side disconnect with `Reconnect: false`** — `Close()` returns rather than hanging
- **Dial errors are not swallowed** — an unreachable server still returns the error from
  `Connect()` (`TestConnectFailsForBadURL` continues to pass unchanged)

all clean:

- `gofmt` -> clean
- `make vet` ->  clean
- `golangci-lint run` -> 0 issues
- `make test` (whole repo, `-race`) -> no failures, no data races
- `go build ./...` with zenoh-c installed -> clean

## Scope and impact

In terms of severity, this wasn't severe. The only in-tree caller
(`plugins/inputs/asr/asr_stream.go`) passes `Reconnect: true`, so no shipping code path
is currently broken by this.

Behaviour for `Reconnect: true` is unchanged.

Another thing i saw was `Reconnect: false`, `sendLoop`  logs write failures rather than exiting
after its connection dies. Not part of the mr just letting you guys know. 
