### PR TITLE
Test: verify PR Triage skips an approved author

### DIFF
--- a/.github/pr-triage-test-scratch.md
+++ b/.github/pr-triage-test-scratch.md
@@ -1,0 +1,5 @@
+# PR Triage test
+
+Scratch file for verifying the PR_TRIAGE_APPROVED_AUTHORS gate (see #2689).
+Safe to delete — this PR exists only to confirm an approved author's PR
+gets skipped entirely (no bot comment) rather than routed to Gemini triage.


### PR DESCRIPTION
Scratch PR to verify #2689's fix: since I (25marcusb) am on the `PR_TRIAGE_APPROVED_AUTHORS` list, PR Triage should skip this PR entirely — no bot comment at all, not even the "passed the check" marker.

Will close this once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)