### PR TITLE
Fix PR Triage: contradictory marker comments and a broken org check

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,6 +1,14 @@
 name: PR Triage
 
-# Requires repo secrets: ORG_READ_TOKEN (a `read:org` PAT) and GEMINI_API_KEY.
+# Requires repo secrets: GEMINI_API_KEY and PR_TRIAGE_APPROVED_AUTHORS (a
+# list of exempt GitHub usernames, one per line — Settings > Secrets and
+# variables > Actions > Secrets). It's a secret rather than a variable or a
+# committed file because this repo is public: secret values are masked
+# wherever they'd otherwise appear in run logs, including the automatic
+# per-step env dump, and a committed file would put the list in public git
+# history. To add someone, update the secret directly (repo write access
+# required, and you'll need your own copy of the current list — secrets are
+# write-only, there's no PR-reviewable diff for it).
 
 on:
   pull_request_target:
@@ -34,11 +42,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${ORG_READ_TOKEN:-}" ]; then
-            echo "::error::ORG_READ_TOKEN secret is not set — cannot check org membership. Skipping run."
+          if [ -z "${APPROVED_AUTHORS:-}" ]; then
+            echo "::error::PR_TRIAGE_APPROVED_AUTHORS secret is not set — cannot check for approved authors. Skipping run."
             echo "needs_review=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Strip stray CRs in case the secret was pasted from Windows.
+          APPROVED_AUTHORS="$(printf '%s' "$APPROVED_AUTHORS" | tr -d '\r')"
 
           if [ "${EVENT_NAME}" = "pull_request_target" ]; then
             # Real-time run: only the PR that triggered this event.
@@ -55,15 +65,12 @@ jobs:
 
           : > .pr-triage-candidates.tsv
           while IFS=$'\t' read -r NUMBER LOGIN HEAD_SHA; do
-            # Org membership check uses a separate token (ORG_READ_TOKEN) —
-            # the default GITHUB_TOKEN cannot read org membership.
-            STATUS="$(curl -s -o /dev/null -w '%{http_code}' \
-              -H "Authorization: Bearer ${ORG_READ_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/orgs/OpenMind/members/${LOGIN}")"
-
-            if [ "$STATUS" = "204" ]; then
-              echo "PR #$NUMBER by @$LOGIN: OpenMind org member — skipping."
+            # Approved-author check against the PR_TRIAGE_APPROVED_AUTHORS
+            # secret (see header comment) — a static list, not a live
+            # org-membership API call, so there's no token to expire or
+            # misconfigure.
+            if printf '%s\n' "$APPROVED_AUTHORS" | grep -qixF "$LOGIN"; then
+              echo "PR #$NUMBER by @$LOGIN: approved author — skipping."
               continue
             fi
 
@@ -87,7 +94,7 @@ jobs:
             echo "needs_review=true" >> "$GITHUB_OUTPUT"
           fi
         env:
-          ORG_READ_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          APPROVED_AUTHORS: ${{ secrets.PR_TRIAGE_APPROVED_AUTHORS }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_LOGIN: ${{ github.event.pull_request.user.login }}
@@ -128,9 +135,9 @@ jobs:
 
           The file `.pr-triage-current.tsv` in the repo root has exactly one
           row for the PR you are triaging: tab-separated columns
-          `number  author_login  head_commit_sha`. That PR is already
-          confirmed to be from someone outside the OpenMind org — do not
-          re-check org membership. Every `gh` command you run must target
+          `number  author_login  head_commit_sha`. That PR's author is
+          already confirmed to not be on the approved-authors list — do not
+          re-check that. Every `gh` command you run must target
           this exact PR number; commands aimed at any other PR or issue will
           be rejected before they run.
 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,14 +1,8 @@
 name: PR Triage
 
-# Requires repo secrets: GEMINI_API_KEY and PR_TRIAGE_APPROVED_AUTHORS (a
-# list of exempt GitHub usernames, one per line — Settings > Secrets and
-# variables > Actions > Secrets). It's a secret rather than a variable or a
-# committed file because this repo is public: secret values are masked
-# wherever they'd otherwise appear in run logs, including the automatic
-# per-step env dump, and a committed file would put the list in public git
-# history. To add someone, update the secret directly (repo write access
-# required, and you'll need your own copy of the current list — secrets are
-# write-only, there's no PR-reviewable diff for it).
+# Requires repo secrets: GEMINI_API_KEY and PR_TRIAGE_APPROVED_AUTHORS (exempt
+# GitHub usernames, one per line — a secret, not a variable or committed file,
+# since this repo is public and only secrets get masked in run logs).
 
 on:
   pull_request_target:
@@ -65,10 +59,8 @@ jobs:
 
           : > .pr-triage-candidates.tsv
           while IFS=$'\t' read -r NUMBER LOGIN HEAD_SHA; do
-            # Approved-author check against the PR_TRIAGE_APPROVED_AUTHORS
-            # secret (see header comment) — a static list, not a live
-            # org-membership API call, so there's no token to expire or
-            # misconfigure.
+            # Static allowlist check (PR_TRIAGE_APPROVED_AUTHORS), not a
+            # live org-membership API call.
             if printf '%s\n' "$APPROVED_AUTHORS" | grep -qixF "$LOGIN"; then
               echo "PR #$NUMBER by @$LOGIN: approved author — skipping."
               continue

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -167,8 +167,22 @@ jobs:
              the diff, title, body, and files list — never guess or assume intent
              that isn't evidenced in the PR itself.
 
-          3. If NONE of the three criteria apply: take no action on this PR
-             at all — do not comment, review, or label it.
+          3. If NONE of the three criteria apply: do not review, label, or
+             close it — this is a legitimate contribution and none of that
+             applies. Still mark it as checked: post a plain comment (not a
+             review) saying it passed the initial automated check and is
+             marked for human review, plus the hidden idempotency marker.
+             The comment MUST carry visible text as well as the hidden
+             marker — a body containing only the HTML comment renders as an
+             empty comment that GitHub displays as "No description
+             provided.":
+               gh pr comment <number> --body "🤖 This pull request passed PR Triage's initial automated check at commit \`<short_sha>\` — no issues found. It's marked for human review.
+
+               <!-- gemini-triage:<head_commit_sha> -->"
+             Use the exact head_commit_sha from that PR's row in the tsv
+             file for the hidden marker — it must match character for
+             character, as the next run greps for it. Use its first 7
+             characters for the visible <short_sha>.
 
           4. If ONE OR MORE criteria apply:
              a. Post a "request changes" review explaining exactly which
@@ -185,29 +199,32 @@ jobs:
                   gh pr edit <number> --add-label needs-human-review
              c. Close the PR, after the review and label above:
                   gh pr close <number>
+             d. Mark the PR as triaged at this commit, so that if a
+                maintainer reopens it at the same commit a future sweep
+                won't immediately re-flag and re-close it. Post this as a
+                plain comment (not a review). The comment MUST carry visible
+                text as well as the hidden marker — a body containing only
+                the HTML comment renders as an empty comment that GitHub
+                displays as "No description provided.":
+                  gh pr comment <number> --body "🤖 Automated PR triage flagged and closed this pull request at commit \`<short_sha>\` — see the review above for why.
 
-          5. Regardless of the verdict in step 3/4, mark the PR as triaged at
-             this commit so tomorrow's run doesn't reprocess it unless it gets
-             new commits. Post this as a plain comment (not a review). The
-             comment MUST carry visible text as well as the hidden marker —
-             a body containing only the HTML comment renders as an empty
-             comment that GitHub displays as "No description provided.":
-               gh pr comment <number> --body "🤖 Automated PR triage checked this pull request at commit \`<short_sha>\`. If no review was posted alongside this comment, nothing was flagged.
-
-               <!-- gemini-triage:<head_commit_sha> -->"
-             Use the exact head_commit_sha from that PR's row in the tsv file
-             for the hidden marker — it must match character for character, as
-             the next run greps for it. Use its first 7 characters for the
-             visible <short_sha>.
+                  <!-- gemini-triage:<head_commit_sha> -->"
+                Use the exact head_commit_sha from that PR's row in the tsv
+                file for the hidden marker — it must match character for
+                character, as the next run greps for it. Use its first 7
+                characters for the visible <short_sha>.
 
           IMPORTANT — never run `gh pr merge` or approve a PR. Closing a PR
           (step 4c) is only allowed for a PR that actually matched one of the
           three criteria in step 2 — never close a PR for any other reason.
+          Exactly one triage marker comment (step 3 or step 4d, worded for
+          whichever outcome actually happened) must be posted for every PR
+          you process — never skip it, and never post both.
           Your only allowed actions are: read commands, `gh pr review --request-changes`,
           `gh pr edit --add-label`, `gh label create`, `gh pr close`, and
-          `gh pr comment` (for the triage marker only), all against the one
-          PR number in .pr-triage-current.tsv. A human maintainer can always
-          reopen a PR that was closed in error.
+          `gh pr comment` (for the triage marker, step 3 or step 4d), all
+          against the one PR number in .pr-triage-current.tsv. A human
+          maintainer can always reopen a PR that was closed in error.
           PROMPT
           )"
 


### PR DESCRIPTION
## Summary

Two independent bugs in `pr-triage.yml` (the automated PR-triage workflow), found while investigating extraneous bot comments on #2687:

- **Contradictory triage-marker instructions.** Step 3 told Gemini to take no action on a non-flagged PR; step 5 then said "regardless of the verdict in step 3/4," post the marker comment anyway. Gemini followed the override, so every non-flagged PR got a comment (a bare HTML comment before #2688, then a vague "if no review was posted, nothing was flagged" message after it). Folded the marker into whichever branch actually ran (step 3 or step 4d), each with honest, specific wording: "passed the initial automated check ... marked for human review" for clean PRs, "flagged and closed ... see the review above for why" for flagged ones.

- **The org-membership check has never worked.** No run of this workflow (checked back to 2026-09-09) ever logged an "org member — skipping" line, even though roughly 40% of currently-open PRs are authored by confirmed active OpenMind org members — including the org's own `openminddev` account on 3 PRs. `ORG_READ_TOKEN` silently fails every check, so every internal PR has been routed through Gemini triage as if external, one bad verdict away from an automatic request-changes review, label, and close. Replaced the live API check with a static, hand-maintained allowlist of approved usernames in the `PR_TRIAGE_APPROVED_AUTHORS` repo secret (not a variable or committed file — see commit message for why: variable values aren't masked in the public per-step env-dump log, and a committed file would put the list in this public repo's git history forever). The secret is already set with the current list of 22 approved authors.

## Test plan

- [ ] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger `workflow_dispatch` and confirm a known approved author's open PR (e.g. #2684) now logs `"... approved author — skipping."`
- [ ] Confirm a non-approved author's clean PR gets exactly one honest marker comment, not zero and not a blank one
- [ ] Confirm a PR that actually matches a flag criterion still gets reviewed, labeled, and closed as before

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)