### PR TITLE
Include LLM text content in trace output

### DIFF
--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -229,9 +229,15 @@ func toolCallsToMaps(toolCalls []llm.ToolCall) []map[string]any {
 	return result
 }
 
-// traceOutput converts an LLM response's tool calls into a slice of maps for structured tracing.
+// traceOutput converts an LLM response's text and tool calls into a slice of maps for structured tracing.
 func traceOutput(response *llm.Response) []map[string]any {
-	out := make([]map[string]any, 0, len(response.ToolCalls))
+	out := make([]map[string]any, 0, len(response.ToolCalls)+1)
+	if response.TextContent != "" {
+		out = append(out, map[string]any{
+			"type":  "text",
+			"value": response.TextContent,
+		})
+	}
 	for _, tc := range response.ToolCalls {
 		out = append(out, map[string]any{
 			"type":  tc.Name,

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -112,6 +112,23 @@ func TestTraceOutput(t *testing.T) {
 	require.Equal(t, map[string]any{"dir": "left"}, got[0]["value"])
 }
 
+func TestTraceOutputIncludesText(t *testing.T) {
+	got := traceOutput(&llm.Response{
+		TextContent: "hello there",
+		ToolCalls:   []llm.ToolCall{{Name: "move", Arguments: map[string]any{"dir": "left"}}},
+	})
+	require.Len(t, got, 2)
+	require.Equal(t, "text", got[0]["type"])
+	require.Equal(t, "hello there", got[0]["value"])
+	require.Equal(t, "move", got[1]["type"])
+	require.Equal(t, map[string]any{"dir": "left"}, got[1]["value"])
+}
+
+func TestTraceOutputEmptyTextOmitted(t *testing.T) {
+	got := traceOutput(&llm.Response{})
+	require.Len(t, got, 0)
+}
+
 func TestLoadComponentsRequiresLLM(t *testing.T) {
 	m := NewModeSetup(config.ModeConfig{Name: "greeting"}, &config.SystemConfig{}, nil)
 	err := m.loadComponents()


### PR DESCRIPTION
## Summary
- `traceOutput` in `internal/runtime/config.go` only ever serialized `response.ToolCalls`, so `llm_output` in `traces/*.jsonl` was `[]` for every conversational (non-tool-call) turn — the model's actual text reply was never recorded.
- Now includes a `{"type":"text","value":<TextContent>}` entry ahead of the tool-call entries whenever `response.TextContent` is non-empty.

Found while investigating why every line in a robot's `tracer_2026-08-31.jsonl` had `"llm_output":[]` despite active conversation.

## Test plan
- [x] `go test ./internal/runtime/... ./internal/providers/...` passes
- [x] `go vet ./internal/runtime/... ./internal/providers/...` passes
- [x] Added `TestTraceOutputIncludesText` and `TestTraceOutputEmptyTextOmitted` covering the new behavior

https://claude.ai/code/session_01WtDnirL8kmxDz482UjMtvF