### PR TITLE
[test] PR Triage smoke test — safe to close

### DIFF
--- a/.pr-triage-smoke-test/README.md
+++ b/.pr-triage-smoke-test/README.md
@@ -1,0 +1,1 @@
+Throwaway file to trigger a pull_request_target smoke test. Safe to delete.


### PR DESCRIPTION
Throwaway PR to exercise the real `pull_request_target` trigger on the PR Triage workflow (`.github/workflows/pr-triage.yml`) against `worktree-om1-pr-triage-workflow`. Opened by an OpenMind org member, so it should hit the org-membership skip path and post nothing. Safe to close/delete after verifying the run.