### PR TITLE
fix(knowledgebase): normalize embedder base URL

### DIFF
--- a/internal/knowledgebase/embedding.go
+++ b/internal/knowledgebase/embedding.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/openmind/om1/internal/httpclient"
@@ -36,7 +37,7 @@ func NewHTTPEmbedder(baseURL string) *HTTPEmbedder {
 		baseURL = DefaultBaseURL
 	}
 	return &HTTPEmbedder{
-		baseURL: baseURL,
+		baseURL: strings.TrimRight(baseURL, "/"),
 		client:  httpclient.Default(),
 	}
 }

--- a/internal/knowledgebase/embedding_test.go
+++ b/internal/knowledgebase/embedding_test.go
@@ -46,6 +46,17 @@ func TestEmbedSuccess(t *testing.T) {
 	require.Equal(t, "hello world", gotBody["query"], "query is sent in the request body")
 }
 
+func TestEmbedBaseURLWithTrailingSlash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/embed", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(embedResponse{EmbeddingB64: encodeEmbedding([]float32{1})})
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewHTTPEmbedder(srv.URL+"/").Embed(context.Background(), "query")
+	require.NoError(t, err)
+}
+
 func TestEmbedErrorStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
## Overview

While testing the HTTP embedder with a trailing-slash base URL, I found that it sent requests to `//embed` instead of `/embed`. Services that do not normalize duplicate path separators can return 404, preventing embedding requests from succeeding.

Closes #2656.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation improvement
- [ ] Bounty issue submission
- [ ] Other:

## Changes

- Trim trailing slashes when constructing an HTTP embedder.
- Add a regression test that verifies the request path remains `/embed` when the configured base URL ends in `/`.

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not applicable)
- [x] Local testing completed
- [x] Tests added/updated

## Testing

- `go test ./internal/knowledgebase -count=1`
- `go test -race ./internal/knowledgebase -count=1`
- `go vet ./internal/knowledgebase`
- `git diff --check`

## Impact

This only normalizes trailing separators at embedder construction time. Existing base URLs without a trailing slash and the default base URL are unchanged.